### PR TITLE
Update when_all to operate on IoAwaitable

### DIFF
--- a/include/boost/capy/concept/io_awaitable.hpp
+++ b/include/boost/capy/concept/io_awaitable.hpp
@@ -100,6 +100,15 @@ concept IoAwaitable =
         a.await_suspend(h, ex, token);
     };
 
+namespace detail {
+
+/** Extract the result type from any awaitable via await_resume().
+*/
+template<typename A>
+using awaitable_result_t = decltype(std::declval<std::decay_t<A>&>().await_resume());
+
+} // namespace detail
+
 } // namespace capy
 } // namespace boost
 

--- a/include/boost/capy/when_all.hpp
+++ b/include/boost/capy/when_all.hpp
@@ -12,7 +12,7 @@
 
 #include <boost/capy/detail/config.hpp>
 #include <boost/capy/concept/executor.hpp>
-#include <boost/capy/concept/io_launchable_task.hpp>
+#include <boost/capy/concept/io_awaitable.hpp>
 #include <boost/capy/coro.hpp>
 #include <boost/capy/ex/executor_ref.hpp>
 #include <boost/capy/ex/frame_allocator.hpp>
@@ -261,14 +261,15 @@ struct when_all_runner
     }
 };
 
-/** Create a runner coroutine for a single task.
+/** Create a runner coroutine for a single awaitable.
 
-    Task is passed directly to ensure proper coroutine frame storage.
+    Awaitable is passed directly to ensure proper coroutine frame storage.
 */
-template<std::size_t Index, typename T, typename... Ts>
-when_all_runner<T, Ts...>
-make_when_all_runner(task<T> inner, when_all_state<Ts...>* state)
+template<std::size_t Index, IoAwaitable Awaitable, typename... Ts>
+when_all_runner<awaitable_result_t<Awaitable>, Ts...>
+make_when_all_runner(Awaitable inner, when_all_state<Ts...>* state)
 {
+    using T = awaitable_result_t<Awaitable>;
     if constexpr (std::is_void_v<T>)
     {
         co_await std::move(inner);
@@ -282,26 +283,28 @@ make_when_all_runner(task<T> inner, when_all_state<Ts...>* state)
 /** Internal awaitable that launches all runner coroutines and waits.
 
     This awaitable is used inside the when_all coroutine to handle
-    the concurrent execution of child tasks.
+    the concurrent execution of child awaitables.
 */
-template<typename... Ts>
+template<IoAwaitable... Awaitables>
 class when_all_launcher
 {
-    std::tuple<task<Ts>...>* tasks_;
-    when_all_state<Ts...>* state_;
+    using state_type = when_all_state<awaitable_result_t<Awaitables>...>;
+
+    std::tuple<Awaitables...>* awaitables_;
+    state_type* state_;
 
 public:
     when_all_launcher(
-        std::tuple<task<Ts>...>* tasks,
-        when_all_state<Ts...>* state)
-        : tasks_(tasks)
+        std::tuple<Awaitables...>* awaitables,
+        state_type* state)
+        : awaitables_(awaitables)
         , state_(state)
     {
     }
 
     bool await_ready() const noexcept
     {
-        return sizeof...(Ts) == 0;
+        return sizeof...(Awaitables) == 0;
     }
 
     coro await_suspend(coro continuation, executor_ref const& caller_ex, std::stop_token const& parent_token = {})
@@ -314,7 +317,7 @@ public:
         {
             state_->parent_stop_callback_.emplace(
                 parent_token,
-                typename when_all_state<Ts...>::stop_callback_fn{&state_->stop_source_});
+                typename state_type::stop_callback_fn{&state_->stop_source_});
 
             if(parent_token.stop_requested())
                 state_->stop_source_.request_stop();
@@ -328,7 +331,7 @@ public:
         auto token = state_->stop_source_.get_token();
         [&]<std::size_t... Is>(std::index_sequence<Is...>) {
             (..., launch_one<Is>(caller_ex, token));
-        }(std::index_sequence_for<Ts...>{});
+        }(std::index_sequence_for<Awaitables...>{});
 
         // Let signal_completion() handle resumption
         return std::noop_coroutine();
@@ -344,7 +347,7 @@ private:
     void launch_one(executor_ref caller_ex, std::stop_token token)
     {
         auto runner = make_when_all_runner<I>(
-            std::move(std::get<I>(*tasks_)), state_);
+            std::move(std::get<I>(*awaitables_)), state_);
 
         auto h = runner.release();
         h.promise().state_ = state_;
@@ -394,31 +397,32 @@ auto extract_results(when_all_state<Ts...>& state)
 
 } // namespace detail
 
-/** Execute multiple tasks concurrently and collect their results.
+/** Execute multiple awaitables concurrently and collect their results.
 
-    Launches all tasks simultaneously and waits for all to complete
+    Launches all awaitables simultaneously and waits for all to complete
     before returning. Results are collected in input order. If any
-    task throws, cancellation is requested for siblings and the first
-    exception is rethrown after all tasks complete.
+    awaitable throws, cancellation is requested for siblings and the first
+    exception is rethrown after all awaitables complete.
 
-    @li All child tasks run concurrently on the caller's executor
+    @li All child awaitables run concurrently on the caller's executor
     @li Results are returned as a tuple in input order
-    @li Void-returning tasks do not contribute to the result tuple
-    @li If all tasks return void, `when_all` returns `task<void>`
+    @li Void-returning awaitables do not contribute to the result tuple
+    @li If all awaitables return void, `when_all` returns `task<void>`
     @li First exception wins; subsequent exceptions are discarded
     @li Stop is requested for siblings on first error
     @li Completes only after all children have finished
 
     @par Thread Safety
     The returned task must be awaited from a single execution context.
-    Child tasks execute concurrently but complete through the caller's
+    Child awaitables execute concurrently but complete through the caller's
     executor.
 
-    @param tasks The tasks to execute concurrently. Each task is
-        consumed (moved-from) when `when_all` is awaited.
+    @param awaitables The awaitables to execute concurrently. Each must
+        satisfy @ref IoAwaitable and is consumed (moved-from) when
+        `when_all` is awaited.
 
     @return A task yielding a tuple of non-void results. Returns
-        `task<void>` when all input tasks return void.
+        `task<void>` when all input awaitables return void.
 
     @par Example
 
@@ -431,7 +435,7 @@ auto extract_results(when_all_state<Ts...>& state)
             fetch_posts( id )      // task<std::vector<Post>>
         );
 
-        // Void tasks don't contribute to result
+        // Void awaitables don't contribute to result
         co_await when_all(
             log_event( "start" ),  // task<void>
             notify_user( id )      // task<void>
@@ -440,22 +444,22 @@ auto extract_results(when_all_state<Ts...>& state)
     }
     @endcode
 
-    @see task
+    @see IoAwaitable, task
 */
-template<typename... Ts>
-[[nodiscard]] task<detail::when_all_result_t<Ts...>>
-when_all(task<Ts>... tasks)
+template<IoAwaitable... As>
+[[nodiscard]] auto when_all(As... awaitables)
+    -> task<detail::when_all_result_t<detail::awaitable_result_t<As>...>>
 {
-    using result_type = detail::when_all_result_t<Ts...>;
+    using result_type = detail::when_all_result_t<detail::awaitable_result_t<As>...>;
 
     // State is stored in the coroutine frame, using the frame allocator
-    detail::when_all_state<Ts...> state;
+    detail::when_all_state<detail::awaitable_result_t<As>...> state;
 
-    // Store tasks in the frame
-    std::tuple<task<Ts>...> task_tuple(std::move(tasks)...);
+    // Store awaitables in the frame
+    std::tuple<As...> awaitable_tuple(std::move(awaitables)...);
 
-    // Launch all tasks and wait for completion
-    co_await detail::when_all_launcher<Ts...>(&task_tuple, &state);
+    // Launch all awaitables and wait for completion
+    co_await detail::when_all_launcher<As...>(&awaitable_tuple, &state);
 
     // Propagate first exception if any.
     // Safe without explicit acquire: capture_exception() is sequenced-before

--- a/include/boost/capy/when_any.hpp
+++ b/include/boost/capy/when_any.hpp
@@ -171,10 +171,6 @@ using unique_variant_t = typename deduplicate_impl<
 template<typename T0, typename... Ts>
 using when_any_result_t = std::pair<std::size_t, unique_variant_t<T0, Ts...>>;
 
-// Extract result type from any awaitable via await_resume()
-template<typename A>
-using awaitable_result_t = decltype(std::declval<std::decay_t<A>&>().await_resume());
-
 /** Core shared state for when_any operations.
 
     Contains all members and methods common to both heterogeneous (variadic)

--- a/test/unit/when_all.cpp
+++ b/test/unit/when_all.cpp
@@ -10,7 +10,9 @@
 // Test that header file is self-contained.
 #include <boost/capy/when_all.hpp>
 
+#include <boost/capy/ex/async_event.hpp>
 #include <boost/capy/ex/run_async.hpp>
+#include <boost/capy/io_task.hpp>
 #include <boost/capy/task.hpp>
 
 #include "test_helpers.hpp"
@@ -62,6 +64,18 @@ static_assert(std::is_void_v<
 
 // Verify when_all returns task which satisfies awaitable protocols
 static_assert(IoAwaitableTask<task<std::tuple<int, int>>>);
+
+// Verify non-task IoAwaitables work with when_all
+template<typename... Args>
+concept WhenAllCallable = requires(Args... args) {
+    when_all(std::move(args)...);
+};
+
+static_assert(WhenAllCallable<stop_only_awaitable>);
+static_assert(WhenAllCallable<stop_only_awaitable, stop_only_awaitable>);
+static_assert(WhenAllCallable<async_event::wait_awaiter>);
+static_assert(WhenAllCallable<async_event::wait_awaiter, stop_only_awaitable>);
+static_assert(WhenAllCallable<task<int>, stop_only_awaitable>);
 
 struct when_all_test
 {
@@ -866,6 +880,172 @@ struct when_all_test
 TEST_SUITE(
     when_all_test,
     "boost.capy.when_all");
+
+//----------------------------------------------------------
+// IoAwaitable (non-task) tests for when_all
+//----------------------------------------------------------
+
+struct when_all_io_awaitable_test
+{
+    // Test: when_all with stop_only_awaitable and task<int>
+    // stop_only_awaitable only completes via cancellation, so we
+    // provide a parent stop_source to trigger both completions.
+    void
+    testStopOnlyAwaitableWithTask()
+    {
+        std::queue<coro> work_queue;
+        queuing_executor ex(work_queue);
+        bool completed = false;
+        int result = 0;
+
+        std::stop_source parent_stop;
+
+        run_async(ex, parent_stop.get_token(),
+            [&](std::tuple<int> t) {
+                completed = true;
+                result = std::get<0>(t);
+            },
+            [](std::exception_ptr) {})(
+            when_all(stop_only_awaitable{}, returns_int(42)));
+
+        // stop_only_awaitable needs cancellation to complete
+        parent_stop.request_stop();
+
+        while (!work_queue.empty()) {
+            auto h = work_queue.front();
+            work_queue.pop();
+            h.resume();
+        }
+
+        BOOST_TEST(completed);
+        BOOST_TEST_EQ(result, 42);
+    }
+
+    // Test: when_all with async_event wait_awaiter and task<int>
+    void
+    testAsyncEventWaitWithTask()
+    {
+        std::queue<coro> work_queue;
+        queuing_executor ex(work_queue);
+        bool completed = false;
+        int result = 0;
+
+        async_event event;
+
+        // event.wait() returns io_result<>, returns_int returns int
+        // Result: tuple<io_result<>, int>
+        run_async(ex,
+            [&](auto&& t) {
+                completed = true;
+                result = std::get<1>(t);
+            },
+            [](std::exception_ptr) {})(
+            when_all(event.wait(), returns_int(42)));
+
+        // Set event so the waiter can complete
+        event.set();
+
+        while (!work_queue.empty()) {
+            auto h = work_queue.front();
+            work_queue.pop();
+            h.resume();
+        }
+
+        BOOST_TEST(completed);
+        BOOST_TEST_EQ(result, 42);
+    }
+
+    // Test: when_all with two stop_only_awaitables
+    void
+    testTwoStopOnlyAwaitables()
+    {
+        std::queue<coro> work_queue;
+        queuing_executor ex(work_queue);
+        bool completed = false;
+
+        std::stop_source parent_stop;
+
+        run_async(ex, parent_stop.get_token(),
+            [&]() {
+                completed = true;
+            },
+            [](std::exception_ptr) {})(
+            when_all(stop_only_awaitable{}, stop_only_awaitable{}));
+
+        // Neither can complete on their own - request parent stop
+        parent_stop.request_stop();
+
+        while (!work_queue.empty()) {
+            auto h = work_queue.front();
+            work_queue.pop();
+            h.resume();
+        }
+
+        BOOST_TEST(completed);
+    }
+
+    // Test: when_all with io_task<> types
+    void
+    testIoTaskWithWhenAll()
+    {
+        int dispatch_count = 0;
+        test_executor ex(dispatch_count);
+        bool completed = false;
+
+        auto io_op = []() -> io_task<> {
+            co_return io_result<>{{}};
+        };
+
+        // io_task<> is task<io_result<>>, result: tuple<io_result<>, io_result<>>
+        run_async(ex,
+            [&](auto&&) {
+                completed = true;
+            },
+            [](std::exception_ptr) {})(
+            when_all(io_op(), io_op()));
+
+        BOOST_TEST(completed);
+    }
+
+    // Test: when_all with mixed io_task and regular task
+    void
+    testMixedIoTaskAndRegularTask()
+    {
+        int dispatch_count = 0;
+        test_executor ex(dispatch_count);
+        bool completed = false;
+        int int_result = 0;
+
+        auto io_read = [](std::size_t n) -> io_task<std::size_t> {
+            co_return io_result<std::size_t>{{}, n};
+        };
+
+        run_async(ex,
+            [&](auto&& t) {
+                completed = true;
+                int_result = std::get<0>(t);
+            },
+            [](std::exception_ptr) {})(
+            when_all(returns_int(99), io_read(200)));
+
+        BOOST_TEST(completed);
+        BOOST_TEST_EQ(int_result, 99);
+    }
+
+    void
+    run()
+    {
+        testStopOnlyAwaitableWithTask();
+        testAsyncEventWaitWithTask();
+        testTwoStopOnlyAwaitables();
+        testIoTaskWithWhenAll();
+        testMixedIoTaskAndRegularTask();
+    }
+};
+
+TEST_SUITE(
+    when_all_io_awaitable_test,
+    "boost.capy.when_all_io_awaitable");
 
 } // capy
 } // boost


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated `when_all` API to accept IoAwaitables directly instead of exclusively task types, enabling composition with a broader range of awaitable types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->