### PR TITLE
Fix run_async_wrapper leaving stale TLS frame allocator

### DIFF
--- a/include/boost/capy/ex/run_async.hpp
+++ b/include/boost/capy/ex/run_async.hpp
@@ -328,6 +328,7 @@ class [[nodiscard]] run_async_wrapper
 {
     detail::run_async_trampoline<Ex, Handlers, Alloc> tr_;
     std::stop_token st_;
+    std::pmr::memory_resource* saved_tls_;
 
 public:
     /// Construct wrapper with executor, stop token, handlers, and allocator.
@@ -339,6 +340,7 @@ public:
         : tr_(detail::make_trampoline<Ex, Handlers, Alloc>(
             std::move(ex), std::move(h), std::move(a)))
         , st_(std::move(st))
+        , saved_tls_(current_frame_allocator())
     {
         if constexpr (!std::is_same_v<Alloc, std::pmr::memory_resource*>)
         {
@@ -348,6 +350,13 @@ public:
         }
         // Set TLS before task argument is evaluated
         current_frame_allocator() = tr_.h_.promise().get_resource();
+    }
+
+    ~run_async_wrapper()
+    {
+        // Restore TLS so stale pointer doesn't outlive
+        // the execution context that owns the resource.
+        current_frame_allocator() = saved_tls_;
     }
 
     // Non-copyable, non-movable (must be used immediately)

--- a/test/unit/ex/async_event.cpp
+++ b/test/unit/ex/async_event.cpp
@@ -14,10 +14,14 @@
 #include <boost/capy/error.hpp>
 #include <boost/capy/ex/executor_ref.hpp>
 #include <boost/capy/ex/io_env.hpp>
+#include <boost/capy/ex/run_async.hpp>
+#include <boost/capy/ex/thread_pool.hpp>
 #include <boost/capy/io_result.hpp>
 #include <boost/capy/task.hpp>
+#include <boost/capy/when_all.hpp>
 
 #include <queue>
+#include <semaphore>
 #include <stop_token>
 #include <vector>
 
@@ -676,6 +680,60 @@ struct async_event_test
         h.destroy();
     }
 
+    static task<void>
+    set_event_task(async_event& evt)
+    {
+        evt.set();
+        co_return;
+    }
+
+    static task<void>
+    when_all_set_event_main(bool& finished)
+    {
+        async_event evt;
+        co_await when_all(evt.wait(), set_event_task(evt));
+        finished = true;
+    }
+
+    static task<void>
+    simple_task(bool& finished)
+    {
+        finished = true;
+        co_return;
+    }
+
+    void
+    testRunAsyncThreadPool()
+    {
+        thread_pool pool(1);
+        std::binary_semaphore done(0);
+        bool finished = false;
+
+        run_async(pool.get_executor(),
+            [&]() { done.release(); },
+            [&](std::exception_ptr) { done.release(); }
+        )(simple_task(finished));
+
+        done.acquire();
+        BOOST_TEST(finished);
+    }
+
+    void
+    testWhenAllSetEvent()
+    {
+        thread_pool pool(1);
+        std::binary_semaphore done(0);
+        bool finished = false;
+
+        run_async(pool.get_executor(),
+            [&]() { done.release(); },
+            [&](std::exception_ptr) { done.release(); }
+        )(when_all_set_event_main(finished));
+
+        done.acquire();
+        BOOST_TEST(finished);
+    }
+
     void
     run()
     {
@@ -697,6 +755,8 @@ struct async_event_test
         testSetWithInlineExecutor();
         testMultipleWaitersInlineExecutor();
         testCancellationWithInlineExecutor();
+        testRunAsyncThreadPool();
+        testWhenAllSetEvent();
     }
 };
 


### PR DESCRIPTION
run_async_wrapper sets current_frame_allocator() to the execution context's memory resource so the task argument's coroutine frame is allocated from the correct allocator. When the execution context is later destroyed (e.g. thread_pool goes out of scope), the TLS pointer becomes dangling. Any subsequent coroutine frame allocation on the same thread - such as fuse::armed via run_blocking - dereferences freed memory.

Save TLS in the wrapper constructor and restore it in the destructor so the stale pointer never outlives the execution context.

Add testRunAsyncThreadPool and testWhenAllSetEvent to the async_event test suite exercising run_async with thread_pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-local storage restoration in async operations to ensure proper resource cleanup and allocation context management when async operations complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->