### PR TITLE
Add public type aliases for detail types in when_any/when_all APIs

### DIFF
--- a/include/boost/capy/concept/io_awaitable.hpp
+++ b/include/boost/capy/concept/io_awaitable.hpp
@@ -112,14 +112,14 @@ concept IoAwaitable =
         a.await_suspend(h, env);
     };
 
-namespace detail {
+/** The return type of `co_await a` for awaitable type A.
 
-/** Extract the result type from any awaitable via await_resume().
+    Given an awaitable A, yields the type returned by A::await_resume().
+
+    @tparam A The awaitable type.
 */
 template<typename A>
 using awaitable_result_t = decltype(std::declval<std::decay_t<A>&>().await_resume());
-
-} // namespace detail
 
 } // namespace capy
 } // namespace boost

--- a/include/boost/capy/when_all.hpp
+++ b/include/boost/capy/when_all.hpp
@@ -358,17 +358,6 @@ private:
     }
 };
 
-/** Compute the result type for when_all.
-
-    Returns void when all tasks are void (P2300 aligned),
-    otherwise returns a tuple with void types filtered out.
-*/
-template<typename... Ts>
-using when_all_result_t = std::conditional_t<
-    std::is_same_v<filter_void_tuple_t<Ts...>, std::tuple<>>,
-    void,
-    filter_void_tuple_t<Ts...>>;
-
 /** Helper to extract a single result, returning empty tuple for void.
     This is a separate function to work around a GCC-11 ICE that occurs
     when using nested immediately-invoked lambdas with pack expansion.
@@ -394,6 +383,20 @@ auto extract_results(when_all_state<Ts...>& state)
 }
 
 } // namespace detail
+
+/** Compute a tuple type with void types filtered out.
+
+    Returns void when all types are void (P2300 aligned),
+    otherwise returns a std::tuple with void types removed.
+
+    Example: non_void_tuple_t<int, void, string> = std::tuple<int, string>
+    Example: non_void_tuple_t<void, void> = void
+*/
+template<typename... Ts>
+using non_void_tuple_t = std::conditional_t<
+    std::is_same_v<detail::filter_void_tuple_t<Ts...>, std::tuple<>>,
+    void,
+    detail::filter_void_tuple_t<Ts...>>;
 
 /** Execute multiple awaitables concurrently and collect their results.
 
@@ -446,12 +449,12 @@ auto extract_results(when_all_state<Ts...>& state)
 */
 template<IoAwaitable... As>
 [[nodiscard]] auto when_all(As... awaitables)
-    -> task<detail::when_all_result_t<detail::awaitable_result_t<As>...>>
+    -> task<non_void_tuple_t<awaitable_result_t<As>...>>
 {
-    using result_type = detail::when_all_result_t<detail::awaitable_result_t<As>...>;
+    using result_type = non_void_tuple_t<awaitable_result_t<As>...>;
 
     // State is stored in the coroutine frame, using the frame allocator
-    detail::when_all_state<detail::awaitable_result_t<As>...> state;
+    detail::when_all_state<awaitable_result_t<As>...> state;
 
     // Store awaitables in the frame
     std::tuple<As...> awaitable_tuple(std::move(awaitables)...);
@@ -472,10 +475,6 @@ template<IoAwaitable... As>
     else
         co_return detail::extract_results(state);
 }
-
-/// Compute the result type of `when_all` for the given task types.
-template<typename... Ts>
-using when_all_result_type = detail::when_all_result_t<Ts...>;
 
 } // namespace capy
 } // namespace boost

--- a/include/boost/capy/when_any.hpp
+++ b/include/boost/capy/when_any.hpp
@@ -115,8 +115,6 @@
 namespace boost {
 namespace capy {
 
-namespace detail {
-
 /** Convert void to monostate for variant storage.
 
     std::variant<void, ...> is ill-formed, so void tasks contribute
@@ -128,11 +126,7 @@ namespace detail {
 template<typename T>
 using void_to_monostate_t = std::conditional_t<std::is_void_v<T>, std::monostate, T>;
 
-// Result variant: one alternative per task, preserving positional
-// correspondence. Use .index() to identify which task won.
-// void results become monostate.
-template<typename T0, typename... Ts>
-using when_any_variant_t = std::variant<void_to_monostate_t<T0>, void_to_monostate_t<Ts>...>;
+namespace detail {
 
 /** Core shared state for when_any operations.
 
@@ -202,14 +196,13 @@ struct when_any_core
     @par Lifetime
     Allocated on the parent coroutine's frame, outlives all runners.
 
-    @tparam T0 First task's result type.
-    @tparam Ts Remaining tasks' result types.
+    @tparam Ts Task result types.
 */
-template<typename T0, typename... Ts>
+template<typename... Ts>
 struct when_any_state
 {
-    static constexpr std::size_t task_count = 1 + sizeof...(Ts);
-    using variant_type = when_any_variant_t<T0, Ts...>;
+    static constexpr std::size_t task_count = sizeof...(Ts);
+    using variant_type = std::variant<void_to_monostate_t<Ts>...>;
 
     when_any_core core_;
     std::optional<variant_type> result_;
@@ -562,11 +555,9 @@ private:
     }
     @endcode
 
-    @tparam A0 First awaitable type (must satisfy IoAwaitable).
-    @tparam As Remaining awaitable types (must satisfy IoAwaitable).
-    @param a0 The first awaitable to race.
-    @param as Additional awaitables to race concurrently.
-    @return A task yielding a variant with one alternative per awaitable.
+    @param as Awaitables to race concurrently (at least one required; each
+        must satisfy IoAwaitable).
+    @return A task yielding a std::variant with one alternative per awaitable.
         Use .index() to identify the winner. Void awaitables contribute
         std::monostate.
 
@@ -580,18 +571,15 @@ private:
 
     @see when_all, IoAwaitable
 */
-template<IoAwaitable A0, IoAwaitable... As>
-[[nodiscard]] auto when_any(A0 a0, As... as)
-    -> task<detail::when_any_variant_t<
-        detail::awaitable_result_t<A0>,
-        detail::awaitable_result_t<As>...>>
+template<IoAwaitable... As>
+    requires (sizeof...(As) > 0)
+[[nodiscard]] auto when_any(As... as)
+    -> task<std::variant<void_to_monostate_t<awaitable_result_t<As>>...>>
 {
-    detail::when_any_state<
-        detail::awaitable_result_t<A0>,
-        detail::awaitable_result_t<As>...> state;
-    std::tuple<A0, As...> awaitable_tuple(std::move(a0), std::move(as)...);
+    detail::when_any_state<awaitable_result_t<As>...> state;
+    std::tuple<As...> awaitable_tuple(std::move(as)...);
 
-    co_await detail::when_any_launcher<A0, As...>(&awaitable_tuple, &state);
+    co_await detail::when_any_launcher<As...>(&awaitable_tuple, &state);
 
     if(state.core_.winner_exception_)
         std::rethrow_exception(state.core_.winner_exception_);
@@ -852,12 +840,12 @@ public:
     @see when_any, IoAwaitableRange
 */
 template<IoAwaitableRange R>
-    requires (!std::is_void_v<detail::awaitable_result_t<std::ranges::range_value_t<R>>>)
+    requires (!std::is_void_v<awaitable_result_t<std::ranges::range_value_t<R>>>)
 [[nodiscard]] auto when_any(R&& awaitables)
-    -> task<std::pair<std::size_t, detail::awaitable_result_t<std::ranges::range_value_t<R>>>>
+    -> task<std::pair<std::size_t, awaitable_result_t<std::ranges::range_value_t<R>>>>
 {
     using Awaitable = std::ranges::range_value_t<R>;
-    using T = detail::awaitable_result_t<Awaitable>;
+    using T = awaitable_result_t<Awaitable>;
     using result_type = std::pair<std::size_t, T>;
     using OwnedRange = std::remove_cvref_t<R>;
 
@@ -961,7 +949,7 @@ template<IoAwaitableRange R>
     @see when_any, IoAwaitableRange
 */
 template<IoAwaitableRange R>
-    requires std::is_void_v<detail::awaitable_result_t<std::ranges::range_value_t<R>>>
+    requires std::is_void_v<awaitable_result_t<std::ranges::range_value_t<R>>>
 [[nodiscard]] auto when_any(R&& awaitables) -> task<std::size_t>
 {
     using OwnedRange = std::remove_cvref_t<R>;

--- a/test/unit/when_all.cpp
+++ b/test/unit/when_all.cpp
@@ -53,17 +53,17 @@ static_assert(std::is_same_v<
 
 // Verify result_type: void when all tasks are void, tuple otherwise
 static_assert(std::is_same_v<
-    when_all_result_type<int, std::string>,
+    non_void_tuple_t<int, std::string>,
     std::tuple<int, std::string>>);
 static_assert(std::is_same_v<
-    when_all_result_type<int, void, std::string>,
+    non_void_tuple_t<int, void, std::string>,
     std::tuple<int, std::string>>);
 static_assert(std::is_void_v<
-    when_all_result_type<void>>);
+    non_void_tuple_t<void>>);
 static_assert(std::is_void_v<
-    when_all_result_type<void, void>>);
+    non_void_tuple_t<void, void>>);
 static_assert(std::is_void_v<
-    when_all_result_type<void, void, void>>);
+    non_void_tuple_t<void, void, void>>);
 
 // Verify when_all returns task which satisfies awaitable protocols
 static_assert(IoAwaitable<task<std::tuple<int, int>>>);
@@ -306,17 +306,17 @@ struct when_all_test
     testResultType()
     {
         // Mixed types: void filtered out
-        using mixed_result = when_all_result_type<int, void, std::string>;
+        using mixed_result = non_void_tuple_t<int, void, std::string>;
         static_assert(std::is_same_v<
             mixed_result,
             std::tuple<int, std::string>>);
 
         // All void: returns void (not empty tuple)
-        using all_void_result = when_all_result_type<void, void, void>;
+        using all_void_result = non_void_tuple_t<void, void, void>;
         static_assert(std::is_void_v<all_void_result>);
 
         // Single void: returns void
-        using single_void_result = when_all_result_type<void>;
+        using single_void_result = non_void_tuple_t<void>;
         static_assert(std::is_void_v<single_void_result>);
     }
 


### PR DESCRIPTION
Addresses #160. Public function signatures referenced detail:: types that users cannot name without reaching into the detail namespace. Add awaitable_result_type, when_any_result_type, and when_all_result_type as public aliases, and update all when_any and when_all signatures to use them. Simplify when_any_variant_t and when_any_state to use a flat parameter pack instead of requiring the first type separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made awaitable_result_t publicly available for direct use.
  * Added non-void tuple utility to produce void or compact tuples for multi-awaitable results.

* **Refactor**
  * Simplified when_any to a single variadic overload returning a variant of awaitable results.
  * Streamlined when_all to return void when all awaitables are void and a concise tuple otherwise.

* **Documentation**
  * Updated docs to clarify new public types and when_all/when_any behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->