### PR TITLE
Add thread_pool::join() and fix stop_callback TLS poisoning

### DIFF
--- a/doc/modules/ROOT/pages/4.coroutines/4d.io-awaitable.adoc
+++ b/doc/modules/ROOT/pages/4.coroutines/4d.io-awaitable.adoc
@@ -166,6 +166,54 @@ The key points:
 2. Use the executor to dispatch completion
 3. Respect the stop token for cancellation
 
+=== Stop Callbacks Must Post, Not Resume
+
+When implementing a stoppable awaitable, you may register a `std::stop_callback` to wake the coroutine when cancellation is requested. The callback fires synchronously on whatever thread calls `request_stop()`, which is typically *not* the executor's thread.
+
+[WARNING]
+====
+*Never resume a coroutine handle directly from a stop_callback.* Doing so executes the coroutine on the wrong thread, corrupting the thread-local frame allocator. This causes use-after-free on the next coroutine allocation—potentially in completely unrelated code.
+====
+
+Use `stop_resume_callback` and `io_env::post_resume` from `<boost/capy/ex/io_env.hpp>` to post the resume through the executor:
+
+[source,cpp]
+----
+#include <boost/capy/ex/io_env.hpp>
+
+struct stoppable_awaitable
+{
+    std::optional<stop_resume_callback> stop_cb_;
+
+    bool await_ready() { return false; }
+
+    std::coroutine_handle<> await_suspend(
+        std::coroutine_handle<> h, io_env const* env)
+    {
+        if (env->stop_token.stop_requested())
+            return h;  // Already cancelled, resume immediately
+
+        // Post through executor when stop is requested
+        stop_cb_.emplace(env->stop_token, env->post_resume(h));
+
+        start_async_operation();
+        return std::noop_coroutine();
+    }
+
+    void await_resume() { /* ... */ }
+};
+----
+
+The incorrect pattern—which compiles and appears to work but causes memory corruption—looks like this:
+
+[source,cpp]
+----
+// WRONG: resumes coroutine on the calling thread
+stop_cb_.emplace(env->stop_token, h);  // h is a raw coroutine_handle
+----
+
+See xref:4.coroutines/4e.cancellation.adoc#stoppable-awaitables[Implementing Stoppable Awaitables] for a complete example.
+
 == Reference
 
 [cols="1,3"]

--- a/doc/modules/ROOT/pages/4.coroutines/4e.cancellation.adoc
+++ b/doc/modules/ROOT/pages/4.coroutines/4e.cancellation.adoc
@@ -292,7 +292,70 @@ Capy's I/O operations (provided by Corosio) respect stop tokens at the OS level:
 
 When you request stop, pending I/O operations are cancelled at the OS level, providing immediate response rather than waiting for the operation to complete naturally.
 
-== Part 8: Patterns
+[[stoppable-awaitables]]
+== Part 8: Implementing Stoppable Awaitables
+
+The examples above show *polling* for cancellation with `token.stop_requested()`. For awaitables that suspend indefinitely—waiting for I/O, a lock, or an external event—you need a `std::stop_callback` to wake the coroutine when cancellation arrives.
+
+=== The Dangerous Pattern
+
+A `std::stop_callback` fires synchronously on whatever thread calls `request_stop()`. If the callback resumes the coroutine directly, the coroutine runs on the wrong thread:
+
+[source,cpp]
+----
+// WRONG — causes use-after-free
+std::optional<std::stop_callback<std::coroutine_handle<>>> stop_cb;
+
+std::coroutine_handle<> await_suspend(
+    std::coroutine_handle<> h, io_env const* env)
+{
+    stop_cb.emplace(env->stop_token, h);  // Resumes inline!
+    return std::noop_coroutine();
+}
+----
+
+When an external thread calls `request_stop()`, `h.resume()` executes the coroutine on that thread. The coroutine machinery sets the thread-local frame allocator to the executor's allocator—poisoning the calling thread's TLS. When the executor's pool destructs, the TLS pointer becomes dangling. The next coroutine allocation on that thread dereferences freed memory.
+
+This bug is deterministic, not a race condition. It manifests as a heap-use-after-free in *unrelated* code—wherever the next coroutine frame happens to be allocated on the poisoned thread.
+
+=== The Correct Pattern: resume_via_post
+
+Use `stop_resume_callback` and `io_env::post_resume` to post the resume through the executor, ensuring the coroutine runs on the correct thread:
+
+[source,cpp]
+----
+#include <boost/capy/ex/io_env.hpp>
+
+struct my_stoppable_awaitable
+{
+    std::optional<stop_resume_callback> stop_cb_;
+    // ... other members for the async operation ...
+
+    bool await_ready() { return false; }
+
+    std::coroutine_handle<> await_suspend(
+        std::coroutine_handle<> h, io_env const* env)
+    {
+        if (env->stop_token.stop_requested())
+            return h;  // Already cancelled
+
+        stop_cb_.emplace(env->stop_token, env->post_resume(h));
+
+        start_async_operation(h, env);
+        return std::noop_coroutine();
+    }
+
+    void await_resume() { /* check result or throw */ }
+};
+----
+
+`stop_resume_callback` is a type alias for `std::stop_callback<resume_via_post>`. `post_resume(h)` creates a `resume_via_post` callable that posts the coroutine handle through this environment's executor.
+
+When `request_stop()` fires the callback, the coroutine handle is posted to the executor's queue instead of resumed inline. The executor's worker thread picks it up and resumes it in the correct execution context.
+
+NOTE: Capy's built-in I/O awaitables (via Corosio) already use the post-back pattern internally. This guidance applies when writing your own custom awaitables.
+
+== Part 9: Patterns
 
 === Timeout Pattern
 

--- a/doc/unlisted/execution-thread-pool.adoc
+++ b/doc/unlisted/execution-thread-pool.adoc
@@ -92,28 +92,68 @@ run_async(pool.get_executor())(compute(), [](int result) {
 
 == Lifetime and Shutdown
 
-The pool destructor waits for all work to complete:
+=== Waiting for Work: join()
+
+Call `join()` to block until all outstanding work completes:
+
+[source,cpp]
+----
+thread_pool pool(4);
+
+for (auto& item : batch)
+    run_async(pool.get_executor())(process(item));
+
+pool.join();  // Blocks until all tasks finish
+// Pool is now stopped; worker threads are joined
+----
+
+`join()` releases the pool's internal work guard and blocks until the
+outstanding work count (tracked by `on_work_started()` / `on_work_finished()`)
+reaches zero. After all work completes, the worker threads are joined.
+
+The pool cannot be reused after `join()`. Calling `join()` more than once
+is safe (subsequent calls are no-ops).
+
+=== Immediate Stop: stop()
+
+Call `stop()` to abandon remaining work:
+
+[source,cpp]
+----
+pool.stop();   // Workers exit after current item; queued work is abandoned
+pool.join();   // Wait for threads to finish
+----
+
+If `join()` is blocking on another thread, calling `stop()` causes it to
+stop waiting for outstanding work. The `join()` call still waits for worker
+threads to finish their current item and exit before returning.
+
+=== Destructor Behavior
+
+The destructor calls `stop()` then `join()`:
 
 [source,cpp]
 ----
 {
     thread_pool pool(4);
     run_async(pool.get_executor())(long_running_task());
-    // Destructor blocks until long_running_task completes
+    // Destructor: stop() -> join() -> shutdown services -> destroy services
+    // Queued work that hasn't started is abandoned
 }
 ----
 
-This ensures orderly shutdown without orphaned coroutines.
+To wait for all work to complete before shutdown, call `join()` explicitly
+before the pool goes out of scope.
 
 === Destruction Order
 
 When a pool is destroyed:
 
-1. Threads are signaled to stop accepting new work
-2. Pending work continues to completion
+1. Workers are signaled to stop (pending work is abandoned)
+2. Worker threads are joined
 3. Services are shut down (in reverse order of creation)
 4. Services are destroyed
-5. Threads are joined
+5. Remaining queued work items are destroyed
 
 == Executor Operations
 
@@ -161,7 +201,9 @@ Since callers are never "inside" the thread pool's execution context,
 
 == Work Tracking
 
-Work tracking keeps the pool alive while operations are outstanding:
+Work tracking keeps the pool alive while operations are outstanding.
+When `join()` has been called, the pool waits until the outstanding work
+count reaches zero before stopping the worker threads.
 
 [source,cpp]
 ----
@@ -179,13 +221,14 @@ The `work_guard` RAII wrapper simplifies this:
 {
     work_guard guard(ex);
     // Work count incremented
-    
+
     // ... do work ...
-    
+
 }  // Work count decremented
 ----
 
-`run_async` handles work tracking automatically.
+`run_async` handles work tracking automatically — each launched task
+holds a `work_guard` for its lifetime.
 
 == Services
 
@@ -322,6 +365,12 @@ void process_batch()
 
 | `get_executor()`
 | Get an executor for the pool
+
+| `join()`
+| Wait for all outstanding work to complete
+
+| `stop()`
+| Immediately stop the pool, abandoning queued work
 
 | Services
 | Polymorphic components owned by the pool

--- a/include/boost/capy/ex/io_env.hpp
+++ b/include/boost/capy/ex/io_env.hpp
@@ -13,11 +13,38 @@
 #include <boost/capy/detail/config.hpp>
 #include <boost/capy/ex/executor_ref.hpp>
 
+#include <coroutine>
 #include <memory_resource>
 #include <stop_token>
 
 namespace boost {
 namespace capy {
+
+/** Callable that posts a coroutine handle to an executor.
+
+    Use this as the callback type for `std::stop_callback` instead
+    of a raw `std::coroutine_handle<>`. Raw handles resume the
+    coroutine inline on whatever thread calls `request_stop()`,
+    which bypasses the executor and corrupts the thread-local
+    frame allocator.
+
+    Prefer @ref io_env::post_resume and the @ref stop_resume_callback
+    alias to construct these—see examples there.
+
+    @see io_env::post_resume, stop_resume_callback
+*/
+struct resume_via_post
+{
+    executor_ref ex;
+    std::coroutine_handle<> h;
+
+    // post() must not throw; stop_callback requires a
+    // non-throwing invocable.
+    void operator()() const noexcept
+    {
+        ex.post(h);
+    }
+};
 
 /** Execution environment for IoAwaitables.
 
@@ -33,11 +60,27 @@ namespace capy {
     chain. Awaitables receive `io_env const*` in `await_suspend`
     and should store it directly, never copy the pointed-to object.
 
+    @par Stop Callback Contract
+
+    Awaitables that register a `std::stop_callback` **must not**
+    resume the coroutine handle directly. The callback fires
+    synchronously on the thread that calls `request_stop()`, which
+    may not be an executor-managed thread. Resuming inline poisons
+    that thread's TLS frame allocator with the pool's allocator,
+    causing use-after-free on the next coroutine allocation.
+
+    Use @ref io_env::post_resume and @ref stop_resume_callback:
+    @code
+    std::optional<stop_resume_callback> stop_cb_;
+    // In await_suspend:
+    stop_cb_.emplace(env->stop_token, env->post_resume(h));
+    @endcode
+
     @par Thread Safety
     The referenced executor and allocator must remain valid
     for the lifetime of any coroutine using this environment.
 
-    @see IoAwaitable, IoRunnable
+    @see IoAwaitable, IoRunnable, resume_via_post
 */
 struct io_env
 {
@@ -52,7 +95,42 @@ struct io_env
         When null, the default allocator is used.
     */
     std::pmr::memory_resource* frame_allocator = nullptr;
+
+    /** Create a resume_via_post callable for this environment.
+
+        Convenience method for registering @ref stop_resume_callback
+        instances. Equivalent to `resume_via_post{executor, h}`.
+
+        @par Example
+        @code
+        stop_cb_.emplace(env->stop_token, env->post_resume(h));
+        @endcode
+
+        @param h The coroutine handle to post on cancellation.
+
+        @return A @ref resume_via_post callable that holds a
+        non-owning @ref executor_ref and the coroutine handle.
+        The callable must not outlive the executor it references.
+
+        @see resume_via_post, stop_resume_callback
+    */
+    resume_via_post
+    post_resume(std::coroutine_handle<> h) const noexcept
+    {
+        return resume_via_post{executor, h};
+    }
 };
+
+/** Type alias for a stop callback that posts through the executor.
+
+    Use this to declare the stop callback member in your awaitable:
+    @code
+    std::optional<stop_resume_callback> stop_cb_;
+    @endcode
+
+    @see resume_via_post, io_env::post_resume
+*/
+using stop_resume_callback = std::stop_callback<resume_via_post>;
 
 } // capy
 } // boost

--- a/include/boost/capy/ex/thread_pool.hpp
+++ b/include/boost/capy/ex/thread_pool.hpp
@@ -78,11 +78,47 @@ public:
     thread_pool(thread_pool const&) = delete;
     thread_pool& operator=(thread_pool const&) = delete;
 
+    /** Wait for all outstanding work to complete.
+
+        Releases the internal work guard, then blocks the calling
+        thread until all outstanding work tracked by
+        @ref executor_type::on_work_started and
+        @ref executor_type::on_work_finished completes. After all
+        work finishes, joins the worker threads.
+
+        If @ref stop is called while `join()` is blocking, the
+        pool stops without waiting for remaining work to
+        complete. Worker threads finish their current item and
+        exit; `join()` still waits for all threads to be joined
+        before returning.
+
+        This function is idempotent. The first call performs the
+        join; subsequent calls return immediately.
+
+        @par Preconditions
+        Must not be called from a thread in this pool (undefined
+        behavior).
+
+        @par Postconditions
+        All worker threads have been joined. The pool cannot be
+        reused.
+
+        @par Thread Safety
+        May be called from any thread not in this pool.
+    */
+    void
+    join() noexcept;
+
     /** Request all worker threads to stop.
 
-        Signals all threads to exit. Threads will finish their
-        current work item before exiting. Does not wait for
-        threads to exit.
+        Signals all threads to exit after finishing their current
+        work item. Queued work that has not started is abandoned.
+        Does not wait for threads to exit.
+
+        If @ref join is blocking on another thread, calling
+        `stop()` causes it to stop waiting for outstanding
+        work. The `join()` call still waits for worker threads
+        to finish their current item and exit before returning.
     */
     void
     stop() noexcept;
@@ -129,17 +165,30 @@ public:
         return *pool_;
     }
 
-    /// Notify that work has started (no-op for thread pools).
-    void
-    on_work_started() const noexcept
-    {
-    }
+    /** Notify that work has started.
 
-    /// Notify that work has finished (no-op for thread pools).
+        Increments the outstanding work count. Must be paired
+        with a subsequent call to @ref on_work_finished.
+
+        @see on_work_finished, work_guard
+    */
+    BOOST_CAPY_DECL
     void
-    on_work_finished() const noexcept
-    {
-    }
+    on_work_started() const noexcept;
+
+    /** Notify that work has finished.
+
+        Decrements the outstanding work count. When the count
+        reaches zero after @ref thread_pool::join has been called,
+        the pool's worker threads are signaled to stop.
+
+        @pre A preceding call to @ref on_work_started was made.
+
+        @see on_work_started, work_guard
+    */
+    BOOST_CAPY_DECL
+    void
+    on_work_finished() const noexcept;
 
     /** Dispatch a coroutine for execution.
 

--- a/src/ex/thread_pool.cpp
+++ b/src/ex/thread_pool.cpp
@@ -11,6 +11,8 @@
 #include <boost/capy/ex/thread_pool.hpp>
 #include <boost/capy/detail/intrusive.hpp>
 #include <boost/capy/test/thread_name.hpp>
+#include <algorithm>
+#include <atomic>
 #include <condition_variable>
 #include <cstdio>
 #include <mutex>
@@ -29,9 +31,14 @@
     thread is named with a configurable prefix plus index for debugger
     visibility.
 
-    Shutdown sequence: stop() sets the stop flag and notifies all threads,
-    then the destructor joins threads and destroys any remaining queued
-    work without executing it.
+    Work tracking: on_work_started/on_work_finished maintain an atomic
+    outstanding_work_ counter. join() blocks until this counter reaches
+    zero, then signals workers to stop and joins threads.
+
+    Two shutdown paths:
+    - join(): waits for outstanding work to drain, then stops workers.
+    - stop(): immediately signals workers to exit; queued work is abandoned.
+    - Destructor: stop() then join() (abandon + wait for threads).
 */
 
 namespace boost {
@@ -59,7 +66,10 @@ class thread_pool::impl
 
         void destroy()
         {
+            auto h = h_;
             delete this;
+            if(h && h != std::noop_coroutine())
+                h.destroy();
         }
     };
 
@@ -67,7 +77,9 @@ class thread_pool::impl
     std::condition_variable cv_;
     detail::intrusive_queue<work> q_;
     std::vector<std::thread> threads_;
+    std::atomic<std::size_t> outstanding_work_{0};
     bool stop_{false};
+    bool joined_{false};
     std::size_t num_threads_;
     char thread_name_prefix_[13]{};  // 12 chars max + null terminator
     std::once_flag start_flag_;
@@ -75,11 +87,6 @@ class thread_pool::impl
 public:
     ~impl()
     {
-        stop();
-        for(auto& t : threads_)
-            if(t.joinable())
-                t.join();
-
         while(auto* w = q_.pop())
             w->destroy();
     }
@@ -88,9 +95,8 @@ public:
         : num_threads_(num_threads)
     {
         if(num_threads_ == 0)
-            num_threads_ = std::thread::hardware_concurrency();
-        if(num_threads_ == 0)
-            num_threads_ = 1;
+            num_threads_ = std::max(
+                std::thread::hardware_concurrency(), 1u);
 
         // Truncate prefix to 12 chars, leaving room for up to 3-digit index.
         auto n = thread_name_prefix.copy(thread_name_prefix_, 12);
@@ -110,9 +116,47 @@ public:
     }
 
     void
+    on_work_started() noexcept
+    {
+        outstanding_work_.fetch_add(1, std::memory_order_acq_rel);
+    }
+
+    void
+    on_work_finished() noexcept
+    {
+        if(outstanding_work_.fetch_sub(
+            1, std::memory_order_acq_rel) == 1)
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if(joined_ && !stop_)
+                stop_ = true;
+            cv_.notify_all();
+        }
+    }
+
+    void
     join() noexcept
     {
-        stop();
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            if(joined_)
+                return;
+            joined_ = true;
+
+            if(outstanding_work_.load(
+                std::memory_order_acquire) == 0)
+            {
+                stop_ = true;
+                cv_.notify_all();
+            }
+            else
+            {
+                cv_.wait(lock, [this]{
+                    return stop_;
+                });
+            }
+        }
+
         for(auto& t : threads_)
             if(t.joinable())
                 t.join();
@@ -156,7 +200,7 @@ private:
                     return !q_.empty() ||
                         stop_;
                 });
-                if(stop_ && q_.empty())
+                if(stop_)
                     return;
                 w = q_.pop();
             }
@@ -171,6 +215,7 @@ private:
 thread_pool::
 ~thread_pool()
 {
+    impl_->stop();
     impl_->join();
     shutdown();
     destroy();
@@ -182,6 +227,13 @@ thread_pool(std::size_t num_threads, std::string_view thread_name_prefix)
     : impl_(new impl(num_threads, thread_name_prefix))
 {
     this->set_frame_allocator(std::allocator<void>{});
+}
+
+void
+thread_pool::
+join() noexcept
+{
+    impl_->join();
 }
 
 void
@@ -199,6 +251,20 @@ get_executor() const noexcept
 {
     return executor_type(
         const_cast<thread_pool&>(*this));
+}
+
+void
+thread_pool::executor_type::
+on_work_started() const noexcept
+{
+    pool_->impl_->on_work_started();
+}
+
+void
+thread_pool::executor_type::
+on_work_finished() const noexcept
+{
+    pool_->impl_->on_work_finished();
 }
 
 void

--- a/test/unit/ex/thread_pool.cpp
+++ b/test/unit/ex/thread_pool.cpp
@@ -13,10 +13,13 @@
 
 #include <boost/capy/concept/execution_context.hpp>
 #include <boost/capy/concept/executor.hpp>
+#include <boost/capy/ex/run_async.hpp>
+#include <boost/capy/ex/work_guard.hpp>
 
 #include "test_helpers.hpp"
 
 #include <atomic>
+#include <thread>
 #include <vector>
 
 namespace boost {
@@ -318,6 +321,238 @@ struct thread_pool_test
     }
 
     void
+    testJoinDrainsWork()
+    {
+        thread_pool pool(2);
+        auto ex = pool.get_executor();
+        std::atomic<int> count{0};
+
+        constexpr int N = 50;
+        for(int i = 0; i < N; ++i)
+        {
+            run_async(ex,
+                [&]{ count.fetch_add(1); }
+            )(void_task());
+        }
+
+        pool.join();
+        BOOST_TEST_EQ(count.load(), N);
+    }
+
+    void
+    testJoinNoWork()
+    {
+        // join() on a pool with no posted work returns promptly
+        thread_pool pool(2);
+        pool.join();
+    }
+
+    void
+    testJoinNoThreadsStarted()
+    {
+        // join() without ever posting (lazy start never triggered)
+        thread_pool pool(2);
+        // Don't call get_executor() or post anything
+        pool.join();
+    }
+
+    void
+    testJoinIdempotent()
+    {
+        thread_pool pool(1);
+        pool.join();
+        pool.join();  // second call should be a no-op
+    }
+
+    void
+    testStopThenJoin()
+    {
+        thread_pool pool(2);
+        pool.stop();
+        pool.join();  // should return immediately
+    }
+
+    void
+    testStopInterruptsJoin()
+    {
+        thread_pool pool(2);
+        auto ex = pool.get_executor();
+
+        // Hold work guard to keep join() blocking
+        auto guard = make_work_guard(ex);
+
+        std::atomic<bool> join_returned{false};
+        std::thread joiner([&]{
+            pool.join();
+            join_returned.store(true);
+        });
+
+        // Give join() time to block
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(50));
+        BOOST_TEST(!join_returned.load());
+
+        // stop() should interrupt the blocking join()
+        pool.stop();
+
+        joiner.join();
+        BOOST_TEST(join_returned.load());
+    }
+
+    void
+    testDestructorAbandonsPending()
+    {
+        // Verify the destructor doesn't hang when work items
+        // are genuinely queued but unprocessed. We block the
+        // single worker thread with a spinning callback, then
+        // post items that pile up in the queue. After releasing
+        // the worker, the destructor's stop() causes it to exit
+        // without draining the queue.
+        {
+            std::atomic<bool> busy{false};
+            std::atomic<bool> release{false};
+
+            thread_pool pool(1);
+            auto ex = pool.get_executor();
+
+            // Block the worker via run_async callback
+            run_async(ex, [&]{
+                busy.store(true);
+                while(!release.load())
+                    std::this_thread::yield();
+            })(void_task());
+
+            // Wait until worker is executing our callback
+            while(!busy.load())
+                std::this_thread::yield();
+
+            // Queue items that can't be processed yet
+            for(int i = 0; i < 50; ++i)
+                ex.post(std::noop_coroutine());
+
+            // Release worker, then pool destructs immediately.
+            // stop() races with the worker — pending items
+            // are abandoned and destroyed by ~impl().
+            release.store(true);
+        }
+    }
+
+    void
+    testStopCallbackPostBack()
+    {
+        // Cancel a suspended task via stop_token, then let the
+        // pool destruct. stop_only_awaitable uses resume_via_post
+        // so the coroutine resumes on a pool thread, not on the
+        // thread that calls request_stop().
+        {
+            thread_pool pool(1);
+            auto ex = pool.get_executor();
+            std::stop_source ss;
+
+            auto make_task = []() -> task<void> {
+                co_await stop_only_awaitable{};
+            };
+
+            run_async(ex, ss.get_token())(make_task());
+
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(50));
+
+            ss.request_stop();
+        }
+    }
+
+    void
+    testStopCallbackWithJoin()
+    {
+        // Cancel a suspended task, then join() the pool.
+        // Verifies work counting and join() interact correctly
+        // with stop_callback cancellation.
+        {
+            thread_pool pool(1);
+            auto ex = pool.get_executor();
+            std::stop_source ss;
+
+            auto make_task = []() -> task<void> {
+                co_await stop_only_awaitable{};
+            };
+
+            run_async(ex, ss.get_token())(make_task());
+
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(50));
+
+            ss.request_stop();
+            pool.join();
+        }
+    }
+
+    void
+    testStopCallbackRepeated()
+    {
+        // Stress test: repeated cancel + pool destruction cycles.
+        for(int iter = 0; iter < 50; ++iter)
+        {
+            thread_pool pool(2);
+            auto ex = pool.get_executor();
+            std::stop_source ss;
+
+            auto make_task = []() -> task<void> {
+                co_await stop_only_awaitable{};
+            };
+
+            for(int i = 0; i < 5; ++i)
+                run_async(ex, ss.get_token())(make_task());
+
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(10));
+
+            ss.request_stop();
+        }
+    }
+
+    void
+    testWorkGuardKeepsPoolAlive()
+    {
+        thread_pool pool(1);
+        auto ex = pool.get_executor();
+        std::atomic<bool> join_returned{false};
+
+        auto guard = make_work_guard(ex);
+
+        std::thread joiner([&]{
+            pool.join();
+            join_returned.store(true);
+        });
+
+        // Give join() time to block
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(50));
+        BOOST_TEST(!join_returned.load());
+
+        // Releasing the guard should allow join() to complete
+        guard.reset();
+
+        joiner.join();
+        BOOST_TEST(join_returned.load());
+    }
+
+    void
+    testJoinWithRunAsync()
+    {
+        thread_pool pool(2);
+        auto ex = pool.get_executor();
+        std::atomic<int> result{0};
+
+        run_async(ex,
+            [&](int v){ result.store(v); }
+        )(returns_int(42));
+
+        pool.join();
+        BOOST_TEST_EQ(result.load(), 42);
+    }
+
+    void
     run()
     {
         testConstruct();
@@ -332,6 +567,18 @@ struct thread_pool_test
         testConcurrentPost();
         testDefaultExecutor();
         testThreadNaming();
+        testJoinDrainsWork();
+        testJoinNoWork();
+        testJoinNoThreadsStarted();
+        testJoinIdempotent();
+        testStopThenJoin();
+        testStopInterruptsJoin();
+        testDestructorAbandonsPending();
+        testStopCallbackPostBack();
+        testStopCallbackWithJoin();
+        testStopCallbackRepeated();
+        testWorkGuardKeepsPoolAlive();
+        testJoinWithRunAsync();
     }
 };
 

--- a/test/unit/test_helpers.hpp
+++ b/test/unit/test_helpers.hpp
@@ -248,13 +248,15 @@ struct self_destroy_awaitable
 };
 
 
-// test awaitable that must be stopped in order to resume
+// test awaitable that must be stopped in order to resume.
+// Uses resume_via_post to ensure the coroutine resumes on the
+// executor's thread, not on whatever thread calls request_stop().
 struct stop_only_awaitable
 {
     stop_only_awaitable() noexcept = default;
     stop_only_awaitable(stop_only_awaitable && ) noexcept {}
 
-    std::optional<std::stop_callback<std::coroutine_handle<>>> stop_cb;
+    std::optional<stop_resume_callback> stop_cb;
 
     bool await_ready() {return false;}
 
@@ -262,7 +264,7 @@ struct stop_only_awaitable
     {
         if (env->stop_token.stop_requested())
             return h;
-        stop_cb.emplace(env->stop_token, h);
+        stop_cb.emplace(env->stop_token, env->post_resume(h));
         return std::noop_coroutine();
     }
     void await_resume() {}


### PR DESCRIPTION
Closes #141

Add join() to thread_pool with real work counting via on_work_started/on_work_finished, matching asio::thread_pool semantics. join() blocks until outstanding work drains, then joins worker threads. stop() interrupts a blocking join().

Fix a deterministic use-after-free where std::stop_callback resumed coroutines inline on the wrong thread, poisoning that thread's TLS frame allocator with a pool-owned resource. Add resume_via_post callable for stop_callbacks to post resumption through the executor. Fix stop_only_awaitable test helper to use the post-back pattern. As defense-in-depth, work::destroy() now destroys abandoned coroutine handles instead of leaking them.

Document the stop callback contract on io_env: awaitables must not resume coroutine handles directly in a stop_callback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread pool can now wait for all outstanding work to complete before shutting down.
  * Suspended tasks can be resumed by posting their continuation to the executor instead of resuming inline.

* **Improvements**
  * Executors now track outstanding work to support reliable drain-and-wait behavior.
  * Clarified stop vs. join semantics: queued-but-not-started work is abandoned; join waits for in-flight work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->