### PR TITLE
Drone: newer macos and freebsd

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -49,6 +49,27 @@ def main(ctx):
                 'B2_CXXFLAGS': '-fexperimental-library',
             },
             globalenv=globalenv),
+
+        osx_cxx("macOS: Clang 26.2.0", "clang++", packages="",
+            buildscript="drone", buildtype="boost",
+            xcode_version="26.2.0",
+            environment={
+                'B2_TOOLSET': 'clang',
+                'B2_CXXSTD': '20',
+                'B2_CXXFLAGS': '-fexperimental-library',
+            },
+            globalenv=globalenv),
+    ]
+
+    jobs += [
+        freebsd_cxx("clang-22", "clang++-22",
+            buildscript="drone", buildtype="boost",
+            freebsd_version="15.0",
+            environment={
+                'B2_TOOLSET': 'clang-22',
+                'B2_CXXSTD': '20',
+            },
+            globalenv=globalenv),
     ]
 
     # Jobs not covered by generate()


### PR DESCRIPTION
Newer macos and freebsd on drone.    

Macos builds.  
 
FreeBSD shows errors.  It is certainly within the realm of possibility the agent machine is missing something, even if it seems correct. Let me know. The clang package was installed with "pkg install llvm22", clang-22 is available, and it builds.  But then `no type ... in namespace 'std'` etc.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the continuous integration pipeline by expanding the build platform matrix with new platform-specific configurations. Added a new macOS Clang compiler variant to strengthen C++20 testing and improve validation capabilities.
  * Introduced FreeBSD platform support to the build matrix, enabling more comprehensive cross-platform testing coverage across a wider range of operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->