### PR TITLE
Fix MSVC symmetric transfer use-after-free in final_suspend awaiters

### DIFF
--- a/include/boost/capy/detail/await_suspend_helper.hpp
+++ b/include/boost/capy/detail/await_suspend_helper.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Steve Gerbino
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -18,6 +19,50 @@
 namespace boost {
 namespace capy {
 namespace detail {
+
+/** Perform symmetric transfer, working around an MSVC codegen bug.
+
+    MSVC stores the `std::coroutine_handle<>` returned from
+    `await_suspend` in a hidden `__$ReturnUdt$` variable located
+    on the coroutine frame. When another thread resumes or destroys
+    the frame between the store and the read-back for the
+    symmetric-transfer tail-call, the read hits freed memory.
+
+    This occurs in two scenarios:
+
+    @li `await_suspend` calls `h.destroy()` then returns a handle
+        (e.g. `when_all_runner` and `when_any_runner` final_suspend).
+        The return value is written to the now-destroyed frame.
+
+    @li `await_suspend` hands the continuation to another thread
+        via `executor::dispatch()`, which may resume the parent.
+        The parent can destroy this frame before the runtime reads
+        `__$ReturnUdt$` (e.g. `dispatch_trampoline` final_suspend).
+
+    On MSVC this function calls `h.resume()` on the current stack
+    and returns `void`, causing unconditional suspension. The
+    trade-off is O(n) stack growth instead of O(1) tail-calls.
+
+    On other compilers the handle is returned directly for proper
+    symmetric transfer.
+
+    Callers must use `auto` return type on their `await_suspend`
+    so the return type adapts per platform.
+
+    @param h The coroutine handle to transfer to.
+*/
+#ifdef _MSC_VER
+inline void symmetric_transfer(std::coroutine_handle<> h) noexcept
+{
+    h.resume();
+}
+#else
+inline std::coroutine_handle<>
+symmetric_transfer(std::coroutine_handle<> h) noexcept
+{
+    return h;
+}
+#endif
 
 // Helper to normalize await_suspend return types to std::coroutine_handle<>
 template<typename Awaitable>

--- a/include/boost/capy/ex/run.hpp
+++ b/include/boost/capy/ex/run.hpp
@@ -11,6 +11,7 @@
 #define BOOST_CAPY_RUN_HPP
 
 #include <boost/capy/detail/config.hpp>
+#include <boost/capy/detail/await_suspend_helper.hpp>
 #include <boost/capy/detail/run.hpp>
 #include <boost/capy/concept/executor.hpp>
 #include <boost/capy/concept/io_runnable.hpp>
@@ -96,10 +97,11 @@ struct dispatch_trampoline
                 promise_type* p_;
                 bool await_ready() const noexcept { return false; }
 
-                std::coroutine_handle<> await_suspend(
+                auto await_suspend(
                     std::coroutine_handle<>) noexcept
                 {
-                    return p_->caller_ex_.dispatch(p_->parent_);
+                    return detail::symmetric_transfer(
+                        p_->caller_ex_.dispatch(p_->parent_));
                 }
 
                 void await_resume() const noexcept {}

--- a/include/boost/capy/task.hpp
+++ b/include/boost/capy/task.hpp
@@ -16,6 +16,7 @@
 #include <boost/capy/ex/io_awaitable_promise_base.hpp>
 #include <boost/capy/ex/io_env.hpp>
 #include <boost/capy/ex/frame_allocator.hpp>
+#include <boost/capy/detail/await_suspend_helper.hpp>
 
 #include <exception>
 #include <optional>
@@ -204,21 +205,11 @@ struct [[nodiscard]] BOOST_CAPY_CORO_AWAIT_ELIDABLE
             template<class Promise>
             auto await_suspend(std::coroutine_handle<Promise> h) noexcept
             {
-#ifdef _MSC_VER
-                // Workaround: MSVC stores the coroutine_handle<> return
-                // value on the coroutine frame via hidden __$ReturnUdt$.
-                // After await_suspend publishes the handle to another
-                // thread, that thread can resume/destroy the frame before
-                // __resume reads the handle back for the symmetric
-                // transfer tail-call, causing a use-after-free.
                 using R = decltype(a_.await_suspend(h, p_->environment()));
                 if constexpr (std::is_same_v<R, std::coroutine_handle<>>)
-                    a_.await_suspend(h, p_->environment()).resume();
+                    return detail::symmetric_transfer(a_.await_suspend(h, p_->environment()));
                 else
                     return a_.await_suspend(h, p_->environment());
-#else
-                return a_.await_suspend(h, p_->environment());
-#endif
             }
         };
 

--- a/include/boost/capy/when_all.hpp
+++ b/include/boost/capy/when_all.hpp
@@ -161,7 +161,7 @@ struct when_all_runner
                     return false;
                 }
 
-                std::coroutine_handle<> await_suspend(std::coroutine_handle<> h) noexcept
+                auto await_suspend(std::coroutine_handle<> h) noexcept
                 {
                     // Extract everything needed before self-destruction.
                     auto* state = p_->state_;
@@ -174,8 +174,8 @@ struct when_all_runner
                     // If last runner, dispatch parent for symmetric transfer.
                     auto remaining = counter->fetch_sub(1, std::memory_order_acq_rel);
                     if(remaining == 1)
-                        return caller_env->executor.dispatch(cont);
-                    return std::noop_coroutine();
+                        return detail::symmetric_transfer(caller_env->executor.dispatch(cont));
+                    return detail::symmetric_transfer(std::noop_coroutine());
                 }
 
                 void await_resume() const noexcept
@@ -215,15 +215,11 @@ struct when_all_runner
             template<class Promise>
             auto await_suspend(std::coroutine_handle<Promise> h)
             {
-#ifdef _MSC_VER
                 using R = decltype(a_.await_suspend(h, &p_->env_));
                 if constexpr (std::is_same_v<R, std::coroutine_handle<>>)
-                    a_.await_suspend(h, &p_->env_).resume();
+                    return detail::symmetric_transfer(a_.await_suspend(h, &p_->env_));
                 else
                     return a_.await_suspend(h, &p_->env_);
-#else
-                return a_.await_suspend(h, &p_->env_);
-#endif
             }
         };
 

--- a/include/boost/capy/when_any.hpp
+++ b/include/boost/capy/when_any.hpp
@@ -310,7 +310,7 @@ struct when_any_runner
             {
                 promise_type* p_;
                 bool await_ready() const noexcept { return false; }
-                std::coroutine_handle<> await_suspend(std::coroutine_handle<> h) noexcept
+                auto await_suspend(std::coroutine_handle<> h) noexcept
                 {
                     // Extract everything needed before self-destruction.
                     auto& core = p_->state_->core_;
@@ -323,8 +323,8 @@ struct when_any_runner
                     // If last runner, dispatch parent for symmetric transfer.
                     auto remaining = counter->fetch_sub(1, std::memory_order_acq_rel);
                     if(remaining == 1)
-                        return caller_env->executor.dispatch(cont);
-                    return std::noop_coroutine();
+                        return detail::symmetric_transfer(caller_env->executor.dispatch(cont));
+                    return detail::symmetric_transfer(std::noop_coroutine());
                 }
                 void await_resume() const noexcept {}
             };
@@ -353,15 +353,11 @@ struct when_any_runner
             template<class Promise>
             auto await_suspend(std::coroutine_handle<Promise> h)
             {
-#ifdef _MSC_VER
                 using R = decltype(a_.await_suspend(h, &p_->env_));
                 if constexpr (std::is_same_v<R, std::coroutine_handle<>>)
-                    a_.await_suspend(h, &p_->env_).resume();
+                    return detail::symmetric_transfer(a_.await_suspend(h, &p_->env_));
                 else
                     return a_.await_suspend(h, &p_->env_);
-#else
-                return a_.await_suspend(h, &p_->env_);
-#endif
             }
         };
 


### PR DESCRIPTION
Resolves #180.

Add detail::symmetric_transfer() to centralize the MSVC workaround where await_suspend returning coroutine_handle<> stores the value on the coroutine frame via __$ReturnUdt$. Apply it to when_all_runner, when_any_runner, and dispatch_trampoline final_suspend sites that were vulnerable but not previously covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined coroutine suspension and resumption mechanisms to improve cross-platform consistency and reliability. Enhanced internal handling of task composition and concurrent operations to ensure more predictable behavior across different compiler implementations. Updated core synchronization logic to reduce edge cases and improve robustness in complex coroutine scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->