### PR TITLE
Add Apple-clang Tsan build and fix tsan errors

### DIFF
--- a/.github/generate-matrix.py
+++ b/.github/generate-matrix.py
@@ -129,6 +129,7 @@ def generate_sanitizer_variant(compiler_family, spec):
         "asan": True,
         "build-type": "RelWithDebInfo",
         "shared": True,
+        "build-cmake": False,
     }
 
     # MSVC and Clang-CL only support ASAN, not UBSAN
@@ -142,14 +143,15 @@ def generate_sanitizer_variant(compiler_family, spec):
 
 
 def generate_tsan_variant(compiler_family, spec):
-    """Generate TSan variant for the latest compiler in a family (Linux only)."""
+    """Generate TSan variant for the latest compiler in a family."""
     overrides = {
         "tsan": True,
         "build-type": "RelWithDebInfo",
         "shared": True,
+        "build-cmake": False,
     }
 
-    if compiler_family == "clang":
+    if compiler_family in ("clang", "apple-clang"):
         overrides["shared"] = False
 
     return make_entry(compiler_family, spec, **overrides)
@@ -202,7 +204,7 @@ def main():
                 matrix.append(generate_sanitizer_variant(family, spec))
 
                 # TSan is incompatible with ASan; separate variant for Linux
-                if family in ("gcc", "clang"):
+                if family in ("gcc", "clang", "apple-clang"):
                     matrix.append(generate_tsan_variant(family, spec))
 
                 if family == "gcc":

--- a/src/ex/detail/strand_service.cpp
+++ b/src/ex/detail/strand_service.cpp
@@ -26,13 +26,17 @@ namespace detail {
     Each strand_impl provides serialization for coroutines
     dispatched through strands that share it.
 */
+// Sentinel stored in cached_frame_ after shutdown to prevent
+// in-flight invokers from repopulating a freed cache slot.
+inline void* const kCacheClosed = reinterpret_cast<void*>(1);
+
 struct strand_impl
 {
     std::mutex mutex_;
     strand_queue pending_;
     bool locked_ = false;
     std::atomic<std::thread::id> dispatch_thread_{};
-    void* cached_frame_ = nullptr;
+    std::atomic<void*> cached_frame_{nullptr};
 };
 
 //----------------------------------------------------------
@@ -52,9 +56,10 @@ struct strand_invoker
             std::size_t padded = (n + A - 1) & ~(A - 1);
             std::size_t total = padded + sizeof(strand_impl*);
 
-            void* p = impl.cached_frame_
-                ? std::exchange(impl.cached_frame_, nullptr)
-                : ::operator new(total);
+            void* p = impl.cached_frame_.exchange(
+                nullptr, std::memory_order_acquire);
+            if(!p || p == kCacheClosed)
+                p = ::operator new(total);
 
             // Trailer lets delete recover impl
             *reinterpret_cast<strand_impl**>(
@@ -70,9 +75,9 @@ struct strand_invoker
             auto* impl = *reinterpret_cast<strand_impl**>(
                 static_cast<char*>(p) + padded);
 
-            if (!impl->cached_frame_)
-                impl->cached_frame_ = p;
-            else
+            void* expected = nullptr;
+            if(!impl->cached_frame_.compare_exchange_strong(
+                expected, p, std::memory_order_release))
                 ::operator delete(p);
         }
 
@@ -126,11 +131,10 @@ protected:
             std::lock_guard<std::mutex> lock(impls_[i].mutex_);
             impls_[i].locked_ = true;
 
-            if(impls_[i].cached_frame_)
-            {
-                ::operator delete(impls_[i].cached_frame_);
-                impls_[i].cached_frame_ = nullptr;
-            }
+            void* p = impls_[i].cached_frame_.exchange(
+                kCacheClosed, std::memory_order_acquire);
+            if(p)
+                ::operator delete(p);
         }
     }
 

--- a/test/unit/test_helpers.hpp
+++ b/test/unit/test_helpers.hpp
@@ -18,7 +18,7 @@
 #include <boost/capy/ex/io_env.hpp>
 #include <boost/capy/task.hpp>
 
-#include <optional>
+#include <atomic>
 #include <stop_token>
 
 #include "test_suite.hpp"
@@ -256,7 +256,31 @@ struct stop_only_awaitable
     stop_only_awaitable() noexcept = default;
     stop_only_awaitable(stop_only_awaitable && ) noexcept {}
 
-    std::optional<stop_resume_callback> stop_cb;
+    // Placement-new storage instead of std::optional to avoid a
+    // data race on optional's _M_engaged flag.  The stop_callback
+    // constructor synchronises with request_stop() through the
+    // stop-state's atomics, but optional::emplace writes _M_engaged
+    // *after* the constructor returns — outside that sync window.
+    // When ~jthread calls request_stop() before join(), the
+    // destructor's _M_reset (on the requesting thread) races with
+    // emplace's _M_engaged write (on the registering thread).
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable: 4324) // padded due to alignas
+#endif
+    alignas(stop_resume_callback)
+        unsigned char stop_cb_buf_[sizeof(stop_resume_callback)]{};
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif
+    std::atomic<bool> active_{false};
+
+    ~stop_only_awaitable()
+    {
+        if (active_.load(std::memory_order_acquire))
+            reinterpret_cast<stop_resume_callback*>(
+                stop_cb_buf_)->~stop_resume_callback();
+    }
 
     bool await_ready() {return false;}
 
@@ -264,7 +288,9 @@ struct stop_only_awaitable
     {
         if (env->stop_token.stop_requested())
             return h;
-        stop_cb.emplace(env->stop_token, env->post_resume(h));
+        ::new(stop_cb_buf_) stop_resume_callback(
+            env->stop_token, env->post_resume(h));
+        active_.store(true, std::memory_order_release);
         return std::noop_coroutine();
     }
     void await_resume() {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to broaden sanitizer variant generation and treat Apple Clang similarly to Clang for TSAN eligibility.
* **Bug Fixes / Stability**
  * Strengthened concurrency handling for cached resources to prevent races during shutdown and improve runtime stability under contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->