### PR TITLE
chore: zlib and brotli are included in mrdocs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,10 @@ function(boost_capy_setup_properties target)
 endfunction()
 
 if (BOOST_CAPY_MRDOCS_BUILD)
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/mrdocs.cpp" "#include <boost/capy.hpp>\n")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/mrdocs.cpp"
+        "#include <boost/capy.hpp>\n"
+        "#include <boost/capy/zlib.hpp>\n"
+        "#include <boost/capy/brotli.hpp>\n")
     add_library(boost_capy_mrdocs "${CMAKE_CURRENT_BINARY_DIR}/mrdocs.cpp")
     boost_capy_setup_properties(boost_capy_mrdocs)
     boost_capy_setup_properties(boost_capy_mrdocs PUBLIC BOOST_CAPY_MRDOCS)


### PR DESCRIPTION
When BOOST_CAPY_MRDOCS_BUILD is enabled, the documentation generation now includes <boost/capy/zlib.hpp> and <boost/capy/brotli.hpp> in addition to <boost/capy.hpp>.

This ensures that symbols from the zlib and brotli libraries are included in the generated documentation.

Fixes #13

Generated with [Claude Code](https://claude.ai/code)