### PR TITLE
Fix RTTI detection for Clang-CL

### DIFF
--- a/include/boost/capy/detail/config.hpp
+++ b/include/boost/capy/detail/config.hpp
@@ -49,13 +49,17 @@
 #endif
 
 // RTTI detection (user may predefine BOOST_CAPY_NO_RTTI)
+//
+// _MSC_VER must be checked before __clang__ because Clang-CL defines
+// both __clang__ and _MSC_VER, but uses the MSVC-style _CPPRTTI macro
+// (not the GCC-style __GXX_RTTI) to signal RTTI availability.
 #ifndef BOOST_CAPY_NO_RTTI
-# if defined(__GNUC__) || defined(__clang__)
-#  ifndef __GXX_RTTI
+# if defined(_MSC_VER)
+#  ifndef _CPPRTTI
 #   define BOOST_CAPY_NO_RTTI 1
 #  endif
-# elif defined(_MSC_VER)
-#  ifndef _CPPRTTI
+# elif defined(__GNUC__) || defined(__clang__)
+#  ifndef __GXX_RTTI
 #   define BOOST_CAPY_NO_RTTI 1
 #  endif
 # endif


### PR DESCRIPTION
Clang-CL defines both __clang__ and _MSC_VER, but uses the MSVC-style _CPPRTTI macro (not __GXX_RTTI) to signal RTTI. The previous check matched __clang__ first, incorrectly set BOOST_CAPY_NO_RTTI=1, and caused the address-based type_id fallback to be used. With shared linking, DLL and EXE get separate copies of the static tag, so find_service() fails across module boundaries ("service not installed").

Fix: check _MSC_VER before __clang__ so Clang-CL uses _CPPRTTI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Runtime Type Information (RTTI) detection for MSVC and Clang-CL compiler configurations. The detection logic now properly evaluates MSVC-specific settings before other compiler checks, preventing misdetection when using Clang-CL as the compiler frontend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->