### PR TITLE
Add timeout combinator, delay awaitable, and timer_service (#63)

### DIFF
--- a/include/boost/capy.hpp
+++ b/include/boost/capy.hpp
@@ -25,8 +25,10 @@
 #include <boost/capy/task.hpp>
 
 // Algorithms
+#include <boost/capy/delay.hpp>
 #include <boost/capy/read.hpp>
 #include <boost/capy/read_until.hpp>
+#include <boost/capy/timeout.hpp>
 #include <boost/capy/when_all.hpp>
 #include <boost/capy/when_any.hpp>
 #include <boost/capy/write.hpp>

--- a/include/boost/capy/cond.hpp
+++ b/include/boost/capy/cond.hpp
@@ -69,7 +69,14 @@ enum class cond
         An `error_code` compares equal to `not_found` when a
         lookup operation failed to find the requested item.
     */
-    not_found = 4
+    not_found = 4,
+
+    /** Operation timed out condition.
+
+        An `error_code` compares equal to `timeout` when an
+        operation exceeded its allowed duration.
+    */
+    timeout = 5
 };
 
 } // capy

--- a/include/boost/capy/delay.hpp
+++ b/include/boost/capy/delay.hpp
@@ -1,0 +1,222 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_DELAY_HPP
+#define BOOST_CAPY_DELAY_HPP
+
+#include <boost/capy/detail/config.hpp>
+#include <boost/capy/ex/executor_ref.hpp>
+#include <boost/capy/ex/io_env.hpp>
+#include <boost/capy/ex/detail/timer_service.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <coroutine>
+#include <new>
+#include <stop_token>
+#include <utility>
+
+namespace boost {
+namespace capy {
+
+/** IoAwaitable returned by @ref delay.
+
+    Suspends the calling coroutine until the deadline elapses
+    or the environment's stop token is activated, whichever
+    comes first. Resumption is always posted through the
+    executor, never inline on the timer thread.
+
+    Not intended to be named directly; use the @ref delay
+    factory function instead.
+
+    @par Cancellation
+
+    If `stop_requested()` is true before suspension, the
+    coroutine resumes immediately without scheduling a timer.
+    If stop is requested while suspended, the stop callback
+    claims the resume and posts it through the executor; the
+    pending timer is cancelled on the next `await_resume` or
+    destructor call.
+
+    @par Thread Safety
+
+    A single `delay_awaitable` must not be awaited concurrently.
+    Multiple independent `delay()` calls on the same
+    execution_context are safe and share one timer thread.
+
+    @see delay, timeout
+*/
+class delay_awaitable
+{
+    std::chrono::nanoseconds dur_;
+
+    detail::timer_service* ts_ = nullptr;
+    detail::timer_service::timer_id tid_ = 0;
+
+    // Declared before stop_cb_buf_: the callback
+    // accesses these members, so they must still be
+    // alive if the stop_cb_ destructor blocks.
+    std::atomic<bool> claimed_{false};
+    bool canceled_ = false;
+    bool stop_cb_active_ = false;
+
+    struct cancel_fn
+    {
+        delay_awaitable* self_;
+        executor_ref ex_;
+        std::coroutine_handle<> h_;
+
+        void operator()() const noexcept
+        {
+            if(!self_->claimed_.exchange(
+                true, std::memory_order_acq_rel))
+            {
+                self_->canceled_ = true;
+                ex_.post(h_);
+            }
+        }
+    };
+
+    using stop_cb_t = std::stop_callback<cancel_fn>;
+
+    // Aligned storage for the stop callback.
+    // Declared last: its destructor may block while
+    // the callback accesses the members above.
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable: 4324)
+#endif
+    alignas(stop_cb_t)
+        unsigned char stop_cb_buf_[sizeof(stop_cb_t)];
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif
+
+    stop_cb_t& stop_cb_() noexcept
+    {
+        return *reinterpret_cast<stop_cb_t*>(stop_cb_buf_);
+    }
+
+public:
+    explicit delay_awaitable(std::chrono::nanoseconds dur) noexcept
+        : dur_(dur)
+    {
+    }
+
+    /// @pre The stop callback must not be active
+    ///      (i.e. the object has not yet been awaited).
+    delay_awaitable(delay_awaitable&& o) noexcept
+        : dur_(o.dur_)
+        , ts_(o.ts_)
+        , tid_(o.tid_)
+        , claimed_(o.claimed_.load(std::memory_order_relaxed))
+        , canceled_(o.canceled_)
+        , stop_cb_active_(std::exchange(o.stop_cb_active_, false))
+    {
+    }
+
+    ~delay_awaitable()
+    {
+        if(stop_cb_active_)
+            stop_cb_().~stop_cb_t();
+        if(ts_)
+            ts_->cancel(tid_);
+    }
+
+    delay_awaitable(delay_awaitable const&) = delete;
+    delay_awaitable& operator=(delay_awaitable const&) = delete;
+    delay_awaitable& operator=(delay_awaitable&&) = delete;
+
+    bool await_ready() const noexcept
+    {
+        return dur_.count() <= 0;
+    }
+
+    std::coroutine_handle<>
+    await_suspend(
+        std::coroutine_handle<> h,
+        io_env const* env) noexcept
+    {
+        // Already stopped: resume immediately
+        if(env->stop_token.stop_requested())
+        {
+            canceled_ = true;
+            return h;
+        }
+
+        ts_ = &env->executor.context().use_service<detail::timer_service>();
+
+        // Schedule timer (won't fire inline since deadline is in the future)
+        tid_ = ts_->schedule_after(dur_,
+            [this, h, ex = env->executor]()
+            {
+                if(!claimed_.exchange(
+                    true, std::memory_order_acq_rel))
+                {
+                    ex.post(h);
+                }
+            });
+
+        // Register stop callback (may fire inline)
+        ::new(stop_cb_buf_) stop_cb_t(
+            env->stop_token,
+            cancel_fn{this, env->executor, h});
+        stop_cb_active_ = true;
+
+        return std::noop_coroutine();
+    }
+
+    void await_resume() noexcept
+    {
+        if(stop_cb_active_)
+        {
+            stop_cb_().~stop_cb_t();
+            stop_cb_active_ = false;
+        }
+        if(ts_)
+            ts_->cancel(tid_);
+    }
+};
+
+/** Suspend the current coroutine for a duration.
+
+    Returns an IoAwaitable that completes at or after the
+    specified duration, or earlier if the environment's stop
+    token is activated. Completion is always normal (void
+    return); no exception is thrown on cancellation.
+
+    Zero or negative durations complete synchronously without
+    scheduling a timer.
+
+    @par Example
+    @code
+    co_await delay(std::chrono::milliseconds(100));
+    @endcode
+
+    @param dur The duration to wait.
+
+    @return A @ref delay_awaitable whose `await_resume`
+        returns `void`.
+
+    @throws Nothing.
+
+    @see timeout, delay_awaitable
+*/
+template<typename Rep, typename Period>
+delay_awaitable
+delay(std::chrono::duration<Rep, Period> dur) noexcept
+{
+    return delay_awaitable{
+        std::chrono::duration_cast<std::chrono::nanoseconds>(dur)};
+}
+
+} // capy
+} // boost
+
+#endif

--- a/include/boost/capy/error.hpp
+++ b/include/boost/capy/error.hpp
@@ -43,7 +43,10 @@ enum class error
     stream_truncated,
 
     /// Requested item was not found. Compare with `cond::not_found`.
-    not_found
+    not_found,
+
+    /// Operation timed out. Compare with `cond::timeout`.
+    timeout
 };
 
 } // capy

--- a/include/boost/capy/ex/detail/timer_service.hpp
+++ b/include/boost/capy/ex/detail/timer_service.hpp
@@ -1,0 +1,126 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_EX_TIMER_SERVICE_HPP
+#define BOOST_CAPY_EX_TIMER_SERVICE_HPP
+
+#include <boost/capy/detail/config.hpp>
+#include <boost/capy/ex/execution_context.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+namespace boost {
+namespace capy {
+namespace detail {
+
+/* Shared timer thread for an execution_context.
+
+   One background std::jthread per execution_context. All timeouts
+   scheduled through this context share the same thread, which sleeps
+   on a condition variable until the next deadline.
+
+   The timer thread never touches coroutine frames or executors
+   directly — callbacks are responsible for posting work through
+   the appropriate executor.
+*/
+
+class BOOST_CAPY_DECL
+    timer_service
+    : public execution_context::service
+{
+public:
+    using timer_id = std::uint64_t;
+
+    explicit timer_service(execution_context& ctx);
+
+    /** Schedule a callback to fire after a duration.
+
+        The callback is invoked on the timer service's background
+        thread. It must not block for extended periods.
+
+        @return An id that can be passed to cancel().
+    */
+    template<typename Rep, typename Period>
+    timer_id schedule_after(
+        std::chrono::duration<Rep, Period> dur,
+        std::function<void()> cb)
+    {
+        auto deadline = std::chrono::steady_clock::now() + dur;
+        return schedule_at(deadline, std::move(cb));
+    }
+
+    /** Cancel a pending timer.
+
+        After this function returns, the callback is guaranteed
+        not to be running and will never be invoked. If the
+        callback is currently executing on the timer thread,
+        this call blocks until it completes.
+
+        Safe to call with any id, including ids that have
+        already fired, been cancelled, or were never issued.
+    */
+    void cancel(timer_id id);
+
+protected:
+    void shutdown() override;
+
+private:
+    struct entry
+    {
+        std::chrono::steady_clock::time_point deadline;
+        timer_id id;
+        std::function<void()> callback;
+
+        bool operator>(entry const& o) const noexcept
+        {
+            return deadline > o.deadline;
+        }
+    };
+
+    timer_id schedule_at(
+        std::chrono::steady_clock::time_point deadline,
+        std::function<void()> cb);
+
+    void run();
+
+// warning C4251: std types need to have dll-interface
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable: 4251)
+#endif
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::condition_variable cancel_cv_;
+    std::priority_queue<
+        entry,
+        std::vector<entry>,
+        std::greater<>> queue_;
+    std::unordered_set<timer_id> active_ids_;
+    timer_id next_id_ = 0;
+    timer_id executing_id_ = 0;
+    bool stopped_ = false;
+    std::jthread thread_;
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif
+};
+
+} // detail
+} // capy
+} // boost
+
+#endif

--- a/include/boost/capy/timeout.hpp
+++ b/include/boost/capy/timeout.hpp
@@ -1,0 +1,132 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_TIMEOUT_HPP
+#define BOOST_CAPY_TIMEOUT_HPP
+
+#include <boost/capy/detail/config.hpp>
+#include <boost/capy/concept/io_awaitable.hpp>
+#include <boost/capy/delay.hpp>
+#include <boost/capy/error.hpp>
+#include <boost/capy/io_result.hpp>
+#include <boost/capy/task.hpp>
+#include <boost/capy/when_any.hpp>
+
+#include <chrono>
+#include <system_error>
+#include <type_traits>
+
+namespace boost {
+namespace capy {
+
+namespace detail {
+
+template<typename T>
+struct is_io_result : std::false_type {};
+
+template<typename... Args>
+struct is_io_result<io_result<Args...>> : std::true_type {};
+
+template<typename T>
+inline constexpr bool is_io_result_v = is_io_result<T>::value;
+
+} // detail
+
+/** Race an awaitable against a deadline.
+
+    Starts the awaitable and a timer concurrently. If the
+    awaitable completes first, its result is returned. If the
+    timer fires first, stop is requested for the awaitable and
+    a timeout error is produced.
+
+    @par Return Type
+
+    The return type matches the inner awaitable's result type:
+
+    @li For `io_result<...>` types: returns `io_result` with
+        `ec == error::timeout` and default-initialized values
+    @li For non-void types: throws `std::system_error(error::timeout)`
+    @li For void: throws `std::system_error(error::timeout)`
+
+    @par Precision
+
+    The timeout fires at or after the specified duration.
+
+    @par Cancellation
+
+    If the parent's stop token is activated, the inner awaitable
+    is cancelled normally (not a timeout). The result reflects
+    the inner awaitable's cancellation behavior.
+
+    @par Example
+    @code
+    auto [ec, n] = co_await timeout(sock.read_some(buf), 50ms);
+    if (ec == cond::timeout) {
+        // handle timeout
+    }
+    @endcode
+
+    @tparam A An IoAwaitable whose result type determines
+        how timeouts are reported.
+
+    @param a The awaitable to race against the deadline.
+    @param dur The maximum duration to wait.
+
+    @return `task<awaitable_result_t<A>>`.
+
+    @throws std::system_error with `error::timeout` if the timer
+        fires first and the result type is not `io_result`.
+        Exceptions thrown by the inner awaitable propagate
+        unchanged.
+
+    @see delay, when_any, cond::timeout
+*/
+template<IoAwaitable A, typename Rep, typename Period>
+auto timeout(A a, std::chrono::duration<Rep, Period> dur)
+    -> task<awaitable_result_t<A>>
+{
+    using T = awaitable_result_t<A>;
+
+    auto result = co_await when_any(
+        std::move(a), delay(dur));
+
+    if(result.index() == 0)
+    {
+        // Task completed first
+        if constexpr (std::is_void_v<T>)
+            co_return;
+        else
+            co_return std::get<0>(std::move(result));
+    }
+    else
+    {
+        // Timer won
+        if constexpr (detail::is_io_result_v<T>)
+        {
+            T timeout_result{};
+            timeout_result.ec = make_error_code(error::timeout);
+            co_return timeout_result;
+        }
+        else if constexpr (std::is_void_v<T>)
+        {
+            throw std::system_error(
+                make_error_code(error::timeout));
+        }
+        else
+        {
+            throw std::system_error(
+                make_error_code(error::timeout));
+        }
+    }
+}
+
+} // capy
+} // boost
+
+#endif

--- a/src/cond.cpp
+++ b/src/cond.cpp
@@ -33,6 +33,7 @@ message(int code) const
     case cond::canceled: return "operation canceled";
     case cond::stream_truncated: return "stream truncated";
     case cond::not_found: return "not found";
+    case cond::timeout: return "operation timed out";
     default:
         return "unknown";
     }
@@ -61,6 +62,9 @@ equivalent(
 
     case cond::not_found:
         return ec == capy::error::not_found;
+
+    case cond::timeout:
+        return ec == capy::error::timeout;
 
     default:
         return false;

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -32,6 +32,7 @@ message(int code) const
     case error::test_failure: return "test failure";
     case error::stream_truncated: return "stream truncated";
     case error::not_found: return "not found";
+    case error::timeout: return "timeout";
     default:
         return "unknown";
     }

--- a/src/ex/detail/timer_service.cpp
+++ b/src/ex/detail/timer_service.cpp
@@ -1,0 +1,112 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#include <boost/capy/ex/detail/timer_service.hpp>
+
+namespace boost {
+namespace capy {
+namespace detail {
+
+timer_service::
+timer_service(execution_context& ctx)
+    : thread_([this] { run(); })
+{
+    (void)ctx;
+}
+
+timer_service::timer_id
+timer_service::
+schedule_at(
+    std::chrono::steady_clock::time_point deadline,
+    std::function<void()> cb)
+{
+    std::lock_guard lock(mutex_);
+    auto id = ++next_id_;
+    active_ids_.insert(id);
+    queue_.push(entry{deadline, id, std::move(cb)});
+    cv_.notify_one();
+    return id;
+}
+
+void
+timer_service::
+cancel(timer_id id)
+{
+    std::unique_lock lock(mutex_);
+    if(!active_ids_.contains(id))
+        return;
+    if(executing_id_ == id)
+    {
+        // Callback is running — wait for it to finish.
+        // run() erases from active_ids_ after execution.
+        while(executing_id_ == id)
+            cancel_cv_.wait(lock);
+        return;
+    }
+    active_ids_.erase(id);
+}
+
+void
+timer_service::
+shutdown()
+{
+    {
+        std::lock_guard lock(mutex_);
+        stopped_ = true;
+    }
+    cv_.notify_one();
+    if(thread_.joinable())
+        thread_.join();
+}
+
+void
+timer_service::
+run()
+{
+    std::unique_lock lock(mutex_);
+    for(;;)
+    {
+        if(stopped_)
+            return;
+
+        if(queue_.empty())
+        {
+            cv_.wait(lock);
+            continue;
+        }
+
+        auto deadline = queue_.top().deadline;
+        auto now = std::chrono::steady_clock::now();
+        if(deadline > now)
+        {
+            cv_.wait_until(lock, deadline);
+            continue;
+        }
+
+        // Pop the entry (const_cast needed because priority_queue::top is const)
+        auto e = std::move(const_cast<entry&>(queue_.top()));
+        queue_.pop();
+
+        // Skip if cancelled (no longer in active set)
+        if(!active_ids_.contains(e.id))
+            continue;
+
+        executing_id_ = e.id;
+        lock.unlock();
+        e.callback();
+        lock.lock();
+        active_ids_.erase(e.id);
+        executing_id_ = 0;
+        cancel_cv_.notify_all();
+    }
+}
+
+} // detail
+} // capy
+} // boost

--- a/test/unit/delay.cpp
+++ b/test/unit/delay.cpp
@@ -1,0 +1,260 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+// Test that header file is self-contained.
+#include <boost/capy/delay.hpp>
+
+#include <boost/capy/ex/run_async.hpp>
+#include <boost/capy/ex/thread_pool.hpp>
+#include <boost/capy/task.hpp>
+
+#include "test_helpers.hpp"
+#include "test_suite.hpp"
+
+#include <latch>
+#include <memory_resource>
+#include <stop_token>
+
+namespace boost {
+namespace capy {
+
+using namespace std::chrono_literals;
+
+struct delay_test
+{
+    // Test: delay completes after duration
+    void
+    testDelayCompletes()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        bool completed = false;
+
+        auto delay_task = [&]() -> task<void>
+        {
+            co_await delay(10ms);
+            completed = true;
+        };
+
+        run_async(pool.get_executor(),
+            [&]() {
+                done.count_down();
+            },
+            [&](std::exception_ptr) {
+                done.count_down();
+            })(delay_task());
+
+        done.wait();
+        BOOST_TEST(completed);
+    }
+
+    // Test: delay waits at least the specified duration
+    void
+    testDelayMinimumDuration()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+
+        auto delay_task = [&]() -> task<void>
+        {
+            co_await delay(50ms);
+        };
+
+        auto start = std::chrono::steady_clock::now();
+
+        run_async(pool.get_executor(),
+            [&]() {
+                done.count_down();
+            },
+            [&](std::exception_ptr) {
+                done.count_down();
+            })(delay_task());
+
+        done.wait();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        BOOST_TEST(elapsed >= 50ms);
+    }
+
+    // Test: stop requested before delay suspends (early-out path)
+    void
+    testDelayCancellationEarlyOut()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        std::stop_source source;
+
+        auto delay_task = [&]() -> task<void>
+        {
+            co_await delay(10s);
+        };
+
+        auto start = std::chrono::steady_clock::now();
+
+        run_async(pool.get_executor(), source.get_token(),
+            [&]() {
+                done.count_down();
+            },
+            [&](std::exception_ptr) {
+                done.count_down();
+            })(delay_task());
+
+        // Cancel immediately — likely before delay suspends
+        source.request_stop();
+
+        done.wait();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        BOOST_TEST(elapsed < 1s);
+    }
+
+    // Test: stop requested after delay is fully suspended
+    //       (exercises cancel_fn stop callback path)
+    void
+    testDelayCancellationWhileSuspended()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        std::latch suspended(1);
+        std::stop_source source;
+
+        auto delay_task = [&]() -> task<void>
+        {
+            // Signal that we're about to suspend on delay
+            suspended.count_down();
+            co_await delay(10s);
+        };
+
+        auto start = std::chrono::steady_clock::now();
+
+        run_async(pool.get_executor(), source.get_token(),
+            [&]() {
+                done.count_down();
+            },
+            [&](std::exception_ptr) {
+                done.count_down();
+            })(delay_task());
+
+        // Wait for the task to reach the delay point
+        suspended.wait();
+        // Small sleep to ensure delay_awaitable::await_suspend
+        // has fully completed (stop callback registered)
+        std::this_thread::sleep_for(10ms);
+        source.request_stop();
+
+        done.wait();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        BOOST_TEST(elapsed < 1s);
+    }
+
+    // Test: zero-duration delay completes immediately
+    void
+    testZeroDuration()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        bool completed = false;
+
+        auto delay_task = [&]() -> task<void>
+        {
+            co_await delay(0ms);
+            completed = true;
+        };
+
+        run_async(pool.get_executor(),
+            [&]() {
+                done.count_down();
+            },
+            [&](std::exception_ptr) {
+                done.count_down();
+            })(delay_task());
+
+        done.wait();
+        BOOST_TEST(completed);
+    }
+
+    // Test: multiple sequential delays
+    void
+    testSequentialDelays()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        int step = 0;
+
+        auto delay_task = [&]() -> task<void>
+        {
+            co_await delay(5ms);
+            step = 1;
+            co_await delay(5ms);
+            step = 2;
+            co_await delay(5ms);
+            step = 3;
+        };
+
+        run_async(pool.get_executor(),
+            [&]() {
+                done.count_down();
+            },
+            [&](std::exception_ptr) {
+                done.count_down();
+            })(delay_task());
+
+        done.wait();
+        BOOST_TEST_EQ(step, 3);
+    }
+
+    // Test: destroying delay_awaitable while suspended
+    //       cleans up both stop callback and timer
+    void
+    testDestroyWhileSuspended()
+    {
+// GCC emits a false -Wmaybe-uninitialized when it inlines
+// the stop_callback destructor through the alignas buffer.
+#if defined(__GNUC__) && !defined(__clang__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+        thread_pool pool(1);
+        auto ex = pool.get_executor();
+        std::stop_source source;
+        io_env env{ex, source.get_token(),
+            std::pmr::get_default_resource()};
+
+        {
+            delay_awaitable da(std::chrono::seconds(10));
+            // Manually suspend — registers timer and stop callback
+            da.await_suspend(std::noop_coroutine(), &env);
+            // da destroyed here without calling await_resume
+        }
+
+        // If cleanup was incomplete, requesting stop or waiting
+        // for the timer would access freed memory (UB/crash).
+        source.request_stop();
+        std::this_thread::sleep_for(20ms);
+        BOOST_TEST(true);
+#if defined(__GNUC__) && !defined(__clang__)
+# pragma GCC diagnostic pop
+#endif
+    }
+
+    void
+    run()
+    {
+        testDelayCompletes();
+        testDelayMinimumDuration();
+        testDelayCancellationEarlyOut();
+        testDelayCancellationWhileSuspended();
+        testZeroDuration();
+        testSequentialDelays();
+        testDestroyWhileSuspended();
+    }
+};
+
+TEST_SUITE(delay_test, "capy.delay");
+
+} // capy
+} // boost

--- a/test/unit/ex/detail/timer_service.cpp
+++ b/test/unit/ex/detail/timer_service.cpp
@@ -1,0 +1,287 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+// Test that header file is self-contained.
+#include <boost/capy/ex/detail/timer_service.hpp>
+
+#include <boost/capy/ex/thread_pool.hpp>
+
+#include "test_helpers.hpp"
+
+#include <atomic>
+#include <latch>
+
+namespace boost {
+namespace capy {
+
+using namespace std::chrono_literals;
+
+struct timer_service_test
+{
+    // Test: timer fires after duration
+    void
+    testBasicFire()
+    {
+        thread_pool pool(1);
+        auto& ts = pool.get_executor().context()
+            .use_service<detail::timer_service>();
+
+        std::latch done(1);
+        bool fired = false;
+
+        ts.schedule_after(1ms, [&] {
+            fired = true;
+            done.count_down();
+        });
+
+        done.wait();
+        BOOST_TEST(fired);
+    }
+
+    // Test: cancel prevents callback from firing
+    void
+    testCancelBeforeFire()
+    {
+        thread_pool pool(1);
+        auto& ts = pool.get_executor().context()
+            .use_service<detail::timer_service>();
+
+        bool fired = false;
+
+        auto id = ts.schedule_after(1s, [&] {
+            fired = true;
+        });
+
+        ts.cancel(id);
+
+        // Give some time to confirm it doesn't fire
+        std::this_thread::sleep_for(20ms);
+        BOOST_TEST(!fired);
+    }
+
+    // Test: cancel on already-fired timer is safe
+    void
+    testCancelAfterFire()
+    {
+        thread_pool pool(1);
+        auto& ts = pool.get_executor().context()
+            .use_service<detail::timer_service>();
+
+        std::latch done(1);
+
+        auto id = ts.schedule_after(1ms, [&] {
+            done.count_down();
+        });
+
+        done.wait();
+        // Should not block or crash
+        ts.cancel(id);
+    }
+
+    // Test: multiple timers fire in deadline order
+    void
+    testFiringOrder()
+    {
+        thread_pool pool(1);
+        auto& ts = pool.get_executor().context()
+            .use_service<detail::timer_service>();
+
+        std::vector<int> order;
+        std::mutex mu;
+        std::latch done(3);
+
+        auto const scale = failsafe_scale;
+
+        ts.schedule_after(30ms * scale, [&] {
+            std::lock_guard lock(mu);
+            order.push_back(3);
+            done.count_down();
+        });
+        ts.schedule_after(10ms * scale, [&] {
+            std::lock_guard lock(mu);
+            order.push_back(1);
+            done.count_down();
+        });
+        ts.schedule_after(20ms * scale, [&] {
+            std::lock_guard lock(mu);
+            order.push_back(2);
+            done.count_down();
+        });
+
+        done.wait();
+        BOOST_TEST_EQ(order.size(), 3u);
+        BOOST_TEST_EQ(order[0], 1);
+        BOOST_TEST_EQ(order[1], 2);
+        BOOST_TEST_EQ(order[2], 3);
+    }
+
+    // Test: zero duration fires promptly
+    void
+    testZeroDuration()
+    {
+        thread_pool pool(1);
+        auto& ts = pool.get_executor().context()
+            .use_service<detail::timer_service>();
+
+        std::latch done(1);
+        auto start = std::chrono::steady_clock::now();
+
+        ts.schedule_after(0ms, [&] {
+            done.count_down();
+        });
+
+        done.wait();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        BOOST_TEST(elapsed < 100ms);
+    }
+
+    // Test: many timers scheduled concurrently
+    void
+    testManyConcurrent()
+    {
+        thread_pool pool(1);
+        auto& ts = pool.get_executor().context()
+            .use_service<detail::timer_service>();
+
+        constexpr int N = 100;
+        std::atomic<int> count{0};
+        std::latch done(N);
+
+        for(int i = 0; i < N; ++i)
+        {
+            ts.schedule_after(1ms, [&] {
+                count.fetch_add(1, std::memory_order_relaxed);
+                done.count_down();
+            });
+        }
+
+        done.wait();
+        BOOST_TEST_EQ(count.load(), N);
+    }
+
+    // Test: cancel subset of timers
+    void
+    testCancelSubset()
+    {
+        thread_pool pool(1);
+        auto& ts = pool.get_executor().context()
+            .use_service<detail::timer_service>();
+
+        std::atomic<int> count{0};
+        std::latch done(1);
+
+        auto id1 = ts.schedule_after(10ms, [&] {
+            count.fetch_add(1, std::memory_order_relaxed);
+        });
+        ts.schedule_after(10ms, [&] {
+            count.fetch_add(1, std::memory_order_relaxed);
+            done.count_down();
+        });
+        auto id3 = ts.schedule_after(10ms, [&] {
+            count.fetch_add(1, std::memory_order_relaxed);
+        });
+
+        ts.cancel(id1);
+        ts.cancel(id3);
+
+        // Wait for the uncancelled timer to fire
+        done.wait();
+        // Give time for any incorrectly-uncancelled timers
+        std::this_thread::sleep_for(20ms);
+        BOOST_TEST_EQ(count.load(), 1);
+    }
+
+    // Test: shutdown with pending timers doesn't crash
+    void
+    testShutdownWithPending()
+    {
+        {
+            thread_pool pool(1);
+            auto& ts = pool.get_executor().context()
+                .use_service<detail::timer_service>();
+
+            // Schedule timers far in the future
+            ts.schedule_after(10s, [] {});
+            ts.schedule_after(10s, [] {});
+            ts.schedule_after(10s, [] {});
+
+            // pool destructor calls shutdown — should not hang
+        }
+        BOOST_TEST(true);
+    }
+
+    // Test: timer fires at or after the specified duration
+    void
+    testFiresAtOrAfter()
+    {
+        thread_pool pool(1);
+        auto& ts = pool.get_executor().context()
+            .use_service<detail::timer_service>();
+
+        std::latch done(1);
+        auto start = std::chrono::steady_clock::now();
+        auto dur = 50ms;
+
+        ts.schedule_after(dur, [&] {
+            done.count_down();
+        });
+
+        done.wait();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        BOOST_TEST(elapsed >= dur);
+    }
+
+    // Test: cancel blocks while callback is executing
+    void
+    testCancelBlocksDuringExecution()
+    {
+        thread_pool pool(1);
+        auto& ts = pool.get_executor().context()
+            .use_service<detail::timer_service>();
+
+        std::atomic<bool> callback_started{false};
+        std::atomic<bool> callback_finished{false};
+        std::latch started(1);
+
+        auto id = ts.schedule_after(1ms, [&] {
+            callback_started.store(true);
+            started.count_down();
+            std::this_thread::sleep_for(50ms);
+            callback_finished.store(true);
+        });
+
+        // Wait for callback to start executing
+        started.wait();
+        BOOST_TEST(callback_started.load());
+
+        // cancel() must block until callback finishes
+        ts.cancel(id);
+        BOOST_TEST(callback_finished.load());
+    }
+
+    void
+    run()
+    {
+        testBasicFire();
+        testCancelBeforeFire();
+        testCancelAfterFire();
+        testFiringOrder();
+        testZeroDuration();
+        testManyConcurrent();
+        testCancelSubset();
+        testShutdownWithPending();
+        testFiresAtOrAfter();
+        testCancelBlocksDuringExecution();
+    }
+};
+
+TEST_SUITE(timer_service_test, "capy.ex.timer_service");
+
+} // capy
+} // boost

--- a/test/unit/test_helpers.hpp
+++ b/test/unit/test_helpers.hpp
@@ -30,6 +30,14 @@
 #include <string>
 #include <thread>
 
+// Valgrind slows execution ~10-20x; scale timing-sensitive
+// durations to avoid false failures.
+#ifdef BOOST_NO_STRESS_TEST
+inline constexpr int failsafe_scale = 20;
+#else
+inline constexpr int failsafe_scale = 1;
+#endif
+
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
 #include <pthread.h>
 #define BOOST_CAPY_TEST_CAN_GET_THREAD_NAME 1

--- a/test/unit/timeout.cpp
+++ b/test/unit/timeout.cpp
@@ -1,0 +1,317 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+// Test that header file is self-contained.
+#include <boost/capy/timeout.hpp>
+
+#include <boost/capy/cond.hpp>
+#include <boost/capy/error.hpp>
+#include <boost/capy/ex/run_async.hpp>
+#include <boost/capy/ex/thread_pool.hpp>
+#include <boost/capy/io_task.hpp>
+#include <boost/capy/task.hpp>
+
+#include "test_helpers.hpp"
+#include "test_suite.hpp"
+
+#include <latch>
+#include <string>
+
+namespace boost {
+namespace capy {
+
+using namespace std::chrono_literals;
+
+//----------------------------------------------------------
+// Helper tasks for timeout testing
+//----------------------------------------------------------
+
+// Returns an int after a brief delay (via stop_only_awaitable pattern)
+inline task<int>
+slow_int(int value)
+{
+    // Yield to allow stop to be observed
+    co_await stop_only_awaitable{};
+    co_return value;
+}
+
+// Returns io_result after a brief delay
+inline io_task<std::size_t>
+slow_io_result(std::size_t n)
+{
+    co_await stop_only_awaitable{};
+    co_return io_result<std::size_t>{{}, n};
+}
+
+// Void task that waits for stop
+inline task<void>
+slow_void_task()
+{
+    co_await stop_only_awaitable{};
+    co_return;
+}
+
+// Task that throws an exception immediately
+inline task<int>
+immediate_throw(char const* msg)
+{
+    throw test_exception(msg);
+    co_return 0;
+}
+
+//----------------------------------------------------------
+// Tests
+//----------------------------------------------------------
+
+struct timeout_test
+{
+    // Test: Task completes immediately, well within timeout
+    void
+    testTaskCompletesBeforeTimeout()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        int result = 0;
+
+        run_async(pool.get_executor(),
+            [&](int v) {
+                result = v;
+                done.count_down();
+            },
+            [&](std::exception_ptr) {
+                done.count_down();
+            })(timeout(returns_int(42), 5s));
+
+        done.wait();
+        BOOST_TEST_EQ(result, 42);
+    }
+
+    // Test: Task completes immediately with string
+    void
+    testTaskCompletesWithString()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        std::string result;
+
+        run_async(pool.get_executor(),
+            [&](std::string v) {
+                result = std::move(v);
+                done.count_down();
+            },
+            [&](std::exception_ptr) {
+                done.count_down();
+            })(timeout(returns_string("hello"), 5s));
+
+        done.wait();
+        BOOST_TEST_EQ(result, "hello");
+    }
+
+    // Test: Void task completes before timeout
+    void
+    testVoidTaskCompletes()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        bool completed = false;
+
+        run_async(pool.get_executor(),
+            [&]() {
+                completed = true;
+                done.count_down();
+            },
+            [&](std::exception_ptr) {
+                done.count_down();
+            })(timeout(void_task(), 5s));
+
+        done.wait();
+        BOOST_TEST(completed);
+    }
+
+    // Test: Timeout fires - io_result path returns error::timeout
+    void
+    testTimeoutIoResult()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        std::error_code ec;
+        std::size_t n = 999;
+
+        run_async(pool.get_executor(),
+            [&](io_result<std::size_t> r) {
+                ec = r.ec;
+                n = r.t1;
+                done.count_down();
+            },
+            [&](std::exception_ptr) {
+                done.count_down();
+            })(timeout(slow_io_result(100), 1ms));
+
+        done.wait();
+        BOOST_TEST(ec == error::timeout);
+        BOOST_TEST(ec == cond::timeout);
+        BOOST_TEST_EQ(n, 0u);
+    }
+
+    // Test: Timeout fires - non-io_result throws system_error
+    void
+    testTimeoutThrowsForNonIoResult()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        bool got_timeout = false;
+
+        run_async(pool.get_executor(),
+            [&](int) {
+                done.count_down();
+            },
+            [&](std::exception_ptr ep) {
+                try
+                {
+                    std::rethrow_exception(ep);
+                }
+                catch(std::system_error const& e)
+                {
+                    got_timeout = (e.code() == error::timeout);
+                }
+                catch(...)
+                {
+                }
+                done.count_down();
+            })(timeout(slow_int(42), 1ms));
+
+        done.wait();
+        BOOST_TEST(got_timeout);
+    }
+
+    // Test: Timeout fires - void task throws system_error
+    void
+    testTimeoutThrowsForVoid()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        bool got_timeout = false;
+
+        run_async(pool.get_executor(),
+            [&]() {
+                done.count_down();
+            },
+            [&](std::exception_ptr ep) {
+                try
+                {
+                    std::rethrow_exception(ep);
+                }
+                catch(std::system_error const& e)
+                {
+                    got_timeout = (e.code() == error::timeout);
+                }
+                catch(...)
+                {
+                }
+                done.count_down();
+            })(timeout(slow_void_task(), 1ms));
+
+        done.wait();
+        BOOST_TEST(got_timeout);
+    }
+
+    // Test: Task exception propagates (not converted to timeout)
+    void
+    testExceptionPropagates()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        bool got_test_exception = false;
+
+        run_async(pool.get_executor(),
+            [&](int) {
+                done.count_down();
+            },
+            [&](std::exception_ptr ep) {
+                try
+                {
+                    std::rethrow_exception(ep);
+                }
+                catch(test_exception const&)
+                {
+                    got_test_exception = true;
+                }
+                catch(...)
+                {
+                }
+                done.count_down();
+            })(timeout(immediate_throw("test error"), 5s));
+
+        done.wait();
+        BOOST_TEST(got_test_exception);
+    }
+
+    // Test: Zero duration times out immediately
+    void
+    testZeroDuration()
+    {
+        thread_pool pool(1);
+        std::latch done(1);
+        bool got_timeout = false;
+
+        run_async(pool.get_executor(),
+            [&](int) {
+                done.count_down();
+            },
+            [&](std::exception_ptr ep) {
+                try
+                {
+                    std::rethrow_exception(ep);
+                }
+                catch(std::system_error const& e)
+                {
+                    got_timeout = (e.code() == error::timeout);
+                }
+                catch(...)
+                {
+                }
+                done.count_down();
+            })(timeout(slow_int(42), 0ms));
+
+        done.wait();
+        BOOST_TEST(got_timeout);
+    }
+
+    // Test: cond::timeout equivalence
+    void
+    testCondEquivalence()
+    {
+        auto ec = make_error_code(error::timeout);
+        BOOST_TEST(ec == cond::timeout);
+        BOOST_TEST(!(ec == cond::canceled));
+        BOOST_TEST(!(ec == cond::eof));
+
+        auto cond_ec = make_error_condition(cond::timeout);
+        BOOST_TEST(cond_ec.message() == "operation timed out");
+    }
+
+    void
+    run()
+    {
+        testTaskCompletesBeforeTimeout();
+        testTaskCompletesWithString();
+        testVoidTaskCompletes();
+        testTimeoutIoResult();
+        testTimeoutThrowsForNonIoResult();
+        testTimeoutThrowsForVoid();
+        testExceptionPropagates();
+        testZeroDuration();
+        testCondEquivalence();
+    }
+};
+
+TEST_SUITE(timeout_test, "capy.timeout");
+
+} // capy
+} // boost


### PR DESCRIPTION
Closes #63

Introduce a first-class timeout(awaitable, duration) function that races an IoAwaitable against a deadline, built on when_any + delay.

Components:

- timer_service: execution_context::service with a background jthread managing a min-heap of deadlines. Lazy-created via use_service. cancel() blocks until any in-progress callback completes.

- delay: standalone IoAwaitable that suspends for a duration using timer_service. Follows the claimed_/stop_callback pattern from async_event for safe cancellation. Destructor cleans up both the stop callback and timer to prevent use-after-free if a coroutine is destroyed while suspended.

- timeout: coroutine wrapper that returns the task result on success, or produces error::timeout on deadline expiry. For io_result types, the error code is set directly; for other types, a system_error is thrown.

- error::timeout and cond::timeout added to error/condition enums.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coroutine delay with stop-token-aware cancellation for suspending tasks.
  * Timeout utility to race awaitables against a deadline; returns timeout results or throws on expiration.
  * New timeout error/condition codes and user-facing messages for timed-out operations.
  * Master headers updated to expose the new delay/timeout utilities.

* **Chores**
  * Added a shared timer service to drive delay/timeout scheduling and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->