### PR TITLE
Dispatch run(ex) task through target executor

### DIFF
--- a/include/boost/capy/ex/run.hpp
+++ b/include/boost/capy/ex/run.hpp
@@ -241,7 +241,7 @@ struct [[nodiscard]] run_awaitable_ex
             env_.frame_allocator = caller_env->frame_allocator;
 
         p.set_environment(&env_);
-        return h;
+        return ex_.dispatch(h);
     }
 
     // Non-copyable

--- a/test/unit/ex/run.cpp
+++ b/test/unit/ex/run.cpp
@@ -19,6 +19,10 @@
 #include "test/unit/custom_task.hpp"
 #include "test/unit/test_helpers.hpp"
 
+#include <boost/capy/ex/strand.hpp>
+#include <boost/capy/ex/thread_pool.hpp>
+
+#include <latch>
 #include <memory>
 
 namespace boost {
@@ -469,6 +473,34 @@ struct run_test
     }
 
     void
+    testRunExStrandFirstInstruction()
+    {
+        // Verify that the first instructions of a task passed
+        // to run(strand) execute inside the strand's serialization,
+        // not inline on an unprotected thread.
+        thread_pool pool(2, "str-pool-");
+        strand s(pool.get_executor());
+        bool inside_strand = false;
+        std::latch done(1);
+
+        auto inner = [&]() -> task<void> {
+            inside_strand = s.running_in_this_thread();
+            co_return;
+        };
+
+        auto outer = [&]() -> task<void> {
+            co_await capy::run(s)(inner());
+        };
+
+        run_async(pool.get_executor(),
+            [&]() { done.count_down(); })(outer());
+        done.wait();
+
+        BOOST_TEST(inside_strand);
+        pool.join();
+    }
+
+    void
     run()
     {
         testCustomTaskType();
@@ -490,6 +522,7 @@ struct run_test
         testStopTokenOverrideOuterStopped();
         testAllocatorPropagation();
         testAllocatorPropagationThroughRun();
+        testRunExStrandFirstInstruction();
     }
 };
 


### PR DESCRIPTION
run_awaitable_ex::await_suspend was resuming the child task via direct symmetric transfer, bypassing the target executor. This meant the first instructions of the task body ran inline on the caller's thread rather than on the executor's thread. For strands, this violated the serialization invariant from the very first instruction.

Route the initial resumption through ex_.dispatch(h) so the executor decides where the task starts. Add a strand-based test that verifies running_in_this_thread() is true at the first instruction of the child task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced coroutine execution handling by routing resumption through the executor dispatch mechanism for improved execution context management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->