### PR TITLE
buffers/buffer_param for passing buffer sequences

### DIFF
--- a/include/boost/capy/buffers/buffer_param.hpp
+++ b/include/boost/capy/buffers/buffer_param.hpp
@@ -7,8 +7,8 @@
 // Official repository: https://github.com/cppalliance/capy
 //
 
-#ifndef BOOST_CAPY_ANY_BUFREF_HPP
-#define BOOST_CAPY_ANY_BUFREF_HPP
+#ifndef BOOST_CAPY_BUFFERS_BUFFER_PARAM_HPP
+#define BOOST_CAPY_BUFFERS_BUFFER_PARAM_HPP
 
 #include <boost/capy/detail/config.hpp>
 #include <boost/capy/buffers.hpp>
@@ -26,12 +26,27 @@ namespace capy {
     the buffer sequence parameter, avoiding the need to
     templatize the implementation.
 
+    @par Passing Convention
+
+    This type is designed to be passed by value. It contains only
+    two pointers (16 bytes on 64-bit systems), making copies trivial.
+    Pass-by-value is preferred as it clearly communicates the
+    lightweight, transient nature of this parameter type:
+
+    @code
+    // Preferred: pass by value
+    void process_buffers( buffer_param buffers );
+
+    // Also acceptable: pass by const reference
+    void process_buffers( buffer_param const& buffers );
+    @endcode
+
     @par Example
+
     The following shows the minimal form of an awaitable, templated on the
     buffer sequence type, with only an `await_suspend` method. The example
-    demonstrates that you can construct an `any_bufref` in the parameter
-    list when calling a virtual interface; there is no need to create a
-    separate variable if not desired.
+    demonstrates that you can pass buffers directly to a virtual interface
+    through implicit conversion.
 
     @code
     template<class Buffers>
@@ -41,12 +56,12 @@ namespace capy {
 
         void await_suspend( std::coroutine_handle<> )
         {
-            my_virtual_engine_submit( any_bufref( b ) );
+            my_virtual_engine_submit( b );
         }
     };
 
-    // Example virtual interface accepting any_bufref
-    void my_virtual_engine_submit( any_bufref p )
+    // Example virtual interface accepting buffer_param by value
+    void my_virtual_engine_submit( buffer_param p )
     {
         capy::mutable_buffer temp[8];
         std::size_t n = p.copy_to( temp, 8 );
@@ -54,7 +69,7 @@ namespace capy {
     }
     @endcode
 */
-class any_bufref
+class buffer_param
 {
 public:
     /** Construct from a const buffer sequence.
@@ -62,8 +77,7 @@ public:
         @param bs The buffer sequence to adapt.
     */
     template<ConstBufferSequence BS>
-    explicit
-    any_bufref(BS const& bs) noexcept
+    buffer_param(BS const& bs) noexcept
         : bs_(&bs)
         , fn_(&copy_impl<BS>)
     {

--- a/test/unit/buffers/buffer_param.cpp
+++ b/test/unit/buffers/buffer_param.cpp
@@ -8,7 +8,7 @@
 //
 
 // Test that header file is self-contained.
-#include <boost/capy/any_bufref.hpp>
+#include <boost/capy/buffers/buffer_param.hpp>
 
 #include <boost/capy/buffers/buffer_pair.hpp>
 #include <boost/core/span.hpp>
@@ -19,7 +19,7 @@
 namespace boost {
 namespace capy {
 
-struct any_bufref_test
+struct buffer_param_test
 {
     void
     testConstBuffer()
@@ -27,7 +27,7 @@ struct any_bufref_test
         char const data[] = "Hello";
         const_buffer cb(data, 5);
 
-        any_bufref ref(cb);
+        buffer_param ref(cb);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -42,7 +42,7 @@ struct any_bufref_test
         char data[] = "Hello";
         mutable_buffer mb(data, 5);
 
-        any_bufref ref(mb);
+        buffer_param ref(mb);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -60,7 +60,7 @@ struct any_bufref_test
             const_buffer(data1, 5),
             const_buffer(data2, 5) }};
 
-        any_bufref ref(cbp);
+        buffer_param ref(cbp);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -80,7 +80,7 @@ struct any_bufref_test
             mutable_buffer(data1, 5),
             mutable_buffer(data2, 5) }};
 
-        any_bufref ref(mbp);
+        buffer_param ref(mbp);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -103,7 +103,7 @@ struct any_bufref_test
             const_buffer(data3, 5) };
         span<const_buffer const> s(arr, 3);
 
-        any_bufref ref(s);
+        buffer_param ref(s);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -127,7 +127,7 @@ struct any_bufref_test
             const_buffer(data2, 3),
             const_buffer(data3, 5) }};
 
-        any_bufref ref(arr);
+        buffer_param ref(arr);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -151,7 +151,7 @@ struct any_bufref_test
             const_buffer(data2, 3),
             const_buffer(data3, 5) };
 
-        any_bufref ref(arr);
+        buffer_param ref(arr);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -175,7 +175,7 @@ struct any_bufref_test
             const_buffer(data2, 3),
             const_buffer(data3, 5) };
 
-        any_bufref ref(arr);
+        buffer_param ref(arr);
 
         // copy only 2 buffers
         mutable_buffer dest[2];
@@ -191,7 +191,7 @@ struct any_bufref_test
     testEmptySequence()
     {
         const_buffer cb;
-        any_bufref ref(cb);
+        buffer_param ref(cb);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -206,7 +206,7 @@ struct any_bufref_test
         char const* data = "Hello";
         const_buffer cb(data, 0);
 
-        any_bufref ref(cb);
+        buffer_param ref(cb);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -224,7 +224,7 @@ struct any_bufref_test
             const_buffer(data2, 0),
             const_buffer(nullptr, 0) };
 
-        any_bufref ref(arr);
+        buffer_param ref(arr);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -241,7 +241,7 @@ struct any_bufref_test
             const_buffer(data1, 0),
             const_buffer(data2, 0) }};
 
-        any_bufref ref(cbp);
+        buffer_param ref(cbp);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -260,7 +260,7 @@ struct any_bufref_test
             const_buffer(data2, 5),
             const_buffer(nullptr, 0) };
 
-        any_bufref ref(arr);
+        buffer_param ref(arr);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -281,7 +281,7 @@ struct any_bufref_test
             const_buffer(data1, 0),
             const_buffer(data2, 5) }};
 
-        any_bufref ref(cbp);
+        buffer_param ref(cbp);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -298,7 +298,7 @@ struct any_bufref_test
         char data[] = "Hello";
         mutable_buffer mb(data, 0);
 
-        any_bufref ref(mb);
+        buffer_param ref(mb);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -315,7 +315,7 @@ struct any_bufref_test
             mutable_buffer(data1, 0),
             mutable_buffer(data2, 0) }};
 
-        any_bufref ref(mbp);
+        buffer_param ref(mbp);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -328,7 +328,7 @@ struct any_bufref_test
         // Empty span (no buffers at all)
         span<const_buffer const> s;
 
-        any_bufref ref(s);
+        buffer_param ref(s);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
@@ -341,11 +341,71 @@ struct any_bufref_test
         // Empty std::array (zero-size)
         std::array<const_buffer, 0> arr{};
 
-        any_bufref ref(arr);
+        buffer_param ref(arr);
 
         mutable_buffer dest[8];
         auto n = ref.copy_to(dest, 8);
         BOOST_TEST_EQ(n, 0);
+    }
+
+    // Helper function that accepts buffer_param by value
+    static std::size_t
+    acceptByValue(buffer_param p)
+    {
+        mutable_buffer dest[8];
+        return p.copy_to(dest, 8);
+    }
+
+    // Helper function that accepts buffer_param by const reference
+    static std::size_t
+    acceptByConstRef(buffer_param const& p)
+    {
+        mutable_buffer dest[8];
+        return p.copy_to(dest, 8);
+    }
+
+    void
+    testPassByValue()
+    {
+        // Test that buffer_param works when passed by value
+        char const data[] = "Hello";
+        const_buffer cb(data, 5);
+
+        // Pass buffer directly (implicit conversion)
+        auto n = acceptByValue(cb);
+        BOOST_TEST_EQ(n, 1);
+
+        // Pass buffer_param object
+        buffer_param p(cb);
+        n = acceptByValue(p);
+        BOOST_TEST_EQ(n, 1);
+
+        // Pass buffer sequence directly
+        std::array<const_buffer, 2> arr{{
+            const_buffer(data, 2),
+            const_buffer(data + 2, 3) }};
+        n = acceptByValue(arr);
+        BOOST_TEST_EQ(n, 2);
+    }
+
+    void
+    testPassByConstRef()
+    {
+        // Test that buffer_param works when passed by const reference
+        char const data[] = "Hello";
+        const_buffer cb(data, 5);
+
+        // Pass buffer_param object by const ref
+        buffer_param p(cb);
+        auto n = acceptByConstRef(p);
+        BOOST_TEST_EQ(n, 1);
+
+        // Pass buffer sequence directly (creates temporary)
+        std::array<const_buffer, 2> arr{{
+            const_buffer(data, 2),
+            const_buffer(data + 2, 3) }};
+        n = acceptByConstRef(arr);
+        BOOST_TEST_EQ(n, 2);
     }
 
     void
@@ -369,12 +429,14 @@ struct any_bufref_test
         testZeroByteMutableBufferPair();
         testEmptySpan();
         testEmptyArray();
+        testPassByValue();
+        testPassByConstRef();
     }
 };
 
 TEST_SUITE(
-    any_bufref_test,
-    "boost.capy.any_bufref");
+    buffer_param_test,
+    "boost.capy.buffers.buffer_param");
 
 } // capy
 } // boost


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed public buffer parameter type for improved API clarity.
  * Updated documentation and examples to demonstrate recommended parameter passing patterns.

* **Tests**
  * Expanded test coverage with additional parameter passing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->