### PR TITLE
Add read overload for ReadStream + DynamicBuffer

### DIFF
--- a/include/boost/capy/read.hpp
+++ b/include/boost/capy/read.hpp
@@ -87,6 +87,62 @@ read(
     co_return {{}, total_read};
 }
 
+/** Read data from a stream into a dynamic buffer.
+
+    This function reads data from the stream into the dynamic buffer
+    until end-of-file is reached or an error occurs. Data is appended
+    to the buffer using prepare/commit semantics.
+
+    The buffer grows using a strategy that starts with `initial_amount`
+    bytes and grows by a factor of 1.5 when filled.
+
+    @param stream The stream to read from, must satisfy @ref ReadStream.
+    @param buffers The dynamic buffer to read into.
+    @param initial_amount The initial number of bytes to prepare.
+
+    @return A task that yields `(std::error_code, std::size_t)`.
+        On success (EOF reached), `ec` is default-constructed and `n`
+        is the total number of bytes read. On error, `ec` contains the
+        error code and `n` is the total number of bytes read before
+        the error.
+
+    @par Example
+    @code
+    task<void> example(ReadStream auto& stream)
+    {
+        std::string body;
+        auto [ec, n] = co_await read(stream, string_dynamic_buffer(&body));
+        // body contains n bytes of data
+    }
+    @endcode
+
+    @see ReadStream, DynamicBufferParam
+*/
+auto
+read(
+    ReadStream auto& stream,
+    DynamicBufferParam auto&& buffers,
+    std::size_t initial_amount = 2048) ->
+        task<io_result<std::size_t>>
+{
+    std::size_t amount = initial_amount;
+    std::size_t total_read = 0;
+    for(;;)
+    {
+        auto mb = buffers.prepare(amount);
+        auto const mb_size = buffer_size(mb);
+        auto [ec, n] = co_await stream.read_some(mb);
+        buffers.commit(n);
+        total_read += n;
+        if(ec == cond::eof)
+            co_return {{}, total_read};
+        if(ec)
+            co_return {ec, total_read};
+        if(n == mb_size)
+            amount = amount / 2 + amount;
+    }
+}
+
 /** Read data from a source into a dynamic buffer.
 
     This function reads data from the source into the dynamic buffer

--- a/test/unit/read.cpp
+++ b/test/unit/read.cpp
@@ -478,12 +478,178 @@ struct read_test
     }
 
     //----------------------------------------------------------
+    // ReadStream + DynamicBuffer tests
+    //----------------------------------------------------------
+
+    void
+    testStreamDynBufString()
+    {
+        // Read all data until EOF
+        BOOST_TEST(test::fuse().armed([](test::fuse& f) -> task<void>
+        {
+            test::read_stream rs(f);
+            rs.provide("hello world");
+
+            string_dynbuf_factory df;
+            auto db = df.buffer();
+            auto [ec, n] = co_await read(rs, db);
+            if(ec)
+                co_return;
+
+            BOOST_TEST_EQ(n, 11u);
+            BOOST_TEST_EQ(df.data(), "hello world");
+        }));
+
+        // Read large data (tests growth strategy)
+        BOOST_TEST(test::fuse().armed([](test::fuse& f) -> task<void>
+        {
+            test::read_stream rs(f);
+            std::string large_data(10000, 'x');
+            rs.provide(large_data);
+
+            string_dynbuf_factory df;
+            auto db = df.buffer();
+            auto [ec, n] = co_await read(rs, db);
+            if(ec)
+                co_return;
+
+            BOOST_TEST_EQ(n, 10000u);
+            BOOST_TEST_EQ(df.data().size(), 10000u);
+            BOOST_TEST(df.data() == large_data);
+        }));
+
+        // Empty stream (immediate EOF)
+        BOOST_TEST(test::fuse().armed([](test::fuse& f) -> task<void>
+        {
+            test::read_stream rs(f);
+
+            string_dynbuf_factory df;
+            auto db = df.buffer();
+            auto [ec, n] = co_await read(rs, db);
+            if(ec)
+                co_return;
+
+            BOOST_TEST_EQ(n, 0u);
+            BOOST_TEST(df.data().empty());
+        }));
+
+        // Custom initial_amount
+        BOOST_TEST(test::fuse().armed([](test::fuse& f) -> task<void>
+        {
+            test::read_stream rs(f);
+            rs.provide("small");
+
+            string_dynbuf_factory df;
+            auto db = df.buffer();
+            auto [ec, n] = co_await read(rs, db, 64);
+            if(ec)
+                co_return;
+
+            BOOST_TEST_EQ(n, 5u);
+            BOOST_TEST_EQ(df.data(), "small");
+        }));
+
+        // Chunked reads with max_read_size
+        BOOST_TEST(test::fuse().armed([](test::fuse& f) -> task<void>
+        {
+            test::read_stream rs(f, 3);
+            rs.provide("hello world");
+
+            string_dynbuf_factory df;
+            auto db = df.buffer();
+            auto [ec, n] = co_await read(rs, db);
+            if(ec)
+                co_return;
+
+            BOOST_TEST_EQ(n, 11u);
+            BOOST_TEST_EQ(df.data(), "hello world");
+        }));
+    }
+
+    void
+    testStreamDynBufCircular()
+    {
+        // Read all data until EOF
+        BOOST_TEST(test::fuse().armed([](test::fuse& f) -> task<void>
+        {
+            test::read_stream rs(f);
+            rs.provide("hello world");
+
+            circular_dynamic_buffer_factory df;
+            auto& db = df.buffer();
+            auto [ec, n] = co_await read(rs, db);
+            if(ec)
+                co_return;
+
+            BOOST_TEST_EQ(n, 11u);
+            BOOST_TEST_EQ(df.data(), "hello world");
+        }));
+
+        // Read larger data
+        BOOST_TEST(test::fuse().armed([](test::fuse& f) -> task<void>
+        {
+            test::read_stream rs(f);
+            std::string data(1000, 'y');
+            rs.provide(data);
+
+            circular_dynamic_buffer_factory df;
+            auto& db = df.buffer();
+            auto [ec, n] = co_await read(rs, db);
+            if(ec)
+                co_return;
+
+            BOOST_TEST_EQ(n, 1000u);
+            BOOST_TEST_EQ(df.data().size(), 1000u);
+            BOOST_TEST(df.data() == data);
+        }));
+
+        // Empty stream
+        BOOST_TEST(test::fuse().armed([](test::fuse& f) -> task<void>
+        {
+            test::read_stream rs(f);
+
+            circular_dynamic_buffer_factory df;
+            auto& db = df.buffer();
+            auto [ec, n] = co_await read(rs, db);
+            if(ec)
+                co_return;
+
+            BOOST_TEST_EQ(n, 0u);
+            BOOST_TEST(df.data().empty());
+        }));
+
+        // Custom initial_amount
+        BOOST_TEST(test::fuse().armed([](test::fuse& f) -> task<void>
+        {
+            test::read_stream rs(f);
+            rs.provide("tiny");
+
+            circular_dynamic_buffer_factory df;
+            auto& db = df.buffer();
+            auto [ec, n] = co_await read(rs, db, 128);
+            if(ec)
+                co_return;
+
+            BOOST_TEST_EQ(n, 4u);
+            BOOST_TEST_EQ(df.data(), "tiny");
+        }));
+    }
+
+    void
+    testStreamDynBuf()
+    {
+        testStreamDynBufString();
+        testStreamDynBufCircular();
+    }
+
+    //----------------------------------------------------------
 
     void
     run()
     {
         testReadStream();
         testReadSource();
+        testStreamDynBuf();
     }
 };
 


### PR DESCRIPTION
Add a new read() function that reads from a ReadStream into a DynamicBufferParam until EOF. The buffer grows using a 1.5x strategy starting from an optional initial_amount (default 2048 bytes).

Add corresponding unit tests covering:
- Reading all data until EOF
- Large data reads (growth strategy)
- Empty streams
- Custom initial_amount parameter
- Chunked reads with max_read_size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced read functionality now supports reading data into dynamic buffers with automatic capacity growth management. The operation intelligently expands buffer capacity during data transfer operations as required and provides comprehensive reporting on the total number of bytes successfully transferred. Complete with practical usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->