### PR TITLE
Add target() to executor_ref and execution_context

### DIFF
--- a/include/boost/capy/ex/execution_context.hpp
+++ b/include/boost/capy/ex/execution_context.hpp
@@ -85,6 +85,8 @@ namespace capy {
 class BOOST_CAPY_DECL
     execution_context
 {
+    detail::type_info const* ti_ = nullptr;
+
     template<class T, class = void>
     struct get_key : std::false_type
     {};
@@ -94,6 +96,9 @@ class BOOST_CAPY_DECL
     {
         using type = typename T::key_type;
     };
+protected:
+    template< typename Derived >
+    explicit execution_context( Derived* ) noexcept;
 
 public:
     //------------------------------------------------
@@ -416,6 +421,36 @@ public:
         owned_ = std::move(p);
     }
 
+    /** Return a pointer to this context if it matches the
+        requested type.
+
+        Performs a type check and downcasts `this` when the
+        types match, or returns `nullptr` otherwise. Analogous
+        to `std::any_cast< ExecutionContext >( &a )`.
+
+        @tparam ExecutionContext The derived context type to
+            retrieve.
+
+        @return A pointer to this context as the requested
+            type, or `nullptr` if the type does not match.
+    */
+    template< typename ExecutionContext >
+    const ExecutionContext* target() const
+    {
+        if ( ti_ && *ti_ == detail::type_id< ExecutionContext >() )
+           return static_cast< ExecutionContext const* >( this );
+        return nullptr;
+    }
+
+    /// @copydoc target() const
+    template< typename ExecutionContext >
+    ExecutionContext* target()
+    {
+        if ( ti_ && *ti_ == detail::type_id< ExecutionContext >() )
+           return static_cast< ExecutionContext* >( this );
+        return nullptr;
+    }
+
 protected:
     /** Shut down all services.
 
@@ -510,6 +545,14 @@ private:
     service* head_ = nullptr;
     bool shutdown_ = false;
 };
+
+template< typename Derived >
+execution_context::
+execution_context( Derived* ) noexcept
+    : execution_context()
+{
+    ti_ = &detail::type_id< Derived >();
+}
 
 } // namespace capy
 } // namespace boost

--- a/include/boost/capy/ex/executor_ref.hpp
+++ b/include/boost/capy/ex/executor_ref.hpp
@@ -248,15 +248,35 @@ public:
         return vt_->equals(ex_, other.ex_);
     }
 
-    /** Returns the type info of the underlying executor type.
+    /** Return a pointer to the wrapped executor if it matches
+        the requested type.
 
-        @return A reference to the type_info for the wrapped executor.
+        Performs a type check against the stored executor and
+        returns a typed pointer when the types match, or
+        `nullptr` otherwise. Analogous to
+        `std::any_cast< Executor >( &a )`.
 
-        @pre This instance was constructed with a valid executor.
+        @tparam Executor The executor type to retrieve.
+
+        @return A pointer to the underlying executor, or
+            `nullptr` if the type does not match.
     */
-    detail::type_info const& type_id() const noexcept
+    template< typename Executor >
+    const Executor* target() const
     {
-        return *vt_->type_id;
+        if ( *vt_->type_id == detail::type_id< Executor >() )
+           return static_cast< Executor const* >( ex_ );
+        return nullptr;
+    }
+
+    /// @copydoc target() const
+    template< typename Executor>
+    Executor* target()
+    {
+        if ( *vt_->type_id == detail::type_id< Executor >() )
+           return const_cast< Executor* >(
+               static_cast< Executor const* >( ex_ ));
+        return nullptr;
     }
 };
 

--- a/test/unit/ex/execution_context.cpp
+++ b/test/unit/ex/execution_context.cpp
@@ -318,6 +318,29 @@ struct execution_context_test
     }
 
     void
+    testTarget()
+    {
+        test_io_context ctx;
+
+        // Matching type returns non-null
+        auto* p = ctx.target<test_io_context>();
+        BOOST_TEST_NE(p, nullptr);
+        BOOST_TEST_EQ(p, &ctx);
+
+        // Const overload
+        execution_context const& cctx = ctx;
+        auto* cp = cctx.target<test_io_context>();
+        BOOST_TEST_NE(cp, nullptr);
+        BOOST_TEST_EQ(cp, &ctx);
+
+        // Wrong type returns nullptr
+        struct other_context : execution_context {};
+        BOOST_TEST_EQ(
+            ctx.target<other_context>(),
+            nullptr);
+    }
+
+    void
     testGetFrameAllocator()
     {
         test_io_context ctx;
@@ -379,6 +402,7 @@ struct execution_context_test
         testMultipleServices();
         testNestedServiceCreation();
         testConcurrentAccess();
+        testTarget();
         testGetFrameAllocator();
         testSetFrameAllocatorRawPointer();
         testSetFrameAllocatorTemplate();

--- a/test/unit/ex/executor_ref.cpp
+++ b/test/unit/ex/executor_ref.cpp
@@ -237,24 +237,28 @@ struct executor_ref_test
     }
 
     void
-    testTypeId()
+    testTarget()
     {
-        thread_pool pool1(1);
-        thread_pool pool2(1);
-        auto executor1 = pool1.get_executor();
-        auto executor2 = pool2.get_executor();
+        thread_pool pool(1);
+        auto executor = pool.get_executor();
+        executor_ref ex(executor);
 
-        executor_ref ex1(executor1);
-        executor_ref ex2(executor2);
+        // Matching type returns non-null
+        auto* p = ex.target<thread_pool::executor_type>();
+        BOOST_TEST_NE(p, nullptr);
 
-        // Same executor type returns equal type_info
-        BOOST_TEST(ex1.type_id() == ex2.type_id());
+        // Const overload
+        executor_ref const& cex = ex;
+        auto* cp = cex.target<thread_pool::executor_type>();
+        BOOST_TEST_NE(cp, nullptr);
 
-        // Different executor type returns different type_info
+        // Wrong type returns nullptr
         test::blocking_context bctx;
         auto ie = bctx.get_executor();
-        executor_ref ex3(ie);
-        BOOST_TEST(ex1.type_id() != ex3.type_id());
+        executor_ref ex2(ie);
+        BOOST_TEST_EQ(
+            ex2.target<thread_pool::executor_type>(),
+            nullptr);
     }
 
     void
@@ -266,7 +270,7 @@ struct executor_ref_test
         testDispatch();
         testPost();
         testMultiplePost();
-        testTypeId();
+        testTarget();
     }
 };
 

--- a/test/unit/test_helpers.hpp
+++ b/test/unit/test_helpers.hpp
@@ -126,6 +126,11 @@ public:
 
     int id = 0;
 
+    test_io_context()
+        : execution_context(this)
+    {
+    }
+
     executor_type
     get_executor() noexcept
     {


### PR DESCRIPTION
Replace executor_ref::type_id() with a type-safe target<T>() accessor modeled after std::any_cast. Add the same target<T>() API to execution_context for downcasting to a derived context type. Add corresponding unit tests for both classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced runtime type identification and type-safe downcasting capabilities for execution contexts and executor references, enabling safe discovery and access to underlying implementations without unsafe casts.
  * Enhanced service resolution with support for keyed type lookups, providing more granular and type-aware service discovery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->