### PR TITLE
Fix Drone CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -21,7 +21,7 @@ def main(ctx):
     # and cmake-superproject (linux/latest gcc) by default
     jobs = generate(
         [
-            'gcc >=12.0',
+            'gcc >=13.0',
             'clang >=17.0',
             'msvc >=14.1',
             'arm64-gcc latest',

--- a/.drone.star
+++ b/.drone.star
@@ -46,7 +46,6 @@ def main(ctx):
             environment={
                 'B2_TOOLSET': 'clang',
                 'B2_CXXSTD': '20',
-                'B2_CXXFLAGS': '-fexperimental-library',
             },
             globalenv=globalenv),
 
@@ -56,7 +55,6 @@ def main(ctx):
             environment={
                 'B2_TOOLSET': 'clang',
                 'B2_CXXSTD': '20',
-                'B2_CXXFLAGS': '-fexperimental-library',
             },
             globalenv=globalenv),
     ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,15 +124,14 @@ jobs:
             build-type: "RelWithDebInfo"
 
           - compiler: "gcc"
-            version: "12"
+            version: "13"
             cxxstd: "20"
             latest-cxxstd: "20"
-            cxx: "g++-12"
-            cc: "gcc-12"
-            runs-on: "ubuntu-latest"
-            container: "ubuntu:22.04"
+            cxx: "g++-13"
+            cc: "gcc-13"
+            runs-on: "ubuntu-24.04"
             b2-toolset: "gcc"
-            name: "GCC 12: C++20"
+            name: "GCC 13: C++20"
             shared: true
             build-type: "Release"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,15 @@ if((APPLE OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD") AND
     check_cxx_compiler_flag(-fexperimental-library
         BOOST_CAPY_HAS_EXPERIMENTAL_LIBRARY)
 endif()
-option(BOOST_CAPY_BUILD_TESTS "Build boost::capy tests" ${BOOST_CAPY_IS_ROOT})
+
+if(DEFINED BUILD_TESTING)
+    set(BOOST_CAPY_BUILD_TESTS_DEFAULT ${BUILD_TESTING})
+elseif(BOOST_CAPY_IS_ROOT)
+    set(BOOST_CAPY_BUILD_TESTS_DEFAULT ON)
+else()
+    set(BOOST_CAPY_BUILD_TESTS_DEFAULT OFF)
+endif()
+option(BOOST_CAPY_BUILD_TESTS "Build boost::capy tests" ${BOOST_CAPY_BUILD_TESTS_DEFAULT})
 
 if (BOOST_CAPY_BUILD_TESTS)
     include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@
 # Copyright (c) 2022 Alan de Freitas (alandefreitas@gmail.com)
 # Copyright (c) 2025 Mohammad Nejati
 # Copyright (c) 2026 Steve Gerbino
+# Copyright (c) 2026 Michael Vandeberg
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -11,7 +12,7 @@
 # Official repository: https://github.com/cppalliance/capy
 #
 
-cmake_minimum_required(VERSION 3.8...3.31)
+cmake_minimum_required(VERSION 3.13...3.31)
 
 set(BOOST_CAPY_VERSION 1)
 if (BOOST_SUPERPROJECT_VERSION)
@@ -24,7 +25,16 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 endif ()
 set(__ignore__ ${CMAKE_C_COMPILER})
 
+# FreeBSD and macOS ship libc++ without full std::stop_token support;
+# -fexperimental-library enables it and links libc++experimental.
+include(CheckCXXCompilerFlag)
+if((APPLE OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD") AND
+    CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    check_cxx_compiler_flag(-fexperimental-library
+        BOOST_CAPY_HAS_EXPERIMENTAL_LIBRARY)
+endif()
 option(BOOST_CAPY_BUILD_TESTS "Build boost::capy tests" ${BOOST_CAPY_IS_ROOT})
+
 if (BOOST_CAPY_BUILD_TESTS)
     include(CTest)
 endif ()
@@ -41,6 +51,8 @@ source_group("" FILES "include/boost/capy.hpp" "build/Jamfile")
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include/boost/capy PREFIX "include" FILES ${BOOST_CAPY_HEADERS})
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX "src" FILES ${BOOST_CAPY_SOURCES})
 
+find_package(Threads REQUIRED)
+
 function(boost_capy_setup_properties target)
     target_compile_features(${target} PUBLIC cxx_std_20)
     target_include_directories(${target} PUBLIC
@@ -49,6 +61,11 @@ function(boost_capy_setup_properties target)
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
     target_compile_definitions(${target} PUBLIC BOOST_CAPY_NO_LIB)
     target_compile_definitions(${target} PRIVATE BOOST_CAPY_SOURCE)
+    target_link_libraries(${target} PUBLIC Threads::Threads)
+    if(BOOST_CAPY_HAS_EXPERIMENTAL_LIBRARY)
+        target_compile_options(${target} PUBLIC -fexperimental-library)
+        target_link_options(${target} PUBLIC -fexperimental-library)
+    endif()
     if (BUILD_SHARED_LIBS)
         target_compile_definitions(${target} PUBLIC BOOST_CAPY_DYN_LINK)
     else ()

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -23,6 +23,10 @@ project boost/capy
   : common-requirements
     <link>shared:<define>BOOST_CAPY_DYN_LINK
     <link>static:<define>BOOST_CAPY_STATIC_LINK
+    <target-os>darwin:<cxxflags>-fexperimental-library
+    <target-os>darwin:<linkflags>-fexperimental-library
+    <target-os>freebsd:<cxxflags>-fexperimental-library
+    <target-os>freebsd:<linkflags>-fexperimental-library
   : usage-requirements
     <define>BOOST_CAPY_NO_LIB
   : source-location ..


### PR DESCRIPTION
Build BSD with experimental library and fix cmake-superproject test BUilds by respecting BUILD_TESTING

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Requirements**
  * Minimum GCC version requirement raised to 13.0.
  * CMake minimum version requirement updated to 3.13.

* **Build Changes**
  * Updated CI/CD configurations with new compiler versions.
  * Adjusted compiler flag handling for improved platform compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->