### PR TITLE
Align read_some/write_some to E2 semantics and add exception docs

### DIFF
--- a/doc/modules/ROOT/pages/5.buffers/5c.sequences.adoc
+++ b/doc/modules/ROOT/pages/5.buffers/5c.sequences.adoc
@@ -117,10 +117,10 @@ task<std::size_t> read_all(Stream& stream, Buffers buffers)
     while (buffer_size(remaining) > 0)
     {
         auto [ec, n] = co_await stream.read_some(remaining);
-        if (ec.failed())
-            break;
         remaining.consume(n);
         total += n;
+        if (ec)
+            break;
     }
     
     co_return total;

--- a/doc/modules/ROOT/pages/5.buffers/5e.algorithms.adoc
+++ b/doc/modules/ROOT/pages/5.buffers/5e.algorithms.adoc
@@ -157,11 +157,10 @@ task<std::size_t> read_full(Stream& stream, Buffers buffers)
     while (buffer_size(remaining) > 0)
     {
         auto [ec, n] = co_await stream.read_some(remaining);
-        if (ec.failed())
-            co_return total;  // Return partial read on error
-        
         remaining.consume(n);
         total += n;
+        if (ec)
+            co_return total;
     }
     
     co_return total;
@@ -181,11 +180,10 @@ task<std::size_t> write_full(Stream& stream, Buffers buffers)
     while (buffer_size(remaining) > 0)
     {
         auto [ec, n] = co_await stream.write_some(remaining);
-        if (ec.failed())
-            co_return total;
-        
         remaining.consume(n);
         total += n;
+        if (ec)
+            co_return total;
     }
     
     co_return total;

--- a/doc/modules/ROOT/pages/5.buffers/5f.dynamic.adoc
+++ b/doc/modules/ROOT/pages/5.buffers/5f.dynamic.adoc
@@ -76,9 +76,8 @@ task<> read_into_buffer(Stream& stream, DynamicBuffer auto& buffer)
     
     // Read into prepared space
     auto [ec, n] = co_await stream.read_some(space);
-    
-    if (!ec.failed())
-        buffer.commit(n);  // Make data readable
+
+    buffer.commit(n);  // Make data readable
 }
 ----
 
@@ -240,9 +239,9 @@ task<std::string> read_line(Stream& stream)
         // Prepare space and read
         auto space = buffer.prepare(256);
         auto [ec, n] = co_await stream.read_some(space);
-        if (ec.failed())
-            throw std::system_error(ec);
         buffer.commit(n);
+        if (ec)
+            throw std::system_error(ec);
         
         // Search for newline in readable data
         auto data = buffer.data();

--- a/doc/modules/ROOT/pages/6.streams/6a.overview.adoc
+++ b/doc/modules/ROOT/pages/6.streams/6a.overview.adoc
@@ -167,10 +167,12 @@ task<> echo(any_stream& stream)
     for (;;)
     {
         auto [ec, n] = co_await stream.read_some(mutable_buffer(buf));
+
+        auto [wec, wn] = co_await write(stream, const_buffer(buf, n));
+
         if (ec)
             co_return;
-        
-        auto [wec, wn] = co_await write(stream, const_buffer(buf, n));
+
         if (wec)
             co_return;
     }

--- a/doc/modules/ROOT/pages/6.streams/6b.streams.adoc
+++ b/doc/modules/ROOT/pages/6.streams/6b.streams.adoc
@@ -28,13 +28,18 @@ template<MutableBufferSequence Buffers>
 IoAwaitable auto read_some(Buffers buffers);
 ----
 
-Returns an awaitable yielding `(error_code, std::size_t)`:
+Attempts to read up to `buffer_size(buffers)` bytes from the stream into the buffer sequence. Await-returns `(error_code, std::size_t)`:
 
-* On success: `!ec`, and `n >= 1` bytes were read
-* On error: `ec`, and `n == 0`
-* On EOF: `ec == cond::eof`, and `n == 0`
+If `buffer_size(buffers) > 0`:
 
-If `buffer_empty(buffers)` is true, completes immediately with `n == 0` and no error.
+* If `!ec`, then `n >= 1 && n \<= buffer_size(buffers)`. `n` bytes were read into the buffer sequence.
+* If `ec`, then `n >= 0 && n \<= buffer_size(buffers)`. `n` is the number of bytes read before the I/O condition arose.
+
+If `buffer_empty(buffers)` is true, `n` is 0. The empty buffer is not itself a cause for error, but `ec` may reflect the state of the stream.
+
+I/O conditions from the underlying system are reported via `ec`. Failures in the library itself (such as allocation failure) are reported via exceptions.
+
+*Throws:* `std::bad_alloc` if coroutine frame allocation fails.
 
 === Partial Transfer
 
@@ -45,7 +50,7 @@ If `buffer_empty(buffers)` is true, completes immediately with `n == 0` and no e
 char buf[1024];
 auto [ec, n] = co_await stream.read_some(mutable_buffer(buf));
 // n might be 1, might be 500, might be 1024
-// The only guarantee: if !ec && n > 0
+// if !ec, then n >= 1
 ----
 
 This matches underlying OS behavior—reads return when *some* data is available.
@@ -58,18 +63,15 @@ template<ReadStream Stream>
 task<> dump_stream(Stream& stream)
 {
     char buf[256];
-    
+
     for (;;)
     {
         auto [ec, n] = co_await stream.read_some(mutable_buffer(buf));
-        
-        if (ec == cond::eof)
-            break;  // End of stream
-        
-        if (ec)
-            throw std::system_error(ec);
-        
+
         std::cout.write(buf, n);
+
+        if (ec)
+            break;
     }
 }
 ----
@@ -95,12 +97,18 @@ template<ConstBufferSequence Buffers>
 IoAwaitable auto write_some(Buffers buffers);
 ----
 
-Returns an awaitable yielding `(error_code, std::size_t)`:
+Attempts to write up to `buffer_size(buffers)` bytes from the buffer sequence to the stream. Await-returns `(error_code, std::size_t)`:
 
-* On success: `!ec`, and `n >= 1` bytes were written
-* On error: `ec`, and `n == 0`
+If `buffer_size(buffers) > 0`:
 
-If `buffer_empty(buffers)` is true, completes immediately with `n == 0` and no error.
+* If `!ec`, then `n >= 1 && n \<= buffer_size(buffers)`. `n` bytes were written from the buffer sequence.
+* If `ec`, then `n >= 0 && n \<= buffer_size(buffers)`. `n` is the number of bytes written before the I/O condition arose.
+
+If `buffer_empty(buffers)` is true, `n` is 0. The empty buffer is not itself a cause for error, but `ec` may reflect the state of the stream.
+
+I/O conditions from the underlying system are reported via `ec`. Failures in the library itself (such as allocation failure) are reported via exceptions.
+
+*Throws:* `std::bad_alloc` if coroutine frame allocation fails.
 
 === Partial Transfer
 
@@ -191,20 +199,15 @@ task<> handle_connection(any_stream& stream)
     
     for (;;)
     {
-        // Read some data
         auto [ec, n] = co_await stream.read_some(mutable_buffer(buf));
-        
-        if (ec == cond::eof)
-            co_return;  // Client closed connection
-        
-        if (ec)
-            throw std::system_error(ec);
-        
-        // Echo it back
+
         auto [wec, wn] = co_await write(stream, const_buffer(buf, n));
-        
+
+        if (ec)
+            break;
+
         if (wec)
-            throw std::system_error(wec);
+            break;
     }
 }
 ----

--- a/doc/modules/ROOT/pages/6.streams/6c.sources-sinks.adoc
+++ b/doc/modules/ROOT/pages/6.streams/6c.sources-sinks.adoc
@@ -29,7 +29,7 @@ template<MutableBufferSequence Buffers>
 IoAwaitable auto read(Buffers buffers);
 ----
 
-Returns an awaitable yielding `(error_code, std::size_t)`:
+Await-returns `(error_code, std::size_t)`:
 
 * On success: `!ec`, and `n == buffer_size(buffers)` (buffer completely filled)
 * On EOF: `ec == cond::eof`, and `n` is bytes read before EOF (partial read)

--- a/doc/modules/ROOT/pages/6.streams/6d.buffer-concepts.adoc
+++ b/doc/modules/ROOT/pages/6.streams/6d.buffer-concepts.adoc
@@ -52,11 +52,11 @@ concept BufferSource =
 IoAwaitable auto pull(const_buffer* arr, std::size_t max_count);
 ----
 
-Returns an awaitable yielding `(error_code, std::size_t)`:
+Await-returns `(error_code, std::size_t)`:
 
-* On success: `!ec.failed()`, fills `arr[0..count-1]` with buffer descriptors
+* On success: `!ec`, fills `arr[0..count-1]` with buffer descriptors
 * On exhausted: `count == 0` indicates no more data
-* On error: `ec.failed()`
+* On error: `ec`
 
 The buffers point into the source's internal storage. You must consume all returned data before calling `pull()` again—the previous buffers become invalid.
 
@@ -73,7 +73,7 @@ task<> process_source(Source& source)
     {
         auto [ec, count] = co_await source.pull(bufs, 8);
         
-        if (ec.failed())
+        if (ec)
             throw std::system_error(ec);
         
         if (count == 0)
@@ -228,7 +228,7 @@ task<> decompress_stream(any_buffer_source& compressed, any_write_sink& output)
     for (;;)
     {
         auto [ec, count] = co_await compressed.pull(bufs, 8);
-        if (ec.failed())
+        if (ec)
             throw std::system_error(ec);
         if (count == 0)
             break;

--- a/doc/modules/ROOT/pages/6.streams/6e.algorithms.adoc
+++ b/doc/modules/ROOT/pages/6.streams/6e.algorithms.adoc
@@ -224,7 +224,7 @@ if (ec == cond::eof)
     // Normal completion
     std::cout << "Transferred " << total << " bytes\n";
 }
-else if (ec.failed())
+else if (ec)
 {
     // Error occurred
     std::cerr << "Error after " << total << " bytes: " << ec.message() << "\n";

--- a/doc/modules/ROOT/pages/6.streams/6f.isolation.adoc
+++ b/doc/modules/ROOT/pages/6.streams/6f.isolation.adoc
@@ -38,7 +38,7 @@ task<> handle_protocol(any_stream& stream)
     for (;;)
     {
         auto [ec, n] = co_await stream.read_some(mutable_buffer(buf));
-        if (ec.failed())
+        if (ec)
             co_return;
         
         // Process and respond...

--- a/doc/modules/ROOT/pages/7.examples/7d.mock-stream-testing.adoc
+++ b/doc/modules/ROOT/pages/7.examples/7d.mock-stream-testing.adoc
@@ -41,17 +41,19 @@ capy::task<bool> echo_line_uppercase(capy::any_stream& stream)
         // ec: std::error_code, n: std::size_t
         auto [ec, n] = co_await stream.read_some(capy::mutable_buffer(&c, 1));
 
+        if (n > 0)
+        {
+            if (c == '\n')
+                break;
+            line += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+        }
+
         if (ec)
         {
             if (ec == capy::cond::eof)
                 break;
             co_return false;
         }
-        
-        if (c == '\n')
-            break;
-        
-        line += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
     }
     
     line += '\n';
@@ -63,11 +65,11 @@ capy::task<bool> echo_line_uppercase(capy::any_stream& stream)
         // wec: std::error_code, wn: std::size_t
         auto [wec, wn] = co_await stream.write_some(
             capy::const_buffer(line.data() + written, line.size() - written));
-        
+
+        written += wn;
+
         if (wec)
             co_return false;
-        
-        written += wn;
     }
     
     co_return true;

--- a/doc/modules/ROOT/pages/7.examples/7e.type-erased-echo.adoc
+++ b/doc/modules/ROOT/pages/7.examples/7e.type-erased-echo.adoc
@@ -55,22 +55,15 @@ capy::task<> echo_session(capy::any_stream& stream)
 
     for (;;)
     {
-        // Read some data
-        // ec: std::error_code, n: std::size_t
         auto [ec, n] = co_await stream.read_some(capy::make_buffer(buffer));
 
-        if (ec == capy::cond::eof)
-            co_return;  // Client closed connection
-
-        if (ec)
-            throw std::system_error(ec);
-
-        // Echo it back
-        // wec: std::error_code, wn: std::size_t
         auto [wec, wn] = co_await capy::write(stream, capy::const_buffer(buffer, n));
 
+        if (ec)
+            co_return;
+
         if (wec)
-            throw std::system_error(wec);
+            co_return;
     }
 }
 

--- a/doc/modules/ROOT/pages/7.examples/7h.custom-dynamic-buffer.adoc
+++ b/doc/modules/ROOT/pages/7.examples/7h.custom-dynamic-buffer.adoc
@@ -155,17 +155,15 @@ capy::task<> read_into_tracked_buffer(capy::test::stream& stream, tracked_buffer
         auto space = buffer.prepare(256);  // mutable_buffer
         // ec: std::error_code, n: std::size_t
         auto [ec, n] = co_await stream.read_some(space);
-        
-        if (ec == capy::cond::eof)
-            break;
-        
-        if (ec)
-            throw std::system_error(ec);
-        
+
         buffer.commit(n);
-        
-        std::cout << "Read " << n << " bytes, buffer size now: " 
-                  << buffer.size() << "\n";
+
+        if (n > 0)
+            std::cout << "Read " << n << " bytes, buffer size now: "
+                      << buffer.size() << "\n";
+
+        if (ec)
+            break;
     }
 }
 

--- a/doc/modules/ROOT/pages/7.examples/7i.echo-server-corosio.adoc
+++ b/doc/modules/ROOT/pages/7.examples/7i.echo-server-corosio.adoc
@@ -34,11 +34,11 @@ capy::task<> echo_session(corosio::tcp_socket sock)
         auto [ec, n] = co_await sock.read_some(
             capy::mutable_buffer(buf, sizeof(buf)));
 
-        if (ec)
-            break;
-
         auto [wec, wn] = co_await capy::write(
             sock, capy::const_buffer(buf, n));
+
+        if (ec)
+            break;
 
         if (wec)
             break;

--- a/doc/modules/ROOT/pages/8.design/8a.CapyLayering.adoc
+++ b/doc/modules/ROOT/pages/8.design/8a.CapyLayering.adoc
@@ -42,7 +42,7 @@ task<> echo(any_stream& stream)
     {
         auto [ec, n] = co_await stream.read_some(
             mutable_buffer(buf));
-        if(ec.failed())
+        if(ec)
             co_return;
         co_await write(stream, const_buffer(buf, n));
     }

--- a/doc/modules/ROOT/pages/8.design/8c.ReadStream.adoc
+++ b/doc/modules/ROOT/pages/8.design/8c.ReadStream.adoc
@@ -23,20 +23,28 @@ A `ReadStream` provides a single operation:
 
 === `read_some(buffers)` -- Partial Read
 
-Reads one or more bytes from the stream into the buffer sequence. Returns `(error_code, std::size_t)` where `n` is the number of bytes read.
+Attempts to read up to `buffer_size(buffers)` bytes from the stream into the buffer sequence. Returns `(error_code, std::size_t)` where `n` is the number of bytes read.
 
 ==== Semantics
 
-- On success: `!ec`, `n >= 1` and `n \<= buffer_size(buffers)`.
-- On EOF: `ec == cond::eof`, `n == 0`.
-- On error: `ec`, `n == 0`.
-- If `buffer_empty(buffers)`: completes immediately, `!ec`, `n == 0`.
+If `buffer_size(buffers) > 0`:
+
+- If `!ec`, then `n >= 1 && n \<= buffer_size(buffers)`. `n` bytes were read into the buffer sequence.
+- If `ec`, then `n >= 0 && n \<= buffer_size(buffers)`. `n` is the number of bytes read before the I/O condition arose.
+
+If `buffer_empty(buffers)` is true, `n` is 0. The empty buffer is not itself a cause for error, but `ec` may reflect the state of the stream.
 
 The caller must not assume the buffer is filled. `read_some` may return fewer bytes than the buffer can hold. This is the defining property of a partial-read primitive.
 
 Once `read_some` returns an error (including EOF), the caller must not call `read_some` again. The stream is done. Not all implementations can reproduce a prior error on subsequent calls, so the behavior after an error is undefined.
 
-Buffers in the sequence are filled completely before proceeding to the next buffer in the sequence.
+Buffers in the sequence are filled in order.
+
+==== Error Reporting
+
+I/O conditions arising from the underlying I/O system (EOF, connection reset, broken pipe, etc.) are reported via the `error_code` component of the return value. Failures in the library wrapper itself (such as memory allocation failure) are reported via exceptions.
+
+*Throws:* `std::bad_alloc` if coroutine frame allocation fails.
 
 ==== Buffer Lifetime
 
@@ -165,14 +173,13 @@ task<> echo(Stream& stream, WriteStream auto& dest)
     {
         auto [ec, n] = co_await stream.read_some(
             mutable_buffer(buf));
-        if(ec == cond::eof)
-            co_return;
+
+        auto [wec, nw] = co_await dest.write_some(
+            const_buffer(buf, n));
+
         if(ec)
             co_return;
 
-        // Forward whatever we received immediately
-        auto [wec, nw] = co_await dest.write_some(
-            const_buffer(buf, n));
         if(wec)
             co_return;
     }
@@ -238,125 +245,86 @@ Because `ReadSource` refines `ReadStream`, this relay function also accepts `Rea
 | `WriteSink::write`
 |===
 
-== Design Foundations: Why Errors Exclude Data
+== Design Foundations: Why Errors May Accompany Data
 
-The `read_some` contract requires that `n` is 0 whenever `ec` is set. Data and errors are mutually exclusive outcomes. This is the most consequential design decision in the `ReadStream` concept, with implications for every consumer of `read_some` in the library. The rule follows Asio's established `AsyncReadStream` contract, is reinforced by the behavior of POSIX and Windows I/O system calls, and produces cleaner consumer code. This section explains the design and its consequences.
+The `read_some` contract permits `n > 0` when `ec` is set. Data and errors are not mutually exclusive: the implementation reports exactly what happened. This is the most consequential design decision in the `ReadStream` concept, with implications for every consumer of `read_some` in the library. This section explains the design and its consequences.
 
-=== Reconstructing Kohlhoff's Reasoning
+=== The Return Type's Purpose
 
-Christopher Kohlhoff's Asio library defines an `AsyncReadStream` concept with the identical requirement: on error, `bytes_transferred` is 0. No design rationale document accompanies this rule. The reasoning presented here was reconstructed from three sources:
+POSIX `read(2)` returns a single `ssize_t` -- either a byte count or -1 with `errno`. It cannot report both a byte count and an error simultaneously. When a partial transfer occurs before an error, POSIX returns the byte count on the current call and defers the error to the next. The `(error_code, size_t)` return type was designed to transcend this limitation. It can carry both values at once, allowing implementations to report partial transfers alongside the condition that stopped the transfer, as a single result.
 
-- *The Asio source code.* The function `non_blocking_recv1` in `socket_ops.ipp` explicitly sets `bytes_transferred = 0` on every error path. The function `complete_iocp_recv` maps Windows IOCP errors to portable error codes, relying on the operating system's guarantee that failed completions report zero bytes. These are deliberate choices, not accidental pass-through of OS behavior.
-- *A documentation note Kohlhoff left.* Titled "Why EOF is an error," it gives two reasons: composed operations need EOF-as-error to report contract violations, and EOF-as-error disambiguates the end of a stream from a successful zero-byte read. The note is terse but the implications are deep.
-- *Analysis of the underlying system calls.* POSIX `recv()` and Windows `WSARecv()` both enforce a binary outcome per call: data or error, never both. This is not because the {cpp} abstraction copied the OS, but because both levels face the same fundamental constraint.
+=== Departing from Asio
 
-The following sections examine each of these points and their consequences.
+Asio's `AsyncReadStream` concept requires `bytes_transferred == 0` on error. This was a reasonable design for an API built around POSIX-like streams, where the underlying system calls enforce binary outcomes per call. However, it imposes a burden on layered streams that do not share this limitation.
 
-=== Alignment with Asio
+A TLS stream might decrypt 100 bytes into user space, then receive a fatal alert on the next record. Under the strict rule it must either report `(!ec, 100)` now and `(ec, 0)` on the next call (requiring deferred-error bookkeeping), or report `(ec, 0)` and discard 100 valid bytes. Neither is clean. Under the relaxed rule, the TLS stream reports `(ec, 100)` honestly: here are the bytes that arrived, and here is the condition that stopped the transfer.
 
-Asio's `AsyncReadStream` concept has enforced the same rule for over two decades: on error, `bytes_transferred` is 0. This is a deliberate design choice, not an accident. The Asio source code explicitly zeroes `bytes_transferred` on every error path, and the underlying system calls (POSIX `recv()`, Windows IOCP) enforce binary outcomes at the OS level. The `read_some` contract follows this established practice.
+The `ReadStream` concept permits both behaviors. Streams that naturally produce `(ec, 0)` on error (such as POSIX socket wrappers) conform. Streams that report `(ec, n)` with `n > 0` (such as TLS or compression layers) also conform. The concept imposes the weakest postcondition that all conforming types can satisfy.
 
 === The Empty-Buffer Rule
 
-Every `ReadStream` must support the following:
+When `buffer_empty(buffers)` is true, `n` is 0. The empty buffer is not itself a cause for error, but `ec` may reflect the state of the stream.
 
-[quote]
-`read_some(empty_buffer)` completes immediately with `{success, 0}`.
+Whether the implementation performs a system call for a zero-length buffer is unspecified. A concrete type that short-circuits with `(!ec, 0)` conforms. A concrete type that forwards the zero-length call to the OS and reports whatever condition arises also conforms. The concept leaves this to the implementation.
 
-This is a no-op. The caller passed no buffer space, so no I/O is attempted. The operation does not inspect the stream's internal state because that would require a probe capability -- a way to ask "is there data? is the stream at EOF?" -- without actually reading. Not every source supports probing. A TCP socket does not know that its peer has closed until it calls `recv()` and gets 0 back. A pipe does not know it is broken until a read fails. The empty-buffer rule is therefore unconditional: return `{success, 0}` regardless of the stream's state.
-
-This rule is a natural consequence of the contract, not a proof of it. When no I/O is attempted, no state is discovered and no error is reported.
+This flexibility permits zero-length operations to serve as probes (fd validation, broken pipe detection) on implementations that support it, without the concept forbidding the resulting error.
 
 === Why EOF Is an Error
 
-Kohlhoff's documentation note gives two reasons for making EOF an error code rather than a success:
+EOF is reported as an error code (`cond::eof`) rather than as a success with `n == 0`, for two reasons:
 
-*Composed operations need EOF-as-error to report contract violations.* The composed `read(stream, buffer(buf, 100))` promises to fill exactly 100 bytes. If the stream ends after 50, the operation did not fulfill its contract. Reporting `{success, 50}` would be misleading -- it suggests the operation completed normally. Reporting `{eof, 50}` tells the caller both what happened (50 bytes landed in the buffer) and why the operation stopped (the stream ended). EOF-as-error is the mechanism by which composed operations explain early termination.
+*Composed operations need EOF-as-error to report early termination.* The composed `read(stream, buffer(buf, 100))` promises to fill exactly 100 bytes. If the stream ends after 50, the operation did not fulfill its contract. Reporting `{success, 50}` would be misleading. Reporting `{eof, 50}` tells the caller both what happened (50 bytes landed in the buffer) and why the operation stopped (the stream ended).
 
-*EOF-as-error disambiguates the empty-buffer no-op from the end of a stream.* Without EOF-as-error, both `read_some(empty_buffer)` on a live stream and `read_some(non_empty_buffer)` on an exhausted stream would produce `{success, 0}`. The caller could not distinguish "I passed no buffer" from "the stream is done." Making EOF an error code separates these two cases cleanly.
+*EOF-as-error disambiguates the empty-buffer case from the end of a stream.* Without EOF-as-error, both `read_some(empty_buffer)` on a live stream and `read_some(non_empty_buffer)` on an exhausted stream could produce `{success, 0}`. The caller could not distinguish "I passed no buffer" from "the stream is done."
 
-These two reasons reinforce each other. Composed operations need EOF to be an error code so they can report early termination. The empty-buffer rule needs EOF to be an error code so `{success, 0}` is unambiguously a no-op. Together with the rule that errors exclude data, `read_some` results form a clean trichotomy: success with data, or an error (including EOF) without data.
+=== The Canonical I/O Loop
 
-=== The Write-Side Asymmetry
-
-On the write side, `WriteSink` provides `write_eof(buffers)` to atomically combine the final data with the EOF signal. A natural question follows: if the write side fuses data with EOF, why does the read side forbid it?
-
-The answer is that the two sides of the I/O boundary have different roles. The writer _decides_ when to signal EOF. The reader _discovers_ it. This asymmetry has three consequences:
-
-*`write_eof` exists for correctness, not convenience.* Protocol framings require the final data and the EOF marker to be emitted together so the peer observes a complete message. HTTP chunked encoding needs the terminal `0\r\n\r\n` coalesced with the final data chunk. A TLS session needs the close-notify alert coalesced with the final application data. A compressor needs `Z_FINISH` applied to the final input. These are correctness requirements, not optimizations. On the read side, whether the last bytes arrive with EOF or on a separate call does not change what the reader observes. The data and the order are identical either way.
-
-*`write_eof` is a separate function the caller explicitly invokes.* `write_some` never signals EOF. The writer opts into data-plus-EOF by calling a different function. The call site reads `write_eof(data)` and the intent is unambiguous. If `read_some` could return data with EOF, every call to `read_some` would _sometimes_ be a data-only operation and _sometimes_ a data-plus-EOF operation. The stream decides which mode the caller gets, at runtime. Every call site must handle both possibilities. The burden falls on every consumer in the codebase, not on a single call site that opted into the combined behavior.
-
-*A hypothetical `read_eof` makes no sense.* On the write side, `write_eof` exists because the producer signals the end of data. On the read side, the consumer does not tell the stream to end -- it discovers that the stream has ended. EOF flows from producer to consumer, not the reverse. There is no action the reader can take to "read the EOF." The reader discovers EOF as a side effect of attempting to read.
-
-=== A Clean Trichotomy
-
-With the current contract, every `read_some` result falls into exactly one of three mutually exclusive cases:
-
-- **Success**: `!ec`, `n >= 1` -- data arrived, process it.
-- **EOF**: `ec == cond::eof`, `n == 0` -- stream ended, no data.
-- **Error**: `ec`, `n == 0` -- failure, no data.
-
-Data is present if and only if the operation succeeded. This invariant -- _data implies success_ -- eliminates an entire category of reasoning from every read loop. The common pattern is:
+Every composed read algorithm that accumulates progress follows the same pattern:
 
 [source,cpp]
 ----
-auto [ec, n] = co_await stream.read_some(buf);
+auto [ec, n] = co_await s.read_some(
+    mutable_buffer(buf + total, size - total));
+total += n;
 if(ec)
-    break;        // EOF or error -- no data to handle
-process(buf, n);  // only reached on success, n >= 1
+    co_return;
 ----
 
-If `read_some` could return `n > 0` with EOF, the loop becomes:
+The advance-then-check ordering is the only correct pattern. It is required for any operation that can report partial progress alongside an error -- `read` returning `(eof, 47)` being the canonical example. If the check precedes the advance, the 47 bytes are silently dropped.
 
-[source,cpp]
-----
-auto [ec, n] = co_await stream.read_some(buf);
-if(n > 0)
-    process(buf, n);  // must handle data even on EOF
-if(ec)
-    break;
-----
+Under the strict rule (`n == 0` on error), the advance is a harmless no-op. Under the relaxed rule (`n >= 0` on error), the advance captures partial progress. The caller writes identical code either way. The perceived simplification of the strict rule exists only if the caller writes the check-then-advance anti-pattern, which is already incorrect for other reasons.
 
-Every consumer pays this tax: an extra branch to handle data accompanying EOF. The branch is easy to forget. Forgetting it silently drops the final bytes of the stream -- a bug that only manifests when the source delivers EOF with its last data rather than on a separate call. A TCP socket receiving data in one packet and FIN in another will not trigger the bug. A memory source that knows its remaining length will. The non-determinism makes the bug difficult to reproduce and diagnose.
+=== Implementer Freedom
 
-The clean trichotomy eliminates this class of bugs entirely.
+Under the strict rule, every stream that might encounter an error after a partial transfer must choose between:
+
+- **Deferred errors.** Report `(!ec, k)` now, remember the error, and report `(ec, 0)` on the next call. This requires per-stream state and makes the stream's behavior depend on call history.
+- **Data loss.** Report `(ec, 0)` and discard the `k` bytes that were transferred.
+- **Internal buffering.** Copy the `k` bytes into an internal buffer and replay them on the next call. This adds allocation and copying overhead.
+
+Under the relaxed rule, the implementation reports what happened: `(ec, k)`. No deferred state, no data loss, no internal buffering.
+
+=== Consistency from Primitives Through Composed Operations
+
+The strict postcondition on `read_some` does not propagate to composed operations. The composed `read` returns `(ec, m)` where `m > 0` on failure, because it accumulates data across multiple internal `read_some` calls. The `(ec, n > 0)` case that the strict rule eliminates from `read_some` is immediately reintroduced one layer up.
+
+The relaxed postcondition avoids this inconsistency. Partial progress alongside an error code is the same pattern at every level -- from `read_some` through composed `read` -- rather than being forbidden at the primitive level and required at the composed level.
 
 === Conforming Sources
 
-Every concrete `ReadStream` implementation naturally separates its last data delivery from its EOF signal:
+Concrete `ReadStream` implementations are free to report `n == 0` or `n > 0` on error, whichever is natural:
 
-- **TCP sockets**: `read_some` maps to a single `recv()` or `WSARecv()` call, returning whatever the kernel has buffered. The kernel delivers bytes on one call and returns 0 on the next. The separation is inherent in the POSIX and Windows APIs.
-- **TLS streams**: `read_some` decrypts and returns one TLS record's worth of application data. The close-notify alert arrives as a separate record.
-- **HTTP content-length body**: the source delivers bytes up to the content-length limit. Once the limit is reached, the next `read_some` returns EOF.
+- **TCP sockets**: `read_some` maps to a single `recv()` or `WSARecv()` call. POSIX and Windows enforce binary outcomes, so these naturally produce `(ec, 0)` on error.
+- **TLS streams**: `read_some` decrypts application data. If a fatal alert arrives after decrypting a partial record, the implementation may report `(ec, n)` with the bytes that were decrypted.
+- **HTTP content-length body**: delivers bytes up to the content-length limit. Once the limit is reached, the next `read_some` returns EOF.
 - **HTTP chunked body**: the unchunker delivers decoded data from chunks. The terminal `0\r\n\r\n` is parsed on a separate pass that returns EOF.
-- **Compression (inflate)**: the decompressor delivers output bytes. When `Z_STREAM_END` is detected, the next read returns EOF.
-- **Memory source**: returns `min(requested, remaining)` bytes. When `remaining` reaches 0, the next call returns EOF.
-- **QUIC streams**: `read_some` returns data from received QUIC frames. Stream FIN is delivered as EOF on a subsequent call.
-- **Buffered read streams**: `read_some` returns data from an internal buffer, refilling from the underlying stream when empty. EOF propagates from the underlying stream.
+- **Compression (inflate)**: the decompressor delivers output bytes. `Z_STREAM_END` may arrive alongside the final output, allowing `(eof, n)` with the last bytes.
+- **Memory source**: returns `min(requested, remaining)` bytes. May report `(eof, n)` on the final call when remaining is known, or `(eof, 0)` on a subsequent call.
+- **QUIC streams**: `read_some` returns data from received QUIC frames. Stream FIN may arrive with the last data, allowing `(eof, n)`.
+- **Buffered read streams**: `read_some` returns data from an internal buffer. EOF propagates from the underlying stream.
 - **Test mock streams**: `read_some` returns configurable data and error sequences for testing.
 
-No source is forced into an unnatural pattern. The `read_some` call that discovers EOF is the natural result of attempting to read from an exhausted stream -- not a separate probing step. Once the caller receives EOF, it stops reading.
-
-=== Composed Operations and Partial Results
-
-The composed `read` algorithm (and `ReadSource::read`) _does_ report `n > 0` on EOF, because it accumulates data across multiple internal `read_some` calls. When the underlying stream signals EOF mid-accumulation, discarding the bytes already gathered would be wrong. The caller needs `n` to know how much valid data landed in the buffer.
-
-The design separates concerns cleanly: the single-shot primitive (`read_some`) delivers unambiguous results with a clean trichotomy. Composed operations that accumulate state (`read`) report what they accumulated, including partial results on EOF. Callers who need partial-on-EOF semantics get them through the composed layer, while the primitive layer remains clean.
-
-=== Evidence from the Asio Implementation
-
-The Asio source code confirms this design at every level.
-
-On POSIX platforms, `non_blocking_recv1` in `socket_ops.ipp` calls `recv()` and branches on the result. If `recv()` returns a positive value, the bytes are reported as a successful transfer. If `recv()` returns 0 on a stream socket, EOF is reported. If `recv()` returns -1, the function explicitly sets `bytes_transferred = 0` before returning the error. The POSIX `recv()` system call itself enforces binary outcomes: it returns `N > 0` on success, `0` on EOF, or `-1` on error. A single call never returns both data and an error.
-
-On Windows, `complete_iocp_recv` processes the results from `GetQueuedCompletionStatus`. It maps `ERROR_NETNAME_DELETED` to `connection_reset` and `ERROR_PORT_UNREACHABLE` to `connection_refused`. Windows IOCP similarly reports zero `bytes_transferred` on failed completions. The operating system enforces the same binary outcome per I/O completion.
-
-The one edge case is POSIX signal interruption (`EINTR`). If a signal arrives after `recv()` has already copied some bytes, the kernel returns the partial byte count as success rather than `-1`/`EINTR`. Asio handles this transparently by retrying on `EINTR`, so the caller never observes it. Even the kernel does not combine data with an error -- it chooses to report the partial data as success.
-
-=== Convergent Design with POSIX
-
-POSIX `recv()` independently enforces the same rule: `N > 0` on success, `-1` on error, `0` on EOF. The kernel never returns "here are your last 5 bytes, and also EOF." It delivers the available bytes on one call and returns 0 on the next. This is not because the {cpp} abstraction copied POSIX semantics. It is because the kernel faces the same fundamental constraint: state is discovered through the act of I/O. The alignment between `read_some` and `recv()` is convergent design, not leaky abstraction.
+No source is forced into an unnatural pattern. Sources that naturally separate data from errors continue to do so. Sources that naturally discover errors alongside data are free to report both.
 
 == Summary
 
@@ -367,4 +335,4 @@ POSIX `recv()` independently enforces the same rule: `N > 0` on success, `-1` on
 - Algorithms that need to process data as it arrives use `read_some` directly.
 - `ReadSource` refines `ReadStream` by adding `read` for complete-read semantics.
 
-The contract that errors exclude data follows Asio's established `AsyncReadStream` contract, aligns with POSIX and Windows system call semantics, and produces a clean trichotomy that makes every read loop safe by construction.
+The contract permits errors to accompany partial data. This uses the richer `(error_code, size_t)` return type to its full potential, avoids forcing non-POSIX streams into a deferred-error model, and produces a postcondition that is consistent from `read_some` through composed operations. The canonical advance-then-check loop handles both cases correctly with no additional call-site cost.

--- a/doc/modules/ROOT/pages/8.design/8d.ReadSource.adoc
+++ b/doc/modules/ROOT/pages/8.design/8d.ReadSource.adoc
@@ -24,14 +24,16 @@ concept ReadSource =
 
 === `read_some(buffers)` -- Partial Read (inherited from `ReadStream`)
 
-Reads one or more bytes from the source into the buffer sequence. Returns `(error_code, std::size_t)` where `n` is the number of bytes read. May return fewer bytes than the buffer can hold.
+Attempts to read up to `buffer_size(buffers)` bytes from the source into the buffer sequence. Returns `(error_code, std::size_t)` where `n` is the number of bytes read. May return fewer bytes than the buffer can hold.
 
 ==== Semantics
 
-- On success: `!ec`, `n >= 1` and `n \<= buffer_size(buffers)`.
-- On EOF: `ec == cond::eof`, `n == 0`.
-- On error: `ec`, `n == 0`.
-- If `buffer_empty(buffers)`: completes immediately, `!ec`, `n == 0`.
+If `buffer_size(buffers) > 0`:
+
+- If `!ec`, then `n >= 1 && n \<= buffer_size(buffers)`. `n` bytes were read into the buffer sequence.
+- If `ec`, then `n >= 0 && n \<= buffer_size(buffers)`. `n` is the number of bytes read before the I/O condition arose.
+
+If `buffer_empty(buffers)` is true, `n` is 0. The empty buffer is not itself a cause for error, but `ec` may reflect the state of the source.
 
 Once `read_some` returns an error (including EOF), the caller must not call `read_some` again. The stream is done. Not all implementations can reproduce a prior error on subsequent calls, so the behavior after an error is undefined.
 
@@ -298,17 +300,19 @@ task<> relay(Src& src, Sink& dest)
     {
         auto [ec, n] = co_await src.read_some(
             mutable_buffer(buf));
+
+        auto [wec, nw] = co_await dest.write(
+            const_buffer(buf, n));
+
+        if(wec)
+            co_return;
+
         if(ec == cond::eof)
         {
             auto [wec] = co_await dest.write_eof();
             co_return;
         }
         if(ec)
-            co_return;
-
-        auto [wec, nw] = co_await dest.write(
-            const_buffer(buf, n));
-        if(wec)
             co_return;
     }
 }
@@ -346,16 +350,16 @@ Examples of types that satisfy `ReadSource`:
 - **File source**: `read_some` is a single `read()` syscall. `read` loops until the buffer is filled or EOF.
 - **Memory source**: `read_some` returns available bytes. `read` fills the buffer from the memory region.
 
-== Why `read_some` Returns No Data on EOF
+== Errors May Accompany Data
 
-The `read_some` contract (inherited from `ReadStream`) requires that when `ec == cond::eof`, `n` is always 0. Data and EOF are delivered in separate calls. See xref:8.design/8a.ReadStream.adoc#_design_foundations_why_errors_exclude_data[ReadStream: Why Errors Exclude Data] for the full rationale. The key points:
+The `read_some` contract (inherited from `ReadStream`) permits `n > 0` when `ec` is set, including on EOF. The implementation reports exactly what happened: the bytes that arrived and the condition that stopped the transfer. See xref:8.design/8c.ReadStream.adoc#_design_foundations_why_errors_may_accompany_data[ReadStream: Why Errors May Accompany Data] for the full rationale. The key points:
 
-- The clean trichotomy (success/EOF/error, where data implies success) eliminates an entire class of bugs where callers accidentally drop the final bytes of a stream.
-- Write-side atomicity (`write_eof(buffers)`) serves correctness for protocol framing. Read-side piggybacking would be a minor optimization with significant API cost.
-- Every concrete source type naturally separates its last data delivery from its EOF indication.
-- POSIX `read()` follows the same model.
+- The `(error_code, size_t)` return type can carry both values simultaneously, transcending the POSIX limitation of reporting only one per call.
+- Layered streams (TLS, compression) may encounter an error after a partial transfer. Allowing `(ec, n)` with `n > 0` avoids forcing deferred-error bookkeeping or data loss.
+- The canonical advance-then-check loop handles both cases correctly with no additional call-site cost.
+- Concrete types that naturally produce `(ec, 0)` on error (POSIX socket wrappers) continue to do so.
 
-This contract carries over to `ReadSource` unchanged. The `read` member function (complete read) _does_ allow `n > 0` on EOF, because it is a composed loop that accumulates data across multiple internal `read_some` calls. When the underlying stream signals EOF mid-accumulation, discarding the bytes already gathered would be wrong. The caller needs `n` to know how much valid data landed in the buffer.
+This contract carries over to `ReadSource` unchanged. Both `read_some` and `read` allow `n > 0` on error or EOF, reporting the bytes that were transferred before the condition arose.
 
 == Summary
 
@@ -370,7 +374,7 @@ This contract carries over to `ReadSource` unchanged. The `read` member function
 | Function | Contract | Use Case
 
 | `ReadSource::read_some`
-| Returns one or more bytes. May fill less than the buffer.
+| Attempts to read up to `buffer_size(buffers)` bytes. May fill less than the buffer.
 | Relays, low-latency forwarding, incremental processing.
 
 | `ReadSource::read`

--- a/doc/modules/ROOT/pages/8.design/8f.WriteStream.adoc
+++ b/doc/modules/ROOT/pages/8.design/8f.WriteStream.adoc
@@ -23,15 +23,24 @@ A `WriteStream` provides a single operation:
 
 === `write_some(buffers)` -- Partial Write
 
-Writes one or more bytes from the buffer sequence. Returns `(error_code, std::size_t)` where `n` is the number of bytes written.
+Attempts to write up to `buffer_size(buffers)` bytes from the buffer sequence to the stream. Returns `(error_code, std::size_t)` where `n` is the number of bytes written.
 
 ==== Semantics
 
-- On success: `!ec`, `n >= 1` and `n \<= buffer_size(buffers)`.
-- On error: `ec`, `n == 0`.
-- If `buffer_empty(buffers)`: completes immediately, `!ec`, `n == 0`.
+If `buffer_size(buffers) > 0`:
+
+- If `!ec`, then `n >= 1 && n \<= buffer_size(buffers)`. `n` bytes were written from the buffer sequence.
+- If `ec`, then `n >= 0 && n \<= buffer_size(buffers)`. `n` is the number of bytes written before the I/O condition arose.
+
+If `buffer_empty(buffers)` is true, `n` is 0. The empty buffer is not itself a cause for error, but `ec` may reflect the state of the stream.
 
 The caller must not assume that all bytes are consumed. `write_some` may write fewer bytes than offered. This is the defining property of a partial-write primitive.
+
+==== Error Reporting
+
+I/O conditions arising from the underlying I/O system (connection reset, broken pipe, etc.) are reported via the `error_code` component of the return value. Failures in the library wrapper itself (such as memory allocation failure) are reported via exceptions.
+
+*Throws:* `std::bad_alloc` if coroutine frame allocation fails.
 
 ==== Buffer Lifetime
 

--- a/doc/modules/ROOT/pages/8.design/8g.WriteSink.adoc
+++ b/doc/modules/ROOT/pages/8.design/8g.WriteSink.adoc
@@ -48,15 +48,18 @@ concept WriteSink =
 
 === `write_some(buffers)` -- Partial Write
 
-Writes one or more bytes from the buffer sequence. May consume less than the full sequence. Returns `(error_code, std::size_t)` where `n` is the number of bytes written.
+Attempts to write up to `buffer_size(buffers)` bytes from the buffer sequence to the stream. May consume less than the full sequence. Returns `(error_code, std::size_t)` where `n` is the number of bytes written.
 
 This is the low-level primitive inherited from `WriteStream`. It is appropriate when the caller manages its own consumption loop or when forwarding data incrementally without needing a complete-write guarantee.
 
 ==== Semantics
 
-- On success: `!ec`, `n >= 1`.
-- On error: `ec`, `n == 0`.
-- If `buffer_empty(buffers)`: completes immediately, `!ec`, `n == 0`.
+If `buffer_size(buffers) > 0`:
+
+- If `!ec`, then `n >= 1 && n \<= buffer_size(buffers)`. `n` bytes were written from the buffer sequence.
+- If `ec`, then `n >= 0 && n \<= buffer_size(buffers)`. `n` is the number of bytes written before the I/O condition arose.
+
+If `buffer_empty(buffers)` is true, `n` is 0. The empty buffer is not itself a cause for error, but `ec` may reflect the state of the stream.
 
 ==== When to Use
 
@@ -177,16 +180,8 @@ task<> relay(Source& src, Sink& dest)
     {
         auto [ec, n] = co_await src.read_some(
             mutable_buffer(buf));
-        if(ec == cond::eof)
-        {
-            // Signal EOF to the destination
-            auto [ec2] = co_await dest.write_eof();
-            co_return;
-        }
-        if(ec)
-            co_return;
 
-        // Interior: partial write is acceptable
+        // Forward whatever arrived before checking the error
         std::size_t written = 0;
         while(written < n)
         {
@@ -196,11 +191,19 @@ task<> relay(Source& src, Sink& dest)
                 co_return;
             written += n2;
         }
+
+        if(ec == cond::eof)
+        {
+            auto [ec2] = co_await dest.write_eof();
+            co_return;
+        }
+        if(ec)
+            co_return;
     }
 }
 ----
 
-The interior loop uses `write_some` because the relay does not need complete-write guarantees for intermediate data. When `read_some` returns EOF, `n` is 0 (per the `ReadStream` contract), so the relay signals EOF via `write_eof()` with no data.
+The interior loop uses `write_some` because the relay does not need complete-write guarantees for intermediate data. When `read_some` returns EOF, any partial bytes are forwarded first, then the relay signals EOF via `write_eof()` with no data.
 
 === Writing Complete Messages
 
@@ -352,7 +355,7 @@ A three-level hierarchy was considered, with an intermediate concept (`WriteClos
 | Function | Contract | Use Case
 
 | `write_some(buffers)`
-| Writes one or more bytes. May consume less than the full sequence.
+| Attempts to write up to `buffer_size(buffers)` bytes. May consume less than the full sequence.
 | Relay interiors, backpressure, implementing composed algorithms.
 
 | `write(buffers)`

--- a/doc/modules/ROOT/pages/8.design/8n.WhyNotCobaltConcepts.adoc
+++ b/doc/modules/ROOT/pages/8.design/8n.WhyNotCobaltConcepts.adoc
@@ -298,17 +298,22 @@ Capy's `WriteStream` concept includes semantic requirements in the concept's doc
 
 // Semantic Requirements:
 //
-// If buffer_size( buffers ) > 0, the operation writes one or more
-// bytes of data to the stream from the buffer sequence:
+// Attempts to write up to buffer_size( buffers ) bytes from
+// the buffer sequence to the stream.
 //
-//   On success: !ec, and n is the number of bytes written.
-//   On error: ec, and n is 0.
+// If buffer_size( buffers ) > 0:
 //
-// If buffer_empty( buffers ) is true, the operation completes
-// immediately. !ec, and n is 0.
+//   If !ec, then n >= 1 && n <= buffer_size( buffers ).
+//     n bytes were written from the buffer sequence.
+//   If ec, then n >= 0 && n <= buffer_size( buffers ).
+//     n is the number of bytes written before the I/O
+//     condition arose.
 //
-// Buffers in the sequence are written completely before proceeding
-// to the next buffer.
+// If buffer_empty( buffers ) is true, n is 0. The empty
+// buffer is not itself a cause for error, but ec may reflect
+// the state of the stream.
+//
+// Buffers in the sequence are consumed in order.
 //
 // Buffer Lifetime:
 //
@@ -336,7 +341,7 @@ The concept also includes a coroutine-specific warning about buffer lifetime:
 |
 
 | Error reporting semantics
-| Documented (`ec` + `n == 0`)
+| Documented (`ec` + `n >= 0 && n \<= buffer_size`)
 |
 
 | Partial write guarantees
@@ -395,7 +400,7 @@ ____
 
 The documentation describes the mechanical role of each function pointer but does not specify what the `implementation` function must do with the buffer, what completion semantics to follow, how to report errors through the `completion_handler`, or under what conditions `try_implementation` should complete synchronously. Implementors can look to the existing I/O wrappers (e.g., `stream_socket`) as reference implementations.
 
-In Capy, the implementation contract lives in the `WriteStream` concept definition. A type satisfies `WriteStream` by providing a `write_some` member function template that returns an `IoAwaitable` decomposing to `(error_code, std::size_t)`. The semantic requirements are part of the concept. There is no separate operation type to construct and no function pointers to provide.
+In Capy, the implementation contract lives in the `WriteStream` concept definition. A type satisfies `WriteStream` by providing a `write_some` member function template that await-returns `(error_code, std::size_t)`. The semantic requirements are part of the concept. There is no separate operation type to construct and no function pointers to provide.
 
 [cols="1,1,1"]
 |===

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -87,10 +87,13 @@ task<> echo(any_stream& stream)
     for(;;)
     {
         auto [ec, n] = co_await stream.read_some(mutable_buffer(buf));
-        if(ec.failed())
-            co_return;
+
         auto [wec, wn] = co_await write(stream, const_buffer(buf, n));
-        if(wec.failed())
+
+        if(ec)
+            co_return;
+
+        if(wec)
             co_return;
     }
 }

--- a/doc/read-some-rationale.md
+++ b/doc/read-some-rationale.md
@@ -9,17 +9,22 @@ permit `n >= 0` on error. A secondary question is the behavior when the
 caller passes a zero-length buffer. The analysis applies symmetrically
 to `WriteStream::write_some`.
 
+The consensus was reached through discussion between Peter Dimov and
+Andrzej Krzemieński, whose arguments shaped both the postcondition
+choice (E2) and the zero-length buffer semantics (Z3).
+
 ## Current Consensus
 
-The current consensus declares the `ReadStream` and `WriteStream`
-concepts with the following contracts:
+The current consensus adopts E2 (error permits `n >= 0`) and Z3
+(empty buffers are not an error). The `ReadStream` and `WriteStream`
+concepts are declared with the following contracts:
 
 ```cpp
 /** Concept for types providing awaitable read operations.
 
     A type satisfies ReadStream if it provides a read_some
     member function template that accepts any MutableBufferSequence
-    and is an IoAwaitable yielding (error_code, std::size_t).
+    and await-returns (error_code, std::size_t).
 
     Semantic Requirements:
 
@@ -28,9 +33,9 @@ concepts with the following contracts:
 
     If buffer_size( buffers ) > 0:
 
-    - If !ec, then 1 <= n <= buffer_size( buffers ). n bytes
+    - If !ec, then n >= 1 && n <= buffer_size( buffers ). n bytes
       were read into the buffer sequence.
-    - If ec, then 0 <= n <= buffer_size( buffers ). n is the
+    - If ec, then n >= 0 && n <= buffer_size( buffers ). n is the
       number of bytes read before the I/O condition arose.
 
     If buffer_empty( buffers ) is true, n is 0. The empty buffer
@@ -38,6 +43,16 @@ concepts with the following contracts:
     of the stream.
 
     Buffers in the sequence are filled in order.
+
+    Error Reporting:
+
+    I/O conditions arising from the underlying I/O system (EOF,
+    connection reset, broken pipe, etc.) are reported via the
+    error_code component of the return value. Failures in the
+    library wrapper itself (such as memory allocation failure)
+    are reported via exceptions.
+
+    Throws: std::bad_alloc if coroutine frame allocation fails.
 */
 template< typename T >
 concept ReadStream =
@@ -55,7 +70,7 @@ concept ReadStream =
 
     A type satisfies WriteStream if it provides a write_some
     member function template that accepts any ConstBufferSequence
-    and is an IoAwaitable yielding (error_code, std::size_t).
+    and await-returns (error_code, std::size_t).
 
     Semantic Requirements:
 
@@ -64,9 +79,9 @@ concept ReadStream =
 
     If buffer_size( buffers ) > 0:
 
-    - If !ec, then 1 <= n <= buffer_size( buffers ). n bytes
+    - If !ec, then n >= 1 && n <= buffer_size( buffers ). n bytes
       were written from the buffer sequence.
-    - If ec, then 0 <= n <= buffer_size( buffers ). n is the
+    - If ec, then n >= 0 && n <= buffer_size( buffers ). n is the
       number of bytes written before the I/O condition arose.
 
     If buffer_empty( buffers ) is true, n is 0. The empty buffer
@@ -74,6 +89,16 @@ concept ReadStream =
     of the stream.
 
     Buffers in the sequence are consumed in order.
+
+    Error Reporting:
+
+    I/O conditions arising from the underlying I/O system (EOF,
+    connection reset, broken pipe, etc.) are reported via the
+    error_code component of the return value. Failures in the
+    library wrapper itself (such as memory allocation failure)
+    are reported via exceptions.
+
+    Throws: std::bad_alloc if coroutine frame allocation fails.
 */
 template< typename T >
 concept WriteStream =
@@ -86,6 +111,13 @@ concept WriteStream =
     };
 ```
 
+E2 is also chosen for consistency: composed operations like `read`
+return partial progress alongside errors by necessity (there is no
+other way to report how many bytes were transferred before EOF). If
+`read_some` adopted E1, callers would need one loop style for
+`read_some` and a different one for `read`. Under E2, the same
+advance-then-check pattern is correct everywhere.
+
 The rationale for these choices follows.
 
 ## Background
@@ -93,9 +125,9 @@ The rationale for these choices follows.
 ### The read_some Contract
 
 `read_some` accepts a buffer sequence and returns `(error_code, size_t)`.
-The success case is uncontroversial:
+When `buffer_size(buffers) > 0`, the non-error case is uncontroversial:
 
-- **Success:** `!ec`, and `n >= 1` (at least one byte transferred).
+- **No error:** `!ec`, and `n >= 1` (at least one byte transferred).
 
 The disputes concern the error case and the empty-buffer case.
 

--- a/doc/unlisted/buffers-index.adoc
+++ b/doc/unlisted/buffers-index.adoc
@@ -182,7 +182,7 @@ task<void> receive_message(ReadStream auto& stream)
 {
     char header[4];
     auto [ec, n] = co_await read(stream, mutable_buffer(header, 4));
-    if (ec.failed())
+    if (ec)
         co_return;
 
     // Parse length from header
@@ -191,7 +191,7 @@ task<void> receive_message(ReadStream auto& stream)
     // Read the body
     std::vector<char> body(len);
     auto [ec2, n2] = co_await read(stream, make_buffer(body));
-    if (ec2.failed())
+    if (ec2)
         co_return;
 
     process_message(body);
@@ -209,7 +209,7 @@ task<void> send_response(WriteStream auto& stream, std::string_view body)
         + std::to_string(body.size()) + "\r\n\r\n";
 
     auto [ec1, n1] = co_await write(stream, make_buffer(headers));
-    if (ec1.failed())
+    if (ec1)
         co_return;
 
     // Write body
@@ -232,11 +232,11 @@ task<void> echo_loop(ReadStream auto& in, WriteStream auto& out)
         auto [ec1, n] = co_await in.read_some(make_buffer(buffer));
         if (ec1 == cond::eof)
             break;
-        if (ec1.failed())
+        if (ec1)
             co_return;
 
         auto [ec2, written] = co_await write(out, make_buffer(buffer, n));
-        if (ec2.failed())
+        if (ec2)
             co_return;
     }
 }

--- a/doc/unlisted/library-buffers.adoc
+++ b/doc/unlisted/library-buffers.adoc
@@ -35,14 +35,14 @@ task<void> echo(ReadStream auto& in, WriteStream auto& out)
     for (;;)
     {
         auto [ec1, n] = co_await in.read_some(make_buffer(buffer));
-        if (ec1 == cond::eof)
-            break;
-        if (ec1.failed())
-            co_return;
 
         auto [ec2, _] = co_await write(out, make_buffer(buffer, n));
-        if (ec2.failed())
-            co_return;
+
+        if (ec1)
+            break;
+
+        if (ec2)
+            break;
     }
 }
 ----

--- a/doc/unlisted/library-io-result.adoc
+++ b/doc/unlisted/library-io-result.adoc
@@ -52,7 +52,7 @@ Explicit, but:
 
 // Returns error code + bytes transferred
 auto [ec, n] = co_await stream.read_some(buffer);
-if (ec.failed())
+if (ec)
     handle_error(ec);
 process_data(buffer, n);
 ----
@@ -75,7 +75,7 @@ Operations that succeed or fail without a result value:
 [source,cpp]
 ----
 auto [ec] = co_await socket.connect(endpoint);
-if (ec.failed())
+if (ec)
     co_return handle_connection_error(ec);
 ----
 
@@ -86,7 +86,7 @@ Operations returning a single value, like bytes transferred:
 [source,cpp]
 ----
 auto [ec, n] = co_await stream.read_some(buffer);
-if (ec.failed())
+if (ec)
     co_return;
 buffer.commit(n);  // n bytes were read
 ----
@@ -138,7 +138,7 @@ io_result<>                      → [ec]
 [source,cpp]
 ----
 auto [ec, n] = co_await stream.read_some(buffer);
-if (ec.failed())
+if (ec)
 {
     log_error(ec);
     co_return;  // Or throw, or return error
@@ -151,7 +151,7 @@ if (ec.failed())
 [source,cpp]
 ----
 auto [ec, n] = co_await stream.read_some(buffer);
-if (ec.failed() && ec != error::operation_aborted)
+if (ec && ec != error::operation_aborted)
 {
     // Handle unexpected errors
     throw system_error(ec);
@@ -164,7 +164,7 @@ if (ec.failed() && ec != error::operation_aborted)
 [source,cpp]
 ----
 auto [ec, n] = co_await stream.read_some(buffer);
-if (ec.failed())
+if (ec)
     throw system_error(ec);
 ----
 
@@ -180,7 +180,7 @@ io_task<std::size_t> read_all(stream& s, buffer& buf)
     while (buf.size() < buf.max_size())
     {
         auto [ec, n] = co_await s.read_some(buf.prepare(1024));
-        if (ec.failed())
+        if (ec)
             co_return {ec, total};  // Return partial progress
         buf.commit(n);
         total += n;
@@ -213,7 +213,7 @@ common) and exceptions for programmer errors (bugs, invariant violations).
 [source,cpp]
 ----
 auto [ec, n] = co_await stream.read_some(buffer);
-if (ec.failed())
+if (ec)
     throw system_error(ec, "read failed");
 // Continue...
 ----
@@ -226,7 +226,7 @@ template<typename... Args>
 auto throw_on_error(io_result<Args...> result)
 {
     auto& [ec, rest...] = result;
-    if (ec.failed())
+    if (ec)
         throw system_error(ec);
     return std::tie(rest...);
 }
@@ -248,7 +248,7 @@ task<void> read_all(stream& s, dynamic_buffer& buf)
         auto [ec, n] = co_await s.read_some(buf.prepare(1024));
         if (ec == error::end_of_stream)
             co_return;  // Normal completion
-        if (ec.failed())
+        if (ec)
             throw system_error(ec);
         buf.commit(n);
     }
@@ -264,7 +264,7 @@ io_task<> write_with_retry(stream& s, const_buffer data, int retries)
     for (int i = 0; i < retries; ++i)
     {
         auto [ec, n] = co_await s.write_some(data);
-        if (!ec.failed())
+        if (!ec)
         {
             data += n;
             if (data.size() == 0)
@@ -300,7 +300,7 @@ io_task<> write_with_retry(stream& s, const_buffer data, int retries)
 | `auto [ec, n] = ...`
 
 | Error check
-| `ec.failed()` (not `ec` or `!!ec`)
+| `if(ec)` or `if(!ec)`
 |===
 
 == Next Steps

--- a/doc/unlisted/library-streams.adoc
+++ b/doc/unlisted/library-streams.adoc
@@ -107,7 +107,7 @@ concept ReadStream = requires(T& stream, MutableBufferSequence auto buffers)
 
 ==== Behavior
 
-`read_some()` reads **at least one byte** (unless EOF or error) but may
+`read_some()` attempts to read up to `buffer_size(buffers)` bytes but may
 read fewer bytes than the buffer can hold:
 
 [source,cpp]
@@ -121,9 +121,12 @@ This matches OS behavior: `recv()` returns whatever data is currently available.
 
 ==== Return Values
 
-* **Success**: `!ec.failed()` is true, `n >= 1`
-* **EOF**: `ec == cond::eof`, `n == 0`
-* **Error**: `ec.failed()` is true, `n == 0`
+If `buffer_size(buffers) > 0`:
+
+* If `!ec`: `n >= 1 && n \<= buffer_size(buffers)`. `n` bytes were read.
+* If `ec`: `n >= 0 && n \<= buffer_size(buffers)`. `n` is the number of bytes read before the I/O condition arose.
+
+If `buffer_empty(buffers)` is true, `n` is 0. The empty buffer is not itself a cause for error, but `ec` may reflect the state of the stream.
 
 ==== Example
 
@@ -133,7 +136,7 @@ task<std::string> read_available(ReadStream auto& stream)
 {
     char buffer[4096];
     auto [ec, n] = co_await stream.read_some(make_buffer(buffer));
-    if (ec.failed())
+    if (ec)
         co_return {};
     co_return std::string(buffer, n);
 }
@@ -157,7 +160,7 @@ concept WriteStream = requires(T& stream, ConstBufferSequence auto buffers)
 
 ==== Behavior
 
-`write_some()` writes **at least one byte** (unless error) but may write
+`write_some()` attempts to write up to `buffer_size(buffers)` bytes but may write
 fewer bytes than provided:
 
 [source,cpp]
@@ -172,8 +175,12 @@ kernel buffers are constrained.
 
 ==== Return Values
 
-* **Success**: `!ec.failed()` is true, `n >= 1`
-* **Error**: `ec.failed()` is true, `n == 0`
+If `buffer_size(buffers) > 0`:
+
+* If `!ec`: `n >= 1 && n \<= buffer_size(buffers)`. `n` bytes were written.
+* If `ec`: `n >= 0 && n \<= buffer_size(buffers)`. `n` is the number of bytes written before the I/O condition arose.
+
+If `buffer_empty(buffers)` is true, `n` is 0. The empty buffer is not itself a cause for error, but `ec` may reflect the state of the stream.
 
 ==== Example
 
@@ -182,7 +189,7 @@ kernel buffers are constrained.
 task<> write_chunk(WriteStream auto& stream, std::string_view data)
 {
     auto [ec, n] = co_await stream.write_some(make_buffer(data));
-    if (ec.failed())
+    if (ec)
         co_return;
     // Only n bytes were written; caller must handle remainder
 }
@@ -222,9 +229,9 @@ auto [ec, n] = co_await source.read(mutable_buffer(header, 16));
 
 ==== Return Values
 
-* **Success**: `!ec.failed()` is true, `n == buffer_size(buffers)`
+* **Success**: `!ec`, `n == buffer_size(buffers)`
 * **EOF**: `ec == cond::eof`, `n` is bytes read before EOF
-* **Error**: `ec.failed()` is true, `n` is bytes read before error
+* **Error**: `ec`, `n` is bytes read before error
 
 ==== Example
 
@@ -234,7 +241,7 @@ task<std::vector<char>> read_exact(ReadSource auto& source, std::size_t count)
 {
     std::vector<char> result(count);
     auto [ec, n] = co_await source.read(make_buffer(result));
-    if (ec.failed())
+    if (ec)
         co_return {};
     co_return result;
 }
@@ -285,8 +292,8 @@ are permitted.
 
 ==== Return Values
 
-* **Success**: `!ec.failed()` is true, `n == buffer_size(buffers)`
-* **Error**: `ec.failed()` is true, `n` is bytes written before error
+* **Success**: `!ec`, `n == buffer_size(buffers)`
+* **Error**: `ec`, `n` is bytes written before error
 
 Reference: `<boost/capy/concept/write_sink.hpp>`
 
@@ -324,9 +331,9 @@ auto [ec, count] = co_await source.pull(arr, 16);
 
 ==== Return Values
 
-* **Data available**: `!ec.failed()` is true, `count > 0`
-* **Source exhausted**: `!ec.failed()` is true, `count == 0`
-* **Error**: `ec.failed()` is true
+* **Data available**: `!ec`, `count > 0`
+* **Source exhausted**: `!ec`, `count == 0`
+* **Error**: `ec`
 
 ==== Buffer Lifetime
 
@@ -344,7 +351,7 @@ task<> consume_all(BufferSource auto& source)
     for (;;)
     {
         auto [ec, count] = co_await source.pull(arr, 16);
-        if (ec.failed())
+        if (ec)
             co_return;
         if (count == 0)
             break;  // Source exhausted
@@ -418,7 +425,7 @@ task<> produce_data(BufferSink auto& sink, std::string_view data)
         {
             // No space; flush and retry
             auto [ec] = co_await sink.commit(0);
-            if (ec.failed())
+            if (ec)
                 co_return;
             continue;
         }
@@ -434,7 +441,7 @@ task<> produce_data(BufferSink auto& sink, std::string_view data)
         }
 
         auto [ec] = co_await sink.commit(written);
-        if (ec.failed())
+        if (ec)
             co_return;
     }
 
@@ -633,11 +640,11 @@ task<> echo(any_stream& stream)
         auto [ec, n] = co_await stream.read_some(make_buffer(buffer));
         if (ec == cond::eof)
             break;
-        if (ec.failed())
+        if (ec)
             co_return;
 
         auto [wec, wn] = co_await write(stream, make_buffer(buffer, n));
-        if (wec.failed())
+        if (wec)
             co_return;
     }
 }
@@ -706,12 +713,12 @@ task<> echo_server(any_stream& stream)
         auto [ec, n] = co_await stream.read_some(make_buffer(buffer));
         if (ec == cond::eof)
             break;
-        if (ec.failed())
+        if (ec)
             co_return;
 
         // Complete write: send all bytes
         auto [wec, _] = co_await write(stream, make_buffer(buffer, n));
-        if (wec.failed())
+        if (wec)
             co_return;
     }
 }
@@ -725,7 +732,7 @@ task<> send_response_body(any_write_sink& body, std::string_view content)
 {
     // Write all content and signal EOF
     auto [ec, n] = co_await body.write(make_buffer(content), true);
-    if (ec.failed())
+    if (ec)
     {
         // Handle error
     }

--- a/doc/unlisted/library-testing.adoc
+++ b/doc/unlisted/library-testing.adoc
@@ -93,11 +93,11 @@ Systematic error injection that tests every failure path:
 fuse f;
 auto r = f.armed([](fuse& f) {
     auto ec = f.maybe_fail();
-    if (ec.failed())
+    if (ec)
         return;  // Exit on injected error
 
     ec = f.maybe_fail();
-    if (ec.failed())
+    if (ec)
         return;
 
     // Success path
@@ -126,12 +126,12 @@ Tests must handle injected errors by returning early:
 ----
 // CORRECT: early return on injected error
 auto [ec, n] = co_await rs.read_some(buf);
-if (ec.failed())
+if (ec)
     co_return;  // fuse injected error, exit gracefully
 
 // WRONG: asserting success unconditionally
 auto [ec, n] = co_await rs.read_some(buf);
-BOOST_TEST(!ec.failed());  // FAILS when fuse injects error!
+BOOST_TEST(!ec);  // FAILS when fuse injects error!
 ----
 
 === Coroutine Support
@@ -147,7 +147,7 @@ rs.provide("test data");
 auto r = f.armed([&](fuse&) -> task<> {
     char buf[32];
     auto [ec, n] = co_await rs.read_some(make_buffer(buf));
-    if (ec.failed())
+    if (ec)
         co_return;
     // Process data...
 });
@@ -184,7 +184,7 @@ public:
     system::error_code do_work()
     {
         auto ec = f_.maybe_fail();  // No-op in production
-        if (ec.failed())
+        if (ec)
             return ec;
         // ... actual work ...
         return {};
@@ -331,7 +331,7 @@ rs.provide("World!");
 auto r = f.armed([&](fuse&) -> task<> {
     char buf[32];
     auto [ec, n] = co_await rs.read_some(make_buffer(buf));
-    if (ec.failed())
+    if (ec)
         co_return;
     // buf contains up to 13 bytes
 });
@@ -400,7 +400,7 @@ write_stream ws(f);
 
 auto r = f.armed([&](fuse&) -> task<> {
     auto [ec, n] = co_await ws.write_some(make_buffer("Hello"));
-    if (ec.failed())
+    if (ec)
         co_return;
 });
 
@@ -467,7 +467,7 @@ rs.provide("Hello, World!");
 auto r = f.armed([&](fuse&) -> task<> {
     char buf[32];
     auto [ec, n] = co_await rs.read(make_buffer(buf));
-    if (ec.failed())
+    if (ec)
         co_return;
     // buf filled completely before returning
 });
@@ -510,10 +510,10 @@ write_sink ws(f);
 
 auto r = f.armed([&](fuse&) -> task<> {
     auto [ec, n] = co_await ws.write(make_buffer("Hello"));
-    if (ec.failed())
+    if (ec)
         co_return;
     auto [ec2] = co_await ws.write_eof();
-    if (ec2.failed())
+    if (ec2)
         co_return;
 });
 
@@ -585,7 +585,7 @@ void test_parser()
         auto r = f.armed([&](fuse&) -> task<> {
             http_request req;
             auto [ec] = co_await parse_request(rs, req);
-            if (ec.failed())
+            if (ec)
                 co_return;
             BOOST_TEST(req.method == "GET");
             BOOST_TEST(req.target == "/");

--- a/example/echo-server-corosio/echo_server.cpp
+++ b/example/echo-server-corosio/echo_server.cpp
@@ -30,11 +30,11 @@ capy::task<> echo_session(corosio::tcp_socket sock)
         auto [ec, n] = co_await sock.read_some(
             capy::mutable_buffer(buf, sizeof(buf)));
 
-        if (ec)
-            break;
-
         auto [wec, wn] = co_await capy::write(
             sock, capy::const_buffer(buf, n));
+
+        if (ec)
+            break;
 
         if (wec)
             break;

--- a/example/mock-stream-testing/mock_stream_testing.cpp
+++ b/example/mock-stream-testing/mock_stream_testing.cpp
@@ -31,17 +31,18 @@ capy::task<bool> echo_line_uppercase(capy::any_stream& stream)
         // ec: std::error_code, n: std::size_t
         auto [ec, n] = co_await stream.read_some(capy::mutable_buffer(&c, 1));
 
-        if (ec)
+        if (n > 0)
         {
-            if (ec == capy::cond::eof)
+            if (c == '\n')
                 break;
-            co_return false;
+            line += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
         }
-        
-        if (c == '\n')
+
+        if (ec == capy::cond::eof)
             break;
-        
-        line += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+
+        if (ec)
+            co_return false;
     }
     
     line += '\n';
@@ -53,11 +54,11 @@ capy::task<bool> echo_line_uppercase(capy::any_stream& stream)
         // wec: std::error_code, wn: std::size_t
         auto [wec, wn] = co_await stream.write_some(
             capy::const_buffer(line.data() + written, line.size() - written));
-        
+
+        written += wn;
+
         if (wec)
             co_return false;
-        
-        written += wn;
     }
     
     co_return true;

--- a/example/type-erased-echo/echo.cpp
+++ b/example/type-erased-echo/echo.cpp
@@ -23,22 +23,17 @@ capy::task<> echo_session(capy::any_stream& stream)
 
     for (;;)
     {
-        // Read some data
         // ec: std::error_code, n: std::size_t
         auto [ec, n] = co_await stream.read_some(capy::make_buffer(buffer));
 
-        if (ec == capy::cond::eof)
-            co_return;  // Client closed connection
-
-        if (ec)
-            throw std::system_error(ec);
-
-        // Echo it back
         // wec: std::error_code, wn: std::size_t
         auto [wec, wn] = co_await capy::write(stream, capy::const_buffer(buffer, n));
 
+        if (ec)
+            co_return;
+
         if (wec)
-            throw std::system_error(wec);
+            co_return;
     }
 }
 

--- a/include/boost/capy/concept/buffer_source.hpp
+++ b/include/boost/capy/concept/buffer_source.hpp
@@ -26,9 +26,8 @@ namespace capy {
 /** Concept for types that produce buffer data asynchronously.
 
     A type satisfies `BufferSource` if it provides a `pull` member function
-    that fills a caller-provided span of buffer descriptors and is an
-    @ref IoAwaitable whose return value decomposes to
-    `(error_code,std::span<const_buffer>)`, plus a `consume` member function
+    that fills a caller-provided span of buffer descriptors and
+    await-returns `(error_code, std::span<const_buffer>)`, plus a `consume` member function
     to indicate how many bytes were used.
 
     Use this concept when you need to produce data asynchronously for

--- a/include/boost/capy/concept/read_source.hpp
+++ b/include/boost/capy/concept/read_source.hpp
@@ -27,8 +27,8 @@ namespace capy {
 
     A type satisfies `ReadSource` if it satisfies @ref ReadStream
     and additionally provides a `read` member function that accepts
-    any @ref MutableBufferSequence and is an @ref IoAwaitable whose
-    return value decomposes to `(error_code, std::size_t)`.
+    any @ref MutableBufferSequence and await-returns
+    `(error_code, std::size_t)`.
 
     `ReadSource` refines `ReadStream`. Every `ReadSource` is a
     `ReadStream`. Algorithms constrained on `ReadStream` accept both
@@ -47,8 +47,8 @@ namespace capy {
 
     @par Semantic Requirements
 
-    The inherited `read_some` operation reads one or more bytes
-    (partial read). See @ref ReadStream.
+    The inherited `read_some` operation attempts to read up to
+    `buffer_size( buffers )` bytes (partial read). See @ref ReadStream.
 
     The `read` operation fills the entire buffer sequence. On return,
     exactly one of the following is true:
@@ -68,6 +68,15 @@ namespace capy {
 
     When the buffer sequence contains multiple buffers, each buffer is
     filled completely before proceeding to the next.
+
+    @par Error Reporting
+    I/O conditions arising from the underlying I/O system (EOF,
+    connection reset, broken pipe, etc.) are reported via the
+    `error_code` component of the return value. Failures in the
+    library wrapper itself (such as memory allocation failure)
+    are reported via exceptions.
+
+    @throws std::bad_alloc If coroutine frame allocation fails.
 
     @par Buffer Lifetime
 

--- a/include/boost/capy/concept/read_stream.hpp
+++ b/include/boost/capy/concept/read_stream.hpp
@@ -26,7 +26,7 @@ namespace capy {
 
     A type satisfies `ReadStream` if it provides a `read_some`
     member function template that accepts any @ref MutableBufferSequence
-    and is an @ref IoAwaitable yielding `(error_code,std::size_t)`.
+    and await-returns `(error_code, std::size_t)`.
 
     @par Syntactic Requirements
     @li `T` must provide a `read_some` member function template
@@ -36,24 +36,31 @@ namespace capy {
         `(error_code,std::size_t)` via structured bindings
 
     @par Semantic Requirements
-    If `buffer_size( buffers ) > 0`, the operation reads one or more
-    bytes from the stream into the buffer sequence:
+    Attempts to read up to `buffer_size( buffers )` bytes from
+    the stream into the buffer sequence.
 
-    @li On success: `!ec`, and `n` is the number of bytes
-        read (at least 1).
-    @li On error: `ec`, and `n` is 0.
-    @li On end-of-file: `ec == cond::eof`, and `n` is 0.
+    If `buffer_size( buffers ) > 0`:
 
-    If `buffer_empty( buffers )` is `true`, the operation completes
-    immediately. `!ec`, and `n` is 0.
+    @li If `!ec`, then `n >= 1 && n <= buffer_size( buffers )`.
+        `n` bytes were read into the buffer sequence.
+    @li If `ec`, then `n >= 0 && n <= buffer_size( buffers )`.
+        `n` is the number of bytes read before the I/O
+        condition arose.
 
-    Buffers in the sequence are filled completely before proceeding
-    to the next buffer.
+    If `buffer_empty( buffers )` is `true`, `n` is 0. The empty
+    buffer is not itself a cause for error, but `ec` may reflect
+    the state of the stream.
 
-    @par Design Rationale
-    The requirement that `n` is 0 whenever `ec` is set follows
-    from a consistency constraint with the empty-buffer rule.
-    See the ReadStream design document for a complete derivation.
+    Buffers in the sequence are filled in order.
+
+    @par Error Reporting
+    I/O conditions arising from the underlying I/O system (EOF,
+    connection reset, broken pipe, etc.) are reported via the
+    `error_code` component of the return value. Failures in the
+    library wrapper itself (such as memory allocation failure)
+    are reported via exceptions.
+
+    @throws std::bad_alloc If coroutine frame allocation fails.
 
     @par Buffer Lifetime
     The caller must ensure that the memory referenced by `buffers`
@@ -87,9 +94,9 @@ namespace capy {
         {
             auto [ec, n] = co_await s.read_some(
                 mutable_buffer( buf + total, size - total ) );
+            total += n;
             if( ec )
                 co_return;
-            total += n;
         }
     }
     @endcode

--- a/include/boost/capy/concept/write_sink.hpp
+++ b/include/boost/capy/concept/write_sink.hpp
@@ -27,7 +27,8 @@ namespace capy {
 
     A type satisfies `WriteSink` if it satisfies @ref WriteStream
     and additionally provides `write`, `write_eof(buffers)`, and
-    `write_eof()` member functions that are @ref IoAwaitable.
+    `write_eof()` member functions that await-return
+    `(error_code, std::size_t)`.
 
     `WriteSink` refines `WriteStream`. Every `WriteSink` is a
     `WriteStream`. Algorithms constrained on `WriteStream` accept
@@ -51,8 +52,8 @@ namespace capy {
 
     @par Semantic Requirements
 
-    The inherited `write_some` operation writes one or more bytes
-    (partial write). See @ref WriteStream.
+    The inherited `write_some` operation attempts to write up to
+    `buffer_size( buffers )` bytes (partial write). See @ref WriteStream.
 
     The `write` operation consumes the entire buffer sequence:
 
@@ -75,6 +76,15 @@ namespace capy {
 
     After `write_eof` (either overload) returns successfully, no
     further writes or EOF signals are permitted.
+
+    @par Error Reporting
+    I/O conditions arising from the underlying I/O system (EOF,
+    connection reset, broken pipe, etc.) are reported via the
+    `error_code` component of the return value. Failures in the
+    library wrapper itself (such as memory allocation failure)
+    are reported via exceptions.
+
+    @throws std::bad_alloc If coroutine frame allocation fails.
 
     @par Buffer Lifetime
 

--- a/include/boost/capy/concept/write_stream.hpp
+++ b/include/boost/capy/concept/write_stream.hpp
@@ -26,8 +26,7 @@ namespace capy {
 
     A type satisfies `WriteStream` if it provides a `write_some`
     member function template that accepts any @ref ConstBufferSequence
-    and is an @ref IoAwaitable whose return value decomposes to
-    `(error_code,std::size_t)`.
+    and await-returns `(error_code, std::size_t)`.
 
     @tparam T The stream type.
 
@@ -41,18 +40,32 @@ namespace capy {
 
     @par Semantic Requirements
 
-    If `buffer_size( buffers ) > 0`, the operation writes one or more
-    bytes of data to the stream from the buffer sequence:
+    Attempts to write up to `buffer_size( buffers )` bytes from
+    the buffer sequence to the stream.
 
-    @li On success: `!ec`, and `n` is the number of bytes
-        written.
-    @li On error: `ec`, and `n` is 0.
+    If `buffer_size( buffers ) > 0`:
 
-    If `buffer_empty( buffers )` is `true`, the operation completes
-    immediately. `!ec`, and `n` is 0.
+    @li If `!ec`, then `n >= 1 && n <= buffer_size( buffers )`.
+        `n` bytes were written from the buffer sequence.
+    @li If `ec`, then `n >= 0 && n <= buffer_size( buffers )`.
+        `n` is the number of bytes written before the I/O
+        condition arose.
 
-    Buffers in the sequence are written completely before proceeding
-    to the next buffer.
+    If `buffer_empty( buffers )` is `true`, `n` is 0. The empty
+    buffer is not itself a cause for error, but `ec` may reflect
+    the state of the stream.
+
+    Buffers in the sequence are consumed in order.
+
+    @par Error Reporting
+
+    I/O conditions arising from the underlying I/O system (EOF,
+    connection reset, broken pipe, etc.) are reported via the
+    `error_code` component of the return value. Failures in the
+    library wrapper itself (such as memory allocation failure)
+    are reported via exceptions.
+
+    @throws std::bad_alloc If coroutine frame allocation fails.
 
     @par Buffer Lifetime
 
@@ -85,9 +98,9 @@ namespace capy {
         {
             auto [ec, n] = co_await s.write_some(
                 const_buffer( buf + total, size - total ) );
+            total += n;
             if( ec )
                 co_return;
-            total += n;
         }
     }
     @endcode

--- a/include/boost/capy/ex/async_event.hpp
+++ b/include/boost/capy/ex/async_event.hpp
@@ -257,7 +257,7 @@ public:
 
         If the event is already set, completes immediately.
 
-        @return An awaitable yielding `(error_code)`.
+        @return An awaitable that await-returns `(error_code)`.
     */
     wait_awaiter wait() noexcept
     {

--- a/include/boost/capy/ex/async_mutex.hpp
+++ b/include/boost/capy/ex/async_mutex.hpp
@@ -390,7 +390,7 @@ public:
 
     /** Returns an awaiter that acquires the mutex.
 
-        @return An awaitable yielding `(error_code)`.
+        @return An awaitable that await-returns `(error_code)`.
     */
     lock_awaiter lock() noexcept
     {
@@ -399,7 +399,7 @@ public:
 
     /** Returns an awaiter that acquires the mutex with RAII.
 
-        @return An awaitable yielding `(error_code,lock_guard)`.
+        @return An awaitable that await-returns `(error_code,lock_guard)`.
     */
     lock_guard_awaiter scoped_lock() noexcept
     {

--- a/include/boost/capy/io/any_buffer_sink.hpp
+++ b/include/boost/capy/io/any_buffer_sink.hpp
@@ -250,7 +250,7 @@ public:
 
         @param n The number of bytes to commit.
 
-        @return An awaitable yielding `(error_code)`.
+        @return An awaitable that await-returns `(error_code)`.
 
         @par Preconditions
         The wrapper must contain a valid sink (`has_value() == true`).
@@ -266,7 +266,7 @@ public:
 
         @param n The number of bytes to commit.
 
-        @return An awaitable yielding `(error_code)`.
+        @return An awaitable that await-returns `(error_code)`.
 
         @par Preconditions
         The wrapper must contain a valid sink (`has_value() == true`).
@@ -276,8 +276,9 @@ public:
 
     /** Write some data from a buffer sequence.
 
-        Writes one or more bytes from the buffer sequence to the
-        underlying sink. May consume less than the full sequence.
+        Attempt to write up to `buffer_size( buffers )` bytes from
+        the buffer sequence to the underlying sink. May consume less
+        than the full sequence.
 
         When the wrapped type provides native @ref WriteSink support,
         the operation forwards directly. Otherwise it is synthesized
@@ -285,7 +286,7 @@ public:
 
         @param buffers The buffer sequence to write.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @par Preconditions
         The wrapper must contain a valid sink (`has_value() == true`).
@@ -305,7 +306,7 @@ public:
 
         @param buffers The buffer sequence to write.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @par Preconditions
         The wrapper must contain a valid sink (`has_value() == true`).
@@ -326,7 +327,7 @@ public:
 
         @param buffers The buffer sequence to write.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @par Preconditions
         The wrapper must contain a valid sink (`has_value() == true`).
@@ -344,7 +345,7 @@ public:
         the underlying `write_eof()` is called. Otherwise the
         operation is implemented as `commit_eof(0)`.
 
-        @return An awaitable yielding `(error_code)`.
+        @return An awaitable that await-returns `(error_code)`.
 
         @par Preconditions
         The wrapper must contain a valid sink (`has_value() == true`).
@@ -400,7 +401,7 @@ private:
     write_eof_buffers_(std::span<const_buffer const> buffers);
 };
 
-/** Type-erased ops for awaitables yielding `io_result<>`. */
+/** Type-erased ops for awaitables that await-return `io_result<>`. */
 struct any_buffer_sink::awaitable_ops
 {
     bool (*await_ready)(void*);
@@ -409,7 +410,7 @@ struct any_buffer_sink::awaitable_ops
     void (*destroy)(void*) noexcept;
 };
 
-/** Type-erased ops for awaitables yielding `io_result<std::size_t>`. */
+/** Type-erased ops for awaitables that await-return `io_result<std::size_t>`. */
 struct any_buffer_sink::write_awaitable_ops
 {
     bool (*await_ready)(void*);

--- a/include/boost/capy/io/any_buffer_source.hpp
+++ b/include/boost/capy/io/any_buffer_source.hpp
@@ -233,7 +233,7 @@ public:
 
         @param dest Span of const_buffer to fill.
 
-        @return An awaitable yielding `(error_code,std::span<const_buffer>)`.
+        @return An awaitable that await-returns `(error_code,std::span<const_buffer>)`.
             On success with data, a non-empty span of filled buffers.
             On EOF, `ec == cond::eof` and span is empty.
 
@@ -247,8 +247,8 @@ public:
 
     /** Read some data into a mutable buffer sequence.
 
-        Reads one or more bytes into the caller's buffers. May fill
-        less than the full sequence.
+        Attempt to read up to `buffer_size( buffers )` bytes into
+        the caller's buffers. May fill less than the full sequence.
 
         When the wrapped type provides native @ref ReadSource support,
         the operation forwards directly. Otherwise it is synthesized
@@ -256,7 +256,7 @@ public:
 
         @param buffers The buffer sequence to fill.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @par Preconditions
         The wrapper must contain a valid source (`has_value() == true`).
@@ -278,7 +278,7 @@ public:
 
         @param buffers The buffer sequence to fill.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
             On success, `n == buffer_size(buffers)`.
             On EOF, `ec == error::eof` and `n` is bytes transferred.
 
@@ -333,7 +333,7 @@ private:
     read_(std::span<mutable_buffer const> buffers);
 };
 
-/** Type-erased ops for awaitables yielding `io_result<std::span<const_buffer>>`. */
+/** Type-erased ops for awaitables that await-return `io_result<std::span<const_buffer>>`. */
 struct any_buffer_source::awaitable_ops
 {
     bool (*await_ready)(void*);
@@ -342,7 +342,7 @@ struct any_buffer_source::awaitable_ops
     void (*destroy)(void*) noexcept;
 };
 
-/** Type-erased ops for awaitables yielding `io_result<std::size_t>`. */
+/** Type-erased ops for awaitables that await-return `io_result<std::size_t>`. */
 struct any_buffer_source::read_awaitable_ops
 {
     bool (*await_ready)(void*);

--- a/include/boost/capy/io/any_read_source.hpp
+++ b/include/boost/capy/io/any_read_source.hpp
@@ -186,12 +186,13 @@ public:
 
     /** Initiate a partial read operation.
 
-        Reads one or more bytes into the provided buffer sequence.
-        May fill less than the full sequence.
+        Attempt to read up to `buffer_size( buffers )` bytes into
+        the provided buffer sequence. May fill less than the
+        full sequence.
 
         @param buffers The buffer sequence to read into.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @par Immediate Completion
         The operation completes immediately without suspending
@@ -224,7 +225,7 @@ public:
 
         @param buffers The buffer sequence to read into.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @par Immediate Completion
         The operation completes immediately without suspending

--- a/include/boost/capy/io/any_read_stream.hpp
+++ b/include/boost/capy/io/any_read_stream.hpp
@@ -192,7 +192,7 @@ public:
             value to ensure the sequence lives in the coroutine frame
             across suspension points.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @par Immediate Completion
         The operation completes immediately without suspending

--- a/include/boost/capy/io/any_write_sink.hpp
+++ b/include/boost/capy/io/any_write_sink.hpp
@@ -191,12 +191,13 @@ public:
 
     /** Initiate a partial write operation.
 
-        Writes one or more bytes from the provided buffer sequence.
-        May consume less than the full sequence.
+        Attempt to write up to `buffer_size( buffers )` bytes from
+        the provided buffer sequence. May consume less than the
+        full sequence.
 
         @param buffers The buffer sequence containing data to write.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @par Immediate Completion
         The operation completes immediately without suspending
@@ -226,7 +227,7 @@ public:
 
         @param buffers The buffer sequence containing data to write.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @par Immediate Completion
         The operation completes immediately without suspending
@@ -256,7 +257,7 @@ public:
 
         @param buffers The buffer sequence containing data to write.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @par Immediate Completion
         The operation completes immediately without suspending
@@ -279,7 +280,7 @@ public:
         The operation completes when the sink is finalized, or
         an error occurs.
 
-        @return An awaitable yielding `(error_code)`.
+        @return An awaitable that await-returns `(error_code)`.
 
         @par Immediate Completion
         The operation completes immediately without suspending

--- a/include/boost/capy/io/any_write_stream.hpp
+++ b/include/boost/capy/io/any_write_stream.hpp
@@ -193,7 +193,7 @@ public:
             Passed by value to ensure the sequence lives in the
             coroutine frame across suspension points.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @par Immediate Completion
         The operation completes immediately without suspending

--- a/include/boost/capy/io/pull_from.hpp
+++ b/include/boost/capy/io/pull_from.hpp
@@ -81,13 +81,11 @@ pull_from(Src& source, Sink& sink)
         auto [ec, n] = co_await source.read(
             std::span<mutable_buffer const>(dst_bufs));
 
-        if(n > 0)
-        {
-            auto [commit_ec] = co_await sink.commit(n);
-            if(commit_ec)
-                co_return {commit_ec, total};
-            total += n;
-        }
+        auto [commit_ec] = co_await sink.commit(n);
+        total += n;
+
+        if(commit_ec)
+            co_return {commit_ec, total};
 
         if(ec == cond::eof)
         {
@@ -165,16 +163,12 @@ pull_from(Src& source, Sink& sink)
         auto [ec, n] = co_await source.read_some(
             std::span<mutable_buffer const>(dst_bufs));
 
-        // Commit any data that was read
-        if(n > 0)
-        {
-            auto [commit_ec] = co_await sink.commit(n);
-            if(commit_ec)
-                co_return {commit_ec, total};
-            total += n;
-        }
+        auto [commit_ec] = co_await sink.commit(n);
+        total += n;
 
-        // Check for EOF condition
+        if(commit_ec)
+            co_return {commit_ec, total};
+
         if(ec == cond::eof)
         {
             auto [eof_ec] = co_await sink.commit_eof(0);

--- a/include/boost/capy/io/push_to.hpp
+++ b/include/boost/capy/io/push_to.hpp
@@ -139,11 +139,10 @@ push_to(Src& source, Stream& stream)
             co_return {ec, total};
 
         auto [write_ec, n] = co_await stream.write_some(bufs);
-        if(write_ec)
-            co_return {write_ec, total};
-
         total += n;
         source.consume(n);
+        if(write_ec)
+            co_return {write_ec, total};
     }
 }
 

--- a/include/boost/capy/io/write_now.hpp
+++ b/include/boost/capy/io/write_now.hpp
@@ -302,7 +302,7 @@ public:
             value to ensure the sequence lives in the coroutine
             frame across suspension points.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
             On success, `n` equals `buffer_size(buffers)`. On
             error, `n` is the number of bytes written before the
             error. Compare error codes to conditions:
@@ -341,11 +341,11 @@ public:
         {
             auto r =
                 co_await stream_.write_some(cb);
+            cb.consume(r.t1);
+            total_written += r.t1;
             if(r.ec)
                 co_return io_result<std::size_t>{
                     r.ec, total_written};
-            cb.consume(r.t1);
-            total_written += r.t1;
         }
         co_return io_result<std::size_t>{
             {}, total_written};
@@ -385,11 +385,11 @@ public:
         {
             auto r =
                 co_await stream_.write_some(cb);
+            cb.consume(r.t1);
+            total_written += r.t1;
             if(r.ec)
                 co_return io_result<std::size_t>{
                     r.ec, total_written};
-            cb.consume(r.t1);
-            total_written += r.t1;
         }
         co_return io_result<std::size_t>{
             {}, total_written};

--- a/include/boost/capy/read.hpp
+++ b/include/boost/capy/read.hpp
@@ -43,7 +43,7 @@ namespace capy {
     @param buffers The buffer sequence to fill. The caller retains
         ownership and must ensure validity until the operation completes.
 
-    @return An awaitable yielding `(error_code, std::size_t)`.
+    @return An awaitable that await-returns `(error_code, std::size_t)`.
         On success, `n` equals `buffer_size(buffers)`. On error,
         `n` is the number of bytes read before the error. Compare
         error codes to conditions:
@@ -80,10 +80,10 @@ read(
     while(total_read < total_size)
     {
         auto [ec, n] = co_await stream.read_some(consuming);
-        if(ec)
-            co_return {ec, total_read};
         consuming.consume(n);
         total_read += n;
+        if(ec)
+            co_return {ec, total_read};
     }
 
     co_return {{}, total_read};
@@ -109,7 +109,7 @@ read(
         valid until the operation completes.
     @param initial_amount Initial bytes to prepare (default 2048).
 
-    @return An awaitable yielding `(error_code, std::size_t)`.
+    @return An awaitable that await-returns `(error_code, std::size_t)`.
         On success (EOF), `ec` is clear and `n` is total bytes read.
         On error, `n` is bytes read before the error. Compare error
         codes to conditions:
@@ -175,7 +175,7 @@ read(
         valid until the operation completes.
     @param initial_amount Initial bytes to prepare (default 2048).
 
-    @return An awaitable yielding `(error_code, std::size_t)`.
+    @return An awaitable that await-returns `(error_code, std::size_t)`.
         On success (EOF), `ec` is clear and `n` is total bytes read.
         On error, `n` is bytes read before the error. Compare error
         codes to conditions:

--- a/include/boost/capy/read_until.hpp
+++ b/include/boost/capy/read_until.hpp
@@ -262,7 +262,7 @@ struct match_delim
     @param initial_amount Initial bytes to read per iteration (default
         2048). Grows by 1.5x when filled.
 
-    @return An awaitable yielding `(error_code, std::size_t)`.
+    @return An awaitable that await-returns `(error_code, std::size_t)`.
         On success, `n` is the position returned by the match condition
         (bytes up to and including the matched delimiter). Compare error
         codes to conditions:
@@ -340,7 +340,7 @@ read_until(
     @param initial_amount Initial bytes to read per iteration (default
         2048). Grows by 1.5x when filled.
 
-    @return An awaitable yielding `(error_code, std::size_t)`.
+    @return An awaitable that await-returns `(error_code, std::size_t)`.
         On success, `n` is bytes up to and including the delimiter.
         Compare error codes to conditions:
         @li `cond::eof` - EOF before delimiter; `n` is buffer size

--- a/include/boost/capy/test/buffer_sink.hpp
+++ b/include/boost/capy/test/buffer_sink.hpp
@@ -150,7 +150,7 @@ public:
 
         @param n The number of bytes to commit.
 
-        @return An awaitable yielding `(error_code)`.
+        @return An awaitable that await-returns `(error_code)`.
 
         @see fuse
     */
@@ -207,7 +207,7 @@ public:
 
         @param n The number of bytes to commit.
 
-        @return An awaitable yielding `(error_code)`.
+        @return An awaitable that await-returns `(error_code)`.
 
         @see fuse
     */

--- a/include/boost/capy/test/buffer_source.hpp
+++ b/include/boost/capy/test/buffer_source.hpp
@@ -139,7 +139,7 @@ public:
 
         @param dest Span of const_buffer to fill.
 
-        @return An awaitable yielding `(error_code,std::span<const_buffer>)`.
+        @return An awaitable that await-returns `(error_code,std::span<const_buffer>)`.
 
         @see consume, fuse
     */

--- a/include/boost/capy/test/bufgrind.hpp
+++ b/include/boost/capy/test/bufgrind.hpp
@@ -153,7 +153,7 @@ public:
         @par Preconditions
         `static_cast<bool>( *this )` is `true`.
 
-        @return An awaitable yielding `split_type`.
+        @return An awaitable that await-returns `split_type`.
     */
     next_awaitable
     next() noexcept

--- a/include/boost/capy/test/read_source.hpp
+++ b/include/boost/capy/test/read_source.hpp
@@ -121,7 +121,7 @@ public:
 
         @param buffers The mutable buffer sequence to receive data.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @see fuse
     */
@@ -181,7 +181,7 @@ public:
 
         @param buffers The mutable buffer sequence to receive data.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @see fuse
     */

--- a/include/boost/capy/test/read_stream.hpp
+++ b/include/boost/capy/test/read_stream.hpp
@@ -127,7 +127,7 @@ public:
 
         @param buffers The mutable buffer sequence to receive data.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @see fuse
     */

--- a/include/boost/capy/test/stream.hpp
+++ b/include/boost/capy/test/stream.hpp
@@ -205,7 +205,7 @@ public:
 
         @param buffers The mutable buffer sequence to receive data.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @see fuse, close
     */
@@ -288,7 +288,7 @@ public:
         @param buffers The const buffer sequence containing
             data to write.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @see fuse, close
     */

--- a/include/boost/capy/test/write_sink.hpp
+++ b/include/boost/capy/test/write_sink.hpp
@@ -155,7 +155,7 @@ public:
 
         @param buffers The const buffer sequence containing data to write.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @see fuse
     */
@@ -216,7 +216,7 @@ public:
 
         @param buffers The const buffer sequence containing data to write.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @see fuse
     */
@@ -281,7 +281,7 @@ public:
 
         @param buffers The const buffer sequence containing data to write.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @see fuse
     */
@@ -343,7 +343,7 @@ public:
         @par Exception Safety
         No-throw guarantee.
 
-        @return An awaitable yielding `(error_code)`.
+        @return An awaitable that await-returns `(error_code)`.
 
         @see fuse
     */

--- a/include/boost/capy/test/write_stream.hpp
+++ b/include/boost/capy/test/write_stream.hpp
@@ -144,7 +144,7 @@ public:
 
         @param buffers The const buffer sequence containing data to write.
 
-        @return An awaitable yielding `(error_code,std::size_t)`.
+        @return An awaitable that await-returns `(error_code,std::size_t)`.
 
         @see fuse
     */

--- a/include/boost/capy/write.hpp
+++ b/include/boost/capy/write.hpp
@@ -40,7 +40,7 @@ namespace capy {
     @param buffers The buffer sequence to write. The caller retains
         ownership and must ensure validity until the operation completes.
 
-    @return An awaitable yielding `(error_code, std::size_t)`.
+    @return An awaitable that await-returns `(error_code, std::size_t)`.
         On success, `n` equals `buffer_size(buffers)`. On error,
         `n` is the number of bytes written before the error. Compare
         error codes to conditions:
@@ -74,10 +74,10 @@ write(
     while(total_written < total_size)
     {
         auto [ec, n] = co_await stream.write_some(consuming);
-        if(ec)
-            co_return {ec, total_written};
         consuming.consume(n);
         total_written += n;
+        if(ec)
+            co_return {ec, total_written};
     }
 
     co_return {{}, total_written};

--- a/papers/B1005.io-streamables.md
+++ b/papers/B1005.io-streamables.md
@@ -87,13 +87,14 @@ concept ReadStream =
 
 **Semantic requirements:**
 
-If `buffer_size(buffers) > 0`, the operation reads one or more bytes:
+Attempts to read up to `buffer_size(buffers)` bytes from the stream into the buffer sequence.
 
-- On success: `!ec.failed()`, and `n >= 1`
-- On error: `ec.failed()`, and `n == 0`
-- On end-of-file: `ec == cond::eof`, and `n == 0`
+If `buffer_size(buffers) > 0`:
 
-If `buffer_empty(buffers)` is `true`, the operation completes immediately with `!ec.failed()` and `n == 0`.
+- If `!ec`, then `n >= 1 && n <= buffer_size(buffers)`. `n` bytes were read into the buffer sequence.
+- If `ec`, then `n >= 0 && n <= buffer_size(buffers)`. `n` is the number of bytes read before the I/O condition arose.
+
+If `buffer_empty(buffers)` is `true`, `n` is 0. The empty buffer is not itself a cause for error, but `ec` may reflect the state of the stream.
 
 ### 2.2 WriteStream
 
@@ -113,7 +114,14 @@ concept WriteStream =
 
 **Semantic requirements:**
 
-The operation writes one or more bytes. On success, `n` indicates bytes written (at least 1 if `buffer_size(buffers) > 0`). The caller must loop to write remaining data.
+Attempts to write up to `buffer_size(buffers)` bytes from the buffer sequence to the stream.
+
+If `buffer_size(buffers) > 0`:
+
+- If `!ec`, then `n >= 1 && n <= buffer_size(buffers)`. `n` bytes were written from the buffer sequence.
+- If `ec`, then `n >= 0 && n <= buffer_size(buffers)`. `n` is the number of bytes written before the I/O condition arose.
+
+If `buffer_empty(buffers)` is `true`, `n` is 0. The empty buffer is not itself a cause for error, but `ec` may reflect the state of the stream. The caller must loop to write remaining data.
 
 ### 2.3 ReadSource
 
@@ -186,9 +194,9 @@ concept BufferSource =
 
 The `pull` operation fills the provided buffer descriptor array with data from internal storage. On return:
 
-- **Data available**: `!ec.failed()` and `count > 0`. The array contains `count` buffer descriptors.
-- **Source exhausted**: `!ec.failed()` and `count == 0`. The transfer is complete.
-- **Error**: `ec.failed()`.
+- **Data available**: `!ec` and `count > 0`. The array contains `count` buffer descriptors.
+- **Source exhausted**: `!ec` and `count == 0`. The transfer is complete.
+- **Error**: `ec`.
 
 Calling `pull` multiple times without intervening `consume` returns the same unconsumed data. The `consume(n)` operation advances the read position by `n` bytes. The next `pull` returns data starting after the consumed bytes.
 
@@ -502,7 +510,7 @@ io_task<std::size_t> transfer(Source& source, Sink& sink)
     for(;;)
     {
         auto [ec, count] = co_await source.pull(arr, 16);
-        if(ec.failed())
+        if(ec)
             co_return {ec, total};
         if(count == 0)
         {
@@ -510,7 +518,7 @@ io_task<std::size_t> transfer(Source& source, Sink& sink)
             co_return {eof_ec, total};
         }
         auto [write_ec, n] = co_await sink.write(std::span(arr, count));
-        if(write_ec.failed())
+        if(write_ec)
             co_return {write_ec, total};
         source.consume(n);
         total += n;
@@ -533,7 +541,7 @@ task<> process_response(http_response& resp)
         auto [ec, n] = co_await body.read(mutable_buffer(buffer, sizeof(buffer)));
         if(ec == cond::eof)
             break;
-        if(ec.failed())
+        if(ec)
             throw system_error(ec);
         process_chunk(buffer, n);
     }
@@ -550,7 +558,7 @@ task<> send_compressed(any_write_sink& output, std::string_view data)
     zlib_sink compressor(output);  // Wraps output, satisfies WriteSink
     
     auto [ec, n] = co_await compressor.write(make_buffer(data), true);
-    if(ec.failed())
+    if(ec)
         throw system_error(ec);
 }
 ```
@@ -751,7 +759,7 @@ template<mutable_buffer_sequence MB>
 unspecified read_some(MB buffers);
 ```
 
-*Returns:* An awaitable yielding `(error_code, size_t)`.
+*Returns:* An awaitable that await-returns `(error_code, size_t)`.
 
 *Effects:* Equivalent to calling `read_some(buffers)` on the wrapped stream.
 


### PR DESCRIPTION
Adopt the relaxed error postcondition (n >= 0 on error) from the read-some-rationale consensus throughout headers, implementation, docs, examples, and papers. Fix composed algorithms (read, write, write_now, push_to) to use advance-then-check ordering. Replace .failed() with operator bool() idiom. Add error reporting and throws documentation to all concept Javadocs and the rationale doc. Introduce await-returns terminology per stakeholder feedback. Use C++ expressions for range constraints. Remove if(n > 0) guards from echo loops in favor of unconditional write-then-check pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified async operation terminology across API documentation for consistency.
  * Enhanced error handling descriptions with explicit exception documentation.

* **Bug Fixes**
  * Adjusted control flow in I/O operations to report bytes consumed or written before error checks, ensuring consistent accounting in error scenarios.
  * Removed conditional guards to guarantee commit/write attempts regardless of data transferred.

* **Examples**
  * Updated example code to reflect refined error handling behavior in I/O operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->