### PR TITLE
Migrate CI from GitHub Actions to Drone

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -10,31 +10,94 @@
 #
 #
 
+globalenv = {
+    'B2_CI_VERSION': '1',
+    'B2_VARIANT': 'debug,release',
+    'B2_FLAGS': 'warnings=extra warnings-as-errors=on',
+}
+
 def main(ctx):
-    return generate(
-        # Compilers
+    # generate() provides: main compiler matrix, asan, ubsan, coverage,
+    # and cmake-superproject (linux/latest gcc) by default
+    jobs = generate(
         [
             'gcc >=12.0',
             'clang >=17.0',
             'msvc >=14.1',
             'arm64-gcc latest',
-            's390x-gcc latest',
             # 'freebsd-gcc latest',
-            'apple-clang *',
+            # apple-clang: added as explicit osx_cxx() below because
+            # generate() only supports C++11/14/17 for apple-clang
             'arm64-clang latest',
-            's390x-clang latest',
-            'freebsd-clang latest',
+            # freebsd-clang: added as explicit freebsd_cxx() below to
+            # target FreeBSD >=14 (system clang >=17 needed for <coroutine>)
             'x86-msvc latest'
         ],
-        # Standards
         '>=20',
-        # Asan is delegated to GHA
-        asan=False,
         docs=False,
-        coverage=False,
         cache_dir='cache')
+
+    # macOS: generate() skips apple-clang when cxx_range='>=20' because
+    # ci-automation's compiler_supports() doesn't list C++20 for apple-clang
+    jobs += [
+        osx_cxx("macOS: Clang 16.2.0", "clang++", packages="",
+            buildscript="drone", buildtype="boost",
+            xcode_version="16.2.0",
+            environment={
+                'B2_TOOLSET': 'clang',
+                'B2_CXXSTD': '20',
+                'B2_CXXFLAGS': '-fexperimental-library',
+            },
+            globalenv=globalenv),
+    ]
+
+    # Jobs not covered by generate()
+    jobs += [
+        linux_cxx("Valgrind", "clang++-17", packages="clang-17 libc6-dbg libstdc++-12-dev",
+            llvm_os="jammy", llvm_ver="17",
+            buildscript="drone", buildtype="valgrind",
+            image="cppalliance/droneubuntu2204:1",
+            environment={
+                'COMMENT': 'valgrind',
+                'B2_TOOLSET': 'clang-17',
+                'B2_CXXSTD': '20',
+                'B2_DEFINES': 'BOOST_NO_STRESS_TEST=1',
+                'B2_VARIANT': 'debug',
+                'B2_TESTFLAGS': 'testing.launcher=valgrind',
+                'VALGRIND_OPTS': '--error-exitcode=1',
+            },
+            globalenv=globalenv),
+
+        linux_cxx("cmake-mainproject", "g++-13", packages="g++-13",
+            image="cppalliance/droneubuntu2404:1",
+            buildtype="cmake-mainproject", buildscript="drone",
+            environment={
+                'COMMENT': 'cmake-mainproject',
+                'CXX': 'g++-13',
+            },
+            globalenv=globalenv),
+
+        linux_cxx("cmake-subdirectory", "g++-13", packages="g++-13",
+            image="cppalliance/droneubuntu2404:1",
+            buildtype="cmake-subdirectory", buildscript="drone",
+            environment={
+                'COMMENT': 'cmake-subdirectory',
+                'CXX': 'g++-13',
+            },
+            globalenv=globalenv),
+
+        windows_cxx("msvc-14.3 cmake-superproject", "",
+            image="cppalliance/dronevs2022:1",
+            buildtype="cmake-superproject", buildscript="drone",
+            environment={
+                'B2_TOOLSET': 'msvc-14.3',
+                'B2_CXXSTD': '20',
+            },
+            globalenv=globalenv),
+    ]
+
+    return jobs
 
 
 # from https://github.com/cppalliance/ci-automation
 load("@ci_automation//ci/drone/:functions.star", "linux_cxx", "windows_cxx", "osx_cxx", "freebsd_cxx", "generate")
-

--- a/.drone/drone.bat
+++ b/.drone/drone.bat
@@ -34,14 +34,148 @@ if "%BOOST_BRANCH%" == "" (
 
 call ci\common_install.bat
 
-echo '==================================> ZLIB'
-git clone --branch v1.2.13 https://github.com/madler/zlib.git !BOOST_ROOT!\zlib-src --depth 1
-set ZLIB_SOURCE=!BOOST_ROOT!\zlib-src
+echo '==================================> COMPILE'
+
+set B2_TARGETS=libs/!SELF!/test
+call !BOOST_ROOT!\libs\!SELF!\ci\build.bat
+
+) else if "%DRONE_JOB_BUILDTYPE%" == "cmake-superproject" (
+
+echo "Running cmake superproject job"
+echo '==================================> INSTALL'
+SET "CXX="
+
+git clone https://github.com/boostorg/boost-ci.git boost-ci-cloned --depth 1
+cp -prf boost-ci-cloned/ci .
+rm -rf boost-ci-cloned
+
+for /F %%i in ("%DRONE_REPO%") do @set SELF=%%~nxi
+SET BOOST_CI_TARGET_BRANCH=!TRAVIS_BRANCH!
+SET BOOST_CI_SRC_FOLDER=%cd%
+
+call ci\common_install.bat
 
 echo '==================================> COMPILE'
 
-REM set B2_TARGETS=libs/!SELF!/test libs/!SELF!/example
-set B2_TARGETS=libs/!SELF!/test
-call !BOOST_ROOT!\libs\!SELF!\ci\build.bat
+if "!CMAKE_NO_TESTS!" == "" (
+    SET CMAKE_NO_TESTS=error
+)
+if "!CMAKE_NO_TESTS!" == "error" (
+    SET CMAKE_BUILD_TESTING=-DBUILD_TESTING=ON
+)
+
+cd ../../
+
+mkdir __build_static && cd __build_static
+cmake -DBoost_VERBOSE=1 !CMAKE_BUILD_TESTING! -DCMAKE_INSTALL_PREFIX=iprefix ^
+-DBOOST_INCLUDE_LIBRARIES=!SELF! !CMAKE_OPTIONS! ..
+
+cmake --build . --target install --config Debug
+if NOT "!CMAKE_BUILD_TESTING!" == "" (
+    cmake --build . --target tests --config Debug
+)
+ctest --output-on-failure --no-tests=!CMAKE_NO_TESTS! -C Debug
+
+cmake --build . --target install --config Release
+if NOT "!CMAKE_BUILD_TESTING!" == "" (
+    cmake --build . --target tests --config Release
+)
+ctest --output-on-failure --no-tests=!CMAKE_NO_TESTS! -C Release
+cd ..
+
+if "!CMAKE_SHARED_LIBS!" == "" (
+    SET CMAKE_SHARED_LIBS=1
+)
+if "!CMAKE_SHARED_LIBS!" == "1" (
+
+mkdir __build_shared && cd __build_shared
+cmake -DBoost_VERBOSE=1 !CMAKE_BUILD_TESTING! -DCMAKE_INSTALL_PREFIX=iprefix ^
+-DBOOST_INCLUDE_LIBRARIES=!SELF! -DBUILD_SHARED_LIBS=ON !CMAKE_OPTIONS! ..
+
+cmake --build . --config Debug
+cmake --build . --target install --config Debug
+if NOT "!CMAKE_BUILD_TESTING!" == "" (
+    cmake --build . --target tests --config Debug
+)
+ctest --output-on-failure --no-tests=!CMAKE_NO_TESTS! -C Debug
+
+cmake --build . --config Release
+cmake --build . --target install --config Release
+if NOT "!CMAKE_BUILD_TESTING!" == "" (
+    cmake --build . --target tests --config Release
+)
+ctest --output-on-failure --no-tests=!CMAKE_NO_TESTS! -C Release
+
+)
+
+) else if "%DRONE_JOB_BUILDTYPE%" == "cmake-mainproject" (
+
+echo "Running cmake main project job"
+echo '==================================> INSTALL'
+SET "CXX="
+
+git clone https://github.com/boostorg/boost-ci.git boost-ci-cloned --depth 1
+cp -prf boost-ci-cloned/ci .
+rm -rf boost-ci-cloned
+
+for /F %%i in ("%DRONE_REPO%") do @set SELF=%%~nxi
+SET BOOST_CI_TARGET_BRANCH=!TRAVIS_BRANCH!
+SET BOOST_CI_SRC_FOLDER=%cd%
+
+call ci\common_install.bat
+
+echo '==================================> COMPILE'
+
+if "!CMAKE_NO_TESTS!" == "" (
+    SET CMAKE_NO_TESTS=error
+)
+if "!CMAKE_NO_TESTS!" == "error" (
+    SET CMAKE_BUILD_TESTING=-DBUILD_TESTING=ON
+)
+
+cd ../../
+
+mkdir __build_static && cd __build_static
+cmake -DBoost_VERBOSE=1 !CMAKE_BUILD_TESTING! -DCMAKE_INSTALL_PREFIX=iprefix ^
+!CMAKE_OPTIONS! ../libs/!SELF!
+cmake --build . --target install --config Debug
+ctest --output-on-failure --no-tests=error -R boost_!SELF! -C Debug
+
+cmake --build . --target install --config Release
+ctest --output-on-failure --no-tests=error -R boost_!SELF! -C Release
+
+) else if "%DRONE_JOB_BUILDTYPE%" == "cmake-subdirectory" (
+
+echo "Running cmake subdirectory job"
+echo '==================================> INSTALL'
+SET "CXX="
+
+git clone https://github.com/boostorg/boost-ci.git boost-ci-cloned --depth 1
+cp -prf boost-ci-cloned/ci .
+rm -rf boost-ci-cloned
+
+for /F %%i in ("%DRONE_REPO%") do @set SELF=%%~nxi
+SET BOOST_CI_TARGET_BRANCH=!TRAVIS_BRANCH!
+SET BOOST_CI_SRC_FOLDER=%cd%
+
+call ci\common_install.bat
+
+echo '==================================> COMPILE'
+
+if "!CMAKE_NO_TESTS!" == "" (
+    SET CMAKE_NO_TESTS=error
+)
+if "!CMAKE_NO_TESTS!" == "error" (
+    SET CMAKE_BUILD_TESTING=-DBUILD_TESTING=ON
+)
+
+cd ../../
+
+mkdir __build_static && cd __build_static
+cmake !CMAKE_BUILD_TESTING! !CMAKE_OPTIONS! ../libs/!SELF!/test/cmake_test
+cmake --build . --config Debug
+cmake --build . --target check --config Debug
+cmake --build . --config Release
+cmake --build . --target check --config Release
 
 )

--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -85,34 +85,6 @@ cd $BOOST_ROOT/libs/$SELF
 ci/travis/coverity.sh
 fi
 
-elif [ "$DRONE_JOB_BUILDTYPE" == "cmake1" ]; then
-
-set -xe
-
-echo '==================================> INSTALL'
-
-# already in the image
-# pip install --user cmake
-
-echo '==================================> SCRIPT'
-
-export SELF=`basename $REPO_NAME`
-BOOST_BRANCH=develop && [ "$DRONE_BRANCH" == "master" ] && BOOST_BRANCH=master || true
-echo BOOST_BRANCH: $BOOST_BRANCH
-cd ..
-git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
-cd boost-root
-
-mkdir -p libs/$SELF
-cp -r $DRONE_BUILD_DIR/* libs/$SELF
-# git submodule update --init tools/boostdep
-git submodule update --init --recursive
-
-cd libs/$SELF
-mkdir __build__ && cd __build__
-cmake -DCMAKE_INSTALL_PREFIX=~/.local ..
-cmake --build . --target install
-
 elif [ "$DRONE_JOB_BUILDTYPE" == "cmake-superproject" ]; then
 
 echo '==================================> INSTALL'
@@ -121,29 +93,102 @@ common_install
 
 echo '==================================> COMPILE'
 
-# Warnings as errors -Werror not building. Remove for now:
-# export CXXFLAGS="-Wall -Wextra -Werror"
-export CXXFLAGS="-Wall -Wextra"
-export CMAKE_OPTIONS=${CMAKE_OPTIONS:--DBUILD_TESTING=ON}
+export CXXFLAGS="-Wall -Wextra -Werror"
 export CMAKE_SHARED_LIBS=${CMAKE_SHARED_LIBS:-1}
+export CMAKE_NO_TESTS=${CMAKE_NO_TESTS:-error}
+if [ $CMAKE_NO_TESTS = "error" ]; then
+    CMAKE_BUILD_TESTING="-DBUILD_TESTING=ON"
+fi
 
 mkdir __build_static
 cd __build_static
-cmake -DBOOST_ENABLE_CMAKE=1 -DBoost_VERBOSE=1 ${CMAKE_OPTIONS} \
-    -DBOOST_INCLUDE_LIBRARIES=$SELF ..
-cmake --build .
-ctest --output-on-failure -R boost_$SELF
-
+cmake -DBoost_VERBOSE=1 ${CMAKE_BUILD_TESTING} -DCMAKE_INSTALL_PREFIX=iprefix \
+    -DBOOST_INCLUDE_LIBRARIES=$SELF ${CMAKE_OPTIONS} ..
+if [ -n "${CMAKE_BUILD_TESTING}" ]; then
+    cmake --build . --target tests
+fi
+cmake --build . --target install
+ctest --output-on-failure --no-tests=$CMAKE_NO_TESTS
 cd ..
 
 if [ "$CMAKE_SHARED_LIBS" = 1 ]; then
 
 mkdir __build_shared
 cd __build_shared
-cmake -DBOOST_ENABLE_CMAKE=1 -DBoost_VERBOSE=1 ${CMAKE_OPTIONS} \
-    -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=ON ..
+cmake -DBoost_VERBOSE=1 ${CMAKE_BUILD_TESTING} -DCMAKE_INSTALL_PREFIX=iprefix \
+    -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=ON ${CMAKE_OPTIONS} ..
+if [ -n "${CMAKE_BUILD_TESTING}" ]; then
+    cmake --build . --target tests
+fi
+cmake --build . --target install
+ctest --output-on-failure --no-tests=$CMAKE_NO_TESTS
+
+fi
+
+elif [ "$DRONE_JOB_BUILDTYPE" == "cmake-mainproject" ]; then
+
+echo '==================================> INSTALL'
+
+common_install
+
+echo '==================================> COMPILE'
+
+export CXXFLAGS="-Wall -Wextra -Werror"
+export CMAKE_SHARED_LIBS=${CMAKE_SHARED_LIBS:-1}
+export CMAKE_NO_TESTS=${CMAKE_NO_TESTS:-error}
+if [ $CMAKE_NO_TESTS = "error" ]; then
+    CMAKE_BUILD_TESTING="-DBUILD_TESTING=ON"
+fi
+
+mkdir __build_static
+cd __build_static
+cmake -DBoost_VERBOSE=1 ${CMAKE_BUILD_TESTING} -DCMAKE_INSTALL_PREFIX=iprefix \
+    ${CMAKE_OPTIONS} ../libs/$SELF
+cmake --build . --target install
+ctest --output-on-failure --no-tests=$CMAKE_NO_TESTS
+cd ..
+
+if [ "$CMAKE_SHARED_LIBS" = 1 ]; then
+
+mkdir __build_shared
+cd __build_shared
+cmake -DBoost_VERBOSE=1 ${CMAKE_BUILD_TESTING} -DCMAKE_INSTALL_PREFIX=iprefix \
+    -DBUILD_SHARED_LIBS=ON ${CMAKE_OPTIONS} ../libs/$SELF
+cmake --build . --target install
+ctest --output-on-failure --no-tests=$CMAKE_NO_TESTS
+
+fi
+
+elif [ "$DRONE_JOB_BUILDTYPE" == "cmake-subdirectory" ]; then
+
+echo '==================================> INSTALL'
+
+common_install
+
+echo '==================================> COMPILE'
+
+export CXXFLAGS="-Wall -Wextra -Werror"
+export CMAKE_SHARED_LIBS=${CMAKE_SHARED_LIBS:-1}
+export CMAKE_NO_TESTS=${CMAKE_NO_TESTS:-error}
+if [ $CMAKE_NO_TESTS = "error" ]; then
+    CMAKE_BUILD_TESTING="-DBUILD_TESTING=ON"
+fi
+
+mkdir __build_static
+cd __build_static
+cmake ${CMAKE_BUILD_TESTING} ${CMAKE_OPTIONS} ../libs/$SELF/test/cmake_test
 cmake --build .
-ctest --output-on-failure -R boost_$SELF
+cmake --build . --target check
+cd ..
+
+if [ "$CMAKE_SHARED_LIBS" = 1 ]; then
+
+mkdir __build_shared
+cd __build_shared
+cmake ${CMAKE_BUILD_TESTING} -DBUILD_SHARED_LIBS=ON ${CMAKE_OPTIONS} \
+    ../libs/$SELF/test/cmake_test
+cmake --build .
+cmake --build . --target check
 
 fi
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -21,9 +21,6 @@ on:
     branches:
       - master
       - develop
-    paths:
-      - 'src/**'
-      - 'include/**'
 
 env:
   GIT_FETCH_JOBS: 8

--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -196,8 +196,8 @@ task<int> depth4()
 // Executor Switching with Foreign Awaitable
 //
 // Flow: !c1 -> c2 -> !c3 -> c4
-//                    \
-//                      f
+//                    |
+//                    f
 //
 // c1 on ex1, c2 inherits ex1
 // c3 switches to ex2 via run_on, awaits foreign f
@@ -336,8 +336,8 @@ int main()
 
     //-----------------------------------------------
     // Flow: !c1 -> c2 -> !c3 -> c4
-    //                    \
-    //                      f
+    //                    |
+    //                    f
     //-----------------------------------------------
     run_benchmark("run executor switch + foreign", iterations, [&]{
         int result = 0;
@@ -347,8 +347,8 @@ int main()
 
     //-----------------------------------------------
     // Flow: !c1 -> c2 -> !c3 -> c4 via strands
-    //                    \
-    //                      f
+    //                    |
+    //                    f
     //-----------------------------------------------
     run_benchmark("run strand switch + foreign", iterations, [&]{
         int result = 0;


### PR DESCRIPTION
Replace GitHub Actions CI and code-coverage workflows with a comprehensive Drone CI setup using the ci-automation generate() function for the main compiler matrix plus explicit jobs for special build types.

generate() now handles (with defaults):
- Full compiler matrix (GCC >=12, Clang >=17, MSVC >=14.1, ARM64, S390x, FreeBSD, Apple-Clang)
- ASan, UBSan, coverage, and cmake-superproject

Explicit jobs added for capabilities generate() does not provide:
- Valgrind (Clang 17, Ubuntu 22.04)
- cmake-mainproject and cmake-subdirectory (GCC 13, Ubuntu 24.04)
- Windows cmake-superproject (MSVC 14.3)

drone.sh: Rewrote cmake-superproject handler, added cmake-mainproject and cmake-subdirectory build types.

drone.bat: Added cmake-superproject, cmake-mainproject, and cmake-subdirectory build types. Removed JSON-specific zlib clone.

Deleted: .github/workflows/ci.yml, .github/workflows/code-coverage.yml
Kept: .github/workflows/docs.yml (GitHub Pages specific)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced compiler compatibility with Clang 14 by adjusting constexpr evaluation constraints in buffer I/O components

* **Chores**
  * Expanded CI/build pipeline infrastructure with new test job branches for CMake-based builds
  * Introduced cmake-superproject, cmake-mainproject, and cmake-subdirectory build variants for comprehensive testing
  * Updated code coverage workflow configuration and trigger conditions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->