### PR TITLE
Add ThreadSanitizer CI builds for GCC and Clang

### DIFF
--- a/.github/generate-matrix.py
+++ b/.github/generate-matrix.py
@@ -98,7 +98,9 @@ def generate_name(compiler_family, entry):
         macos_ver = runner.replace("macos-", "macOS ")
         modifiers.append(macos_ver)
 
-    if entry.get("asan") and entry.get("ubsan"):
+    if entry.get("tsan"):
+        modifiers.append("tsan")
+    elif entry.get("asan") and entry.get("ubsan"):
         modifiers.append("asan+ubsan")
     elif entry.get("asan"):
         modifiers.append("asan")
@@ -132,6 +134,20 @@ def generate_sanitizer_variant(compiler_family, spec):
     # MSVC and Clang-CL only support ASAN, not UBSAN
     if compiler_family not in ("msvc", "clang-cl"):
         overrides["ubsan"] = True
+
+    if compiler_family == "clang":
+        overrides["shared"] = False
+
+    return make_entry(compiler_family, spec, **overrides)
+
+
+def generate_tsan_variant(compiler_family, spec):
+    """Generate TSan variant for the latest compiler in a family (Linux only)."""
+    overrides = {
+        "tsan": True,
+        "build-type": "RelWithDebInfo",
+        "shared": True,
+    }
 
     if compiler_family == "clang":
         overrides["shared"] = False
@@ -184,6 +200,10 @@ def main():
             # Variants for the latest compiler in each family
             if spec.get("is_latest"):
                 matrix.append(generate_sanitizer_variant(family, spec))
+
+                # TSan is incompatible with ASan; separate variant for Linux
+                if family in ("gcc", "clang"):
+                    matrix.append(generate_tsan_variant(family, spec))
 
                 if family == "gcc":
                     matrix.append(generate_coverage_variant(family, spec))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
         if: ${{ !matrix.coverage && !matrix.time-trace }}
         env:
           ASAN_OPTIONS: ${{ ((matrix.compiler == 'apple-clang' || matrix.compiler == 'clang' || matrix.compiler == 'mingw') && 'detect_invalid_pointer_pairs=0:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1') || 'detect_invalid_pointer_pairs=2:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1' }}
+          TSAN_OPTIONS: ${{ matrix.tsan && 'halt_on_error=1:second_deadlock_stack=1' || '' }}
         with:
           source-dir: boost-root
           modules: capy
@@ -162,6 +163,7 @@ jobs:
           address-model: ${{ (matrix.x86 && '32') || '64' }}
           asan: ${{ matrix.asan }}
           ubsan: ${{ matrix.ubsan }}
+          tsan: ${{ matrix.tsan }}
           shared: ${{ matrix.shared }}
           rtti: on
           cxxflags: ${{ (matrix.asan && matrix.compiler != 'msvc' && matrix.compiler != 'clang-cl' && '-fsanitize-address-use-after-scope -fsanitize=pointer-subtract') || '' }}


### PR DESCRIPTION
Add TSan variants to the build matrix for GCC 15 (shared) and Clang 20 (static), mirroring the existing ASan link modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Thread Sanitizer (TSan) variant support to the build matrix for GCC and Clang, enabling detection of threading issues and data races.
  * Updated CI workflow to configure and propagate TSan environment options during builds, improving quality assurance testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->