### PR TITLE
Explicitly delete move operations on async_event and async_mutex

### DIFF
--- a/include/boost/capy/ex/async_event.hpp
+++ b/include/boost/capy/ex/async_event.hpp
@@ -69,8 +69,14 @@ namespace capy {
 
     @par Thread Safety
 
+    Distinct objects: Safe.@n
+    Shared objects: Unsafe.
+
     The event operations are designed for single-threaded use on one
     executor. The stop callback may fire from any thread.
+
+    This type is non-copyable and non-movable because suspended
+    waiters hold intrusive pointers into the event's internal list.
 
     @par Example
     @code
@@ -232,11 +238,20 @@ public:
         }
     };
 
+    /// Construct an unset event.
     async_event() = default;
 
-    // Non-copyable, non-movable
+    /// Copy constructor (deleted).
     async_event(async_event const&) = delete;
+
+    /// Copy assignment (deleted).
     async_event& operator=(async_event const&) = delete;
+
+    /// Move constructor (deleted).
+    async_event(async_event&&) = delete;
+
+    /// Move assignment (deleted).
+    async_event& operator=(async_event&&) = delete;
 
     /** Returns an awaiter that waits until the event is set.
 

--- a/include/boost/capy/ex/async_mutex.hpp
+++ b/include/boost/capy/ex/async_mutex.hpp
@@ -113,8 +113,14 @@ namespace capy {
 
     @par Thread Safety
 
+    Distinct objects: Safe.@n
+    Shared objects: Unsafe.
+
     The mutex operations are designed for single-threaded use on one
     executor. The stop callback may fire from any thread.
+
+    This type is non-copyable and non-movable because suspended
+    waiters hold intrusive pointers into the mutex's internal list.
 
     @par Example
     @code
@@ -367,11 +373,20 @@ public:
         }
     };
 
+    /// Construct an unlocked mutex.
     async_mutex() = default;
 
-    // Non-copyable, non-movable
+    /// Copy constructor (deleted).
     async_mutex(async_mutex const&) = delete;
+
+    /// Copy assignment (deleted).
     async_mutex& operator=(async_mutex const&) = delete;
+
+    /// Move constructor (deleted).
+    async_mutex(async_mutex&&) = delete;
+
+    /// Move assignment (deleted).
+    async_mutex& operator=(async_mutex&&) = delete;
 
     /** Returns an awaiter that acquires the mutex.
 


### PR DESCRIPTION
Both types hold intrusive lists of suspended waiters whose nodes contain raw pointers back into the list. Moving would invalidate those pointers. The move operations were already implicitly deleted via the Rule of Five; this makes the intent explicit and adds javadoc for the deleted special members and Thread Safety sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `async_event` and `async_mutex` are now non-copyable and non-movable. Code attempting to copy or move these objects will no longer compile. Update usage patterns to pass by reference or use pointers instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->