### PR TITLE
Work around MSVC symmetric transfer use-after-free in transform_awaiter

### DIFF
--- a/include/boost/capy/task.hpp
+++ b/include/boost/capy/task.hpp
@@ -204,7 +204,21 @@ struct [[nodiscard]] BOOST_CAPY_CORO_AWAIT_ELIDABLE
             template<class Promise>
             auto await_suspend(std::coroutine_handle<Promise> h) noexcept
             {
+#ifdef _MSC_VER
+                // Workaround: MSVC stores the coroutine_handle<> return
+                // value on the coroutine frame via hidden __$ReturnUdt$.
+                // After await_suspend publishes the handle to another
+                // thread, that thread can resume/destroy the frame before
+                // __resume reads the handle back for the symmetric
+                // transfer tail-call, causing a use-after-free.
+                using R = decltype(a_.await_suspend(h, p_->environment()));
+                if constexpr (std::is_same_v<R, std::coroutine_handle<>>)
+                    a_.await_suspend(h, p_->environment()).resume();
+                else
+                    return a_.await_suspend(h, p_->environment());
+#else
                 return a_.await_suspend(h, p_->environment());
+#endif
             }
         };
 

--- a/include/boost/capy/when_all.hpp
+++ b/include/boost/capy/when_all.hpp
@@ -215,7 +215,15 @@ struct when_all_runner
             template<class Promise>
             auto await_suspend(std::coroutine_handle<Promise> h)
             {
+#ifdef _MSC_VER
+                using R = decltype(a_.await_suspend(h, &p_->env_));
+                if constexpr (std::is_same_v<R, std::coroutine_handle<>>)
+                    a_.await_suspend(h, &p_->env_).resume();
+                else
+                    return a_.await_suspend(h, &p_->env_);
+#else
                 return a_.await_suspend(h, &p_->env_);
+#endif
             }
         };
 

--- a/include/boost/capy/when_any.hpp
+++ b/include/boost/capy/when_any.hpp
@@ -353,7 +353,15 @@ struct when_any_runner
             template<class Promise>
             auto await_suspend(std::coroutine_handle<Promise> h)
             {
+#ifdef _MSC_VER
+                using R = decltype(a_.await_suspend(h, &p_->env_));
+                if constexpr (std::is_same_v<R, std::coroutine_handle<>>)
+                    a_.await_suspend(h, &p_->env_).resume();
+                else
+                    return a_.await_suspend(h, &p_->env_);
+#else
                 return a_.await_suspend(h, &p_->env_);
+#endif
             }
         };
 


### PR DESCRIPTION
MSVC stores the coroutine_handle<> return value from await_suspend on the coroutine frame via hidden __$ReturnUdt$. After await_suspend publishes the coroutine handle to another thread (e.g. via IOCP), that thread can resume/destroy the frame before __resume reads the handle back for the symmetric transfer tail-call, causing a use-after-free.

On MSVC, call the returned handle's resume() on the machine stack instead of returning it for symmetric transfer. For IOCP awaitables that return noop_coroutine(), this is a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved Microsoft Visual C++ (MSVC) compiler compatibility for coroutine operations to ensure correct suspension and resumption behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->