### PR TITLE
Export and install test_suite for downstream use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,13 +78,16 @@ set_target_properties(boost_capy PROPERTIES
     INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO OFF
     INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL OFF)
 
+include(GNUInstallDirs)
+
+add_subdirectory(extra/test_suite)
+
 if(BOOST_SUPERPROJECT_VERSION AND NOT CMAKE_VERSION VERSION_LESS 3.13)
     boost_install(
         TARGETS boost_capy
         VERSION ${BOOST_SUPERPROJECT_VERSION}
         HEADER_DIRECTORY include)
 else()
-    include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)
 
     # Set INSTALL_INTERFACE for standalone installs (boost_install handles
@@ -95,13 +98,19 @@ else()
     set(BOOST_CAPY_INSTALL_CMAKEDIR
         ${CMAKE_INSTALL_LIBDIR}/cmake/boost_capy)
 
-    install(TARGETS boost_capy
+    install(TARGETS boost_capy boost_capy_test_suite boost_capy_test_suite_main
         EXPORT boost_capy-targets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(DIRECTORY include/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    install(FILES extra/test_suite/test_suite.hpp
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/boost/capy/extra/test_suite)
+    install(FILES
+        extra/test_suite/DiscoverTests.cmake
+        extra/test_suite/DiscoverAndWriteTestsScripts.cmake
+        DESTINATION ${BOOST_CAPY_INSTALL_CMAKEDIR})
     install(EXPORT boost_capy-targets
         NAMESPACE Boost::
         DESTINATION ${BOOST_CAPY_INSTALL_CMAKEDIR})

--- a/cmake/boost_capy-config.cmake.in
+++ b/cmake/boost_capy-config.cmake.in
@@ -1,3 +1,4 @@
 @PACKAGE_INIT@
 include("${CMAKE_CURRENT_LIST_DIR}/boost_capy-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/DiscoverTests.cmake")
 check_required_components(boost_capy)

--- a/extra/test_suite/CMakeLists.txt
+++ b/extra/test_suite/CMakeLists.txt
@@ -15,13 +15,25 @@ cmake_minimum_required(VERSION 3.8...3.20)
 
 # Library target with test_suite.cpp and test_suite.hpp
 add_library(boost_capy_test_suite STATIC test_suite.cpp test_suite.hpp)
-target_include_directories(boost_capy_test_suite PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(boost_capy_test_suite PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/boost/capy/extra/test_suite>)
 target_compile_features(boost_capy_test_suite PUBLIC cxx_std_17)
 
 # Library target that links the previous and adds test_main.cpp
 add_library(boost_capy_test_suite_main STATIC test_main.cpp)
 target_link_libraries(boost_capy_test_suite_main PUBLIC boost_capy_test_suite)
-target_include_directories(boost_capy_test_suite_main PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(boost_capy_test_suite_main PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/boost/capy/extra/test_suite>)
 target_compile_features(boost_capy_test_suite_main PUBLIC cxx_std_17)
+
+set_target_properties(boost_capy_test_suite PROPERTIES
+    EXPORT_NAME capy_test_suite)
+set_target_properties(boost_capy_test_suite_main PROPERTIES
+    EXPORT_NAME capy_test_suite_main)
+
+add_library(Boost::capy_test_suite ALIAS boost_capy_test_suite)
+add_library(Boost::capy_test_suite_main ALIAS boost_capy_test_suite_main)
 
 include(DiscoverTests.cmake)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -7,10 +7,6 @@
 # Official repository: https://github.com/cppalliance/capy
 #
 
-if(NOT TARGET boost_capy_test_suite)
-    add_subdirectory(../../extra/test_suite test_suite)
-endif()
-
 file(GLOB_RECURSE PFILES CONFIGURE_DEPENDS *.cpp *.hpp)
 list(APPEND PFILES
     CMakeLists.txt
@@ -21,7 +17,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES ${PFILES})
 add_executable(boost_capy_tests ${PFILES})
 target_link_libraries(
     boost_capy_tests PRIVATE
-    boost_capy_test_suite_main
+    Boost::capy_test_suite_main
     Boost::capy)
 
 target_include_directories(boost_capy_tests PRIVATE . ../../)


### PR DESCRIPTION
Make boost_capy_test_suite and boost_capy_test_suite_main available to downstream consumers via find_package(boost_capy). Add generator expressions for include dirs, EXPORT_NAME properties, Boost:: aliases, and install rules for targets, headers, and CMake modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added and installed a public test-suite component so test helpers are available after install.
  * Installed test-suite configuration scripts to enable test discovery in packaged builds.
  * Exposed public aliases and adjusted include paths so the test-suite integrates cleanly for both build and install scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->