### PR TITLE
Replace raw #ifdef _MSC_VER with BOOST_CAPY_WORKAROUND macro

### DIFF
--- a/include/boost/capy/buffers/make_buffer.hpp
+++ b/include/boost/capy/buffers/make_buffer.hpp
@@ -22,10 +22,8 @@
 #include <type_traits>
 #include <vector>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4459)
-#endif
+BOOST_CAPY_MSVC_WARNING_PUSH
+BOOST_CAPY_MSVC_WARNING_DISABLE(4459)
 
 namespace boost {
 namespace capy {
@@ -531,8 +529,6 @@ make_buffer(
 } // capy
 } // boost
 
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+BOOST_CAPY_MSVC_WARNING_POP
 
 #endif

--- a/include/boost/capy/delay.hpp
+++ b/include/boost/capy/delay.hpp
@@ -88,15 +88,11 @@ class delay_awaitable
     // Aligned storage for the stop callback.
     // Declared last: its destructor may block while
     // the callback accesses the members above.
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable: 4324)
-#endif
+    BOOST_CAPY_MSVC_WARNING_PUSH
+    BOOST_CAPY_MSVC_WARNING_DISABLE(4324)
     alignas(stop_cb_t)
         unsigned char stop_cb_buf_[sizeof(stop_cb_t)];
-#ifdef _MSC_VER
-# pragma warning(pop)
-#endif
+    BOOST_CAPY_MSVC_WARNING_POP
 
     stop_cb_t& stop_cb_() noexcept
     {

--- a/include/boost/capy/detail/await_suspend_helper.hpp
+++ b/include/boost/capy/detail/await_suspend_helper.hpp
@@ -51,7 +51,7 @@ namespace detail {
 
     @param h The coroutine handle to transfer to.
 */
-#ifdef _MSC_VER
+#if BOOST_CAPY_WORKAROUND(_MSC_VER, >= 1)
 inline void symmetric_transfer(std::coroutine_handle<> h) noexcept
 {
     h.resume();

--- a/include/boost/capy/detail/config.hpp
+++ b/include/boost/capy/detail/config.hpp
@@ -15,6 +15,58 @@
 # define BOOST_CAPY_ASSERT(expr) assert(expr)
 #endif
 
+//------------------------------------------------
+//
+// Compiler bug workarounds
+//
+//------------------------------------------------
+
+/* Standalone workaround macro modeled on Boost.Config's BOOST_WORKAROUND.
+
+   Guard mechanism: when a compiler symbol is not defined, the
+   corresponding _WORKAROUND_GUARD macro is 1, which makes
+   BOOST_CAPY_WORKAROUND evaluate to 0 on that compiler.
+
+   Usage:
+     #if BOOST_CAPY_WORKAROUND(_MSC_VER, >= 1)      // any MSVC
+     #if BOOST_CAPY_WORKAROUND(_MSC_VER, <= 1900)    // MSVC 14.0 and earlier
+     #if BOOST_CAPY_WORKAROUND(__GNUC__, < 12)        // GCC before 12
+*/
+
+#ifndef _MSC_VER
+# define _MSC_VER_WORKAROUND_GUARD 1
+#else
+# define _MSC_VER_WORKAROUND_GUARD 0
+#endif
+
+#ifndef __GNUC__
+# define __GNUC___WORKAROUND_GUARD 1
+#else
+# define __GNUC___WORKAROUND_GUARD 0
+#endif
+
+#ifndef __clang_major__
+# define __clang_major___WORKAROUND_GUARD 1
+#else
+# define __clang_major___WORKAROUND_GUARD 0
+#endif
+
+#define BOOST_CAPY_WORKAROUND(symbol, test)        \
+    ((symbol ## _WORKAROUND_GUARD + 0 == 0) &&     \
+     (symbol != 0) && (1 % (( (symbol test) ) + 1)))
+
+// MSVC warning suppression helpers.
+// On MSVC these expand to __pragma(); elsewhere they are empty.
+#ifdef _MSC_VER
+# define BOOST_CAPY_MSVC_WARNING_PUSH       __pragma(warning(push))
+# define BOOST_CAPY_MSVC_WARNING_DISABLE(x) __pragma(warning(disable: x))
+# define BOOST_CAPY_MSVC_WARNING_POP        __pragma(warning(pop))
+#else
+# define BOOST_CAPY_MSVC_WARNING_PUSH
+# define BOOST_CAPY_MSVC_WARNING_DISABLE(x)
+# define BOOST_CAPY_MSVC_WARNING_POP
+#endif
+
 // Efficient thread-local storage keyword for POD types
 #if !defined(BOOST_CAPY_TLS_KEYWORD)
 # if defined(_MSC_VER)

--- a/include/boost/capy/ex/async_event.hpp
+++ b/include/boost/capy/ex/async_event.hpp
@@ -145,15 +145,11 @@ public:
         // Aligned storage for stop_cb_t. Declared last:
         // its destructor may block while the callback
         // accesses the members above.
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable: 4324) // padded due to alignas
-#endif
+        BOOST_CAPY_MSVC_WARNING_PUSH
+        BOOST_CAPY_MSVC_WARNING_DISABLE(4324) // padded due to alignas
         alignas(stop_cb_t)
             unsigned char stop_cb_buf_[sizeof(stop_cb_t)];
-#ifdef _MSC_VER
-# pragma warning(pop)
-#endif
+        BOOST_CAPY_MSVC_WARNING_POP
 
         stop_cb_t& stop_cb_() noexcept
         {

--- a/include/boost/capy/ex/async_mutex.hpp
+++ b/include/boost/capy/ex/async_mutex.hpp
@@ -194,15 +194,11 @@ public:
         // Aligned storage for stop_cb_t. Declared last:
         // its destructor may block while the callback
         // accesses the members above.
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable: 4324) // padded due to alignas
-#endif
+        BOOST_CAPY_MSVC_WARNING_PUSH
+        BOOST_CAPY_MSVC_WARNING_DISABLE(4324) // padded due to alignas
         alignas(stop_cb_t)
             unsigned char stop_cb_buf_[sizeof(stop_cb_t)];
-#ifdef _MSC_VER
-# pragma warning(pop)
-#endif
+        BOOST_CAPY_MSVC_WARNING_POP
 
         stop_cb_t& stop_cb_() noexcept
         {

--- a/include/boost/capy/ex/detail/timer_service.hpp
+++ b/include/boost/capy/ex/detail/timer_service.hpp
@@ -104,10 +104,8 @@ private:
     void run();
 
 // warning C4251: std types need to have dll-interface
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable: 4251)
-#endif
+    BOOST_CAPY_MSVC_WARNING_PUSH
+    BOOST_CAPY_MSVC_WARNING_DISABLE(4251)
     std::mutex mutex_;
     std::condition_variable cv_;
     std::condition_variable cancel_cv_;
@@ -120,9 +118,7 @@ private:
     timer_id executing_id_ = 0;
     bool stopped_ = false;
     std::thread thread_;
-#ifdef _MSC_VER
-# pragma warning(pop)
-#endif
+    BOOST_CAPY_MSVC_WARNING_POP
 };
 
 } // detail

--- a/include/boost/capy/ex/execution_context.hpp
+++ b/include/boost/capy/ex/execution_context.hpp
@@ -163,15 +163,11 @@ public:
         service* next_ = nullptr;
 
 // warning C4251: 'std::type_index' needs to have dll-interface
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable: 4251)
-#endif
+        BOOST_CAPY_MSVC_WARNING_PUSH
+        BOOST_CAPY_MSVC_WARNING_DISABLE(4251)
         detail::type_index t0_{detail::type_id<void>()};
         detail::type_index t1_{detail::type_id<void>()};
-#ifdef _MSC_VER
-# pragma warning(pop)
-#endif
+        BOOST_CAPY_MSVC_WARNING_POP
     };
 
     //------------------------------------------------
@@ -503,16 +499,12 @@ private:
     struct BOOST_CAPY_DECL
         factory
     {
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable: 4251)
-#endif
 // warning C4251: 'std::type_index' needs to have dll-interface
+        BOOST_CAPY_MSVC_WARNING_PUSH
+        BOOST_CAPY_MSVC_WARNING_DISABLE(4251)
         detail::type_index t0;
         detail::type_index t1;
-#ifdef _MSC_VER
-# pragma warning(pop)
-#endif
+        BOOST_CAPY_MSVC_WARNING_POP
 
         factory(
             detail::type_info const& t0_,
@@ -531,16 +523,12 @@ private:
     service& use_service_impl(factory& f);
     service& make_service_impl(factory& f);
 
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable: 4251)
-#endif
-// warning C4251: 'std::type_index' needs to have dll-interface
+// warning C4251: std::mutex, std::shared_ptr need dll-interface
+    BOOST_CAPY_MSVC_WARNING_PUSH
+    BOOST_CAPY_MSVC_WARNING_DISABLE(4251)
     mutable std::mutex mutex_;
     std::shared_ptr<void> owned_;
-#ifdef _MSC_VER
-# pragma warning(pop)
-#endif
+    BOOST_CAPY_MSVC_WARNING_POP
     std::pmr::memory_resource* frame_alloc_ = nullptr;
     service* head_ = nullptr;
     bool shutdown_ = false;

--- a/include/boost/capy/ex/recycling_memory_resource.hpp
+++ b/include/boost/capy/ex/recycling_memory_resource.hpp
@@ -46,10 +46,8 @@ namespace capy {
     @see get_recycling_memory_resource
     @see run_async
 */
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable: 4275) // non dll-interface base class
-#endif
+BOOST_CAPY_MSVC_WARNING_PUSH
+BOOST_CAPY_MSVC_WARNING_DISABLE(4275) // non dll-interface base class
 class BOOST_CAPY_DECL recycling_memory_resource : public std::pmr::memory_resource
 {
     static constexpr std::size_t num_classes = 6;
@@ -184,9 +182,7 @@ protected:
         return this == &other;
     }
 };
-#ifdef _MSC_VER
-# pragma warning(pop)
-#endif
+BOOST_CAPY_MSVC_WARNING_POP
 
 /** Returns pointer to the default recycling memory resource.
 

--- a/include/boost/capy/io_result.hpp
+++ b/include/boost/capy/io_result.hpp
@@ -63,7 +63,7 @@ struct [[nodiscard]] io_result<>
     /** The error code from the operation. */
     std::error_code ec;
 
-#ifdef _MSC_VER
+#if BOOST_CAPY_WORKAROUND(_MSC_VER, >= 1)
     // Tuple protocol (unconditional - io_result<> is not an aggregate)
     template<std::size_t I>
     auto& get() & noexcept
@@ -108,7 +108,7 @@ struct [[nodiscard]] io_result<T1>
     /// The first payload value. Unspecified when `ec` is set.
     T1 t1{};
 
-#ifdef _MSC_VER
+#if BOOST_CAPY_WORKAROUND(_MSC_VER, >= 1)
     template<std::size_t I>
     auto& get() & noexcept
     {
@@ -164,7 +164,7 @@ struct [[nodiscard]] io_result<T1, T2>
     /// The second payload value. Unspecified when `ec` is set.
     T2 t2{};
 
-#ifdef _MSC_VER
+#if BOOST_CAPY_WORKAROUND(_MSC_VER, >= 1)
     template<std::size_t I>
     auto& get() & noexcept
     {
@@ -227,7 +227,7 @@ struct [[nodiscard]] io_result<T1, T2, T3>
     /// The third payload value. Unspecified when `ec` is set.
     T3 t3{};
 
-#ifdef _MSC_VER
+#if BOOST_CAPY_WORKAROUND(_MSC_VER, >= 1)
     template<std::size_t I>
     auto& get() & noexcept
     {
@@ -260,7 +260,7 @@ struct [[nodiscard]] io_result<T1, T2, T3>
 #endif
 };
 
-#ifdef _MSC_VER
+#if BOOST_CAPY_WORKAROUND(_MSC_VER, >= 1)
 
 // Free-standing get() overloads for ADL (MSVC aggregate workaround).
 /// @cond
@@ -339,12 +339,12 @@ auto&& get(io_result<T1, T2, T3>&& r) noexcept
 
 /// @endcond
 
-#endif // _MSC_VER
+#endif // BOOST_CAPY_WORKAROUND(_MSC_VER, >= 1)
 
 } // namespace capy
 } // namespace boost
 
-#ifdef _MSC_VER
+#if BOOST_CAPY_WORKAROUND(_MSC_VER, >= 1)
 
 // Tuple protocol for structured bindings (MSVC workaround)
 // MSVC has a bug with aggregate decomposition in coroutines, so we use
@@ -448,6 +448,6 @@ struct tuple_element<3, boost::capy::io_result<T1, T2, T3>>
 
 } // namespace std
 
-#endif // _MSC_VER
+#endif // BOOST_CAPY_WORKAROUND(_MSC_VER, >= 1)
 
 #endif // BOOST_CAPY_IO_RESULT_HPP

--- a/src/cond.cpp
+++ b/src/cond.cpp
@@ -76,9 +76,9 @@ equivalent(
 // msvc 14.0 has a bug that warns about inability
 // to use constexpr construction here, even though
 // there's no constexpr construction
-#if defined(_MSC_VER) && _MSC_VER <= 1900
-# pragma warning( push )
-# pragma warning( disable : 4592 )
+#if BOOST_CAPY_WORKAROUND(_MSC_VER, <= 1900)
+BOOST_CAPY_MSVC_WARNING_PUSH
+BOOST_CAPY_MSVC_WARNING_DISABLE(4592)
 #endif
 
 #if defined(__cpp_constinit) && __cpp_constinit >= 201907L
@@ -87,8 +87,8 @@ constinit cond_cat_type cond_cat;
 cond_cat_type cond_cat;
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER <= 1900
-# pragma warning( pop )
+#if BOOST_CAPY_WORKAROUND(_MSC_VER, <= 1900)
+BOOST_CAPY_MSVC_WARNING_POP
 #endif
 
 } // detail

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -43,9 +43,9 @@ message(int code) const
 // msvc 14.0 has a bug that warns about inability
 // to use constexpr construction here, even though
 // there's no constexpr construction
-#if defined(_MSC_VER) && _MSC_VER <= 1900
-# pragma warning( push )
-# pragma warning( disable : 4592 )
+#if BOOST_CAPY_WORKAROUND(_MSC_VER, <= 1900)
+BOOST_CAPY_MSVC_WARNING_PUSH
+BOOST_CAPY_MSVC_WARNING_DISABLE(4592)
 #endif
 
 #if defined(__cpp_constinit) && __cpp_constinit >= 201907L
@@ -54,8 +54,8 @@ constinit error_cat_type error_cat;
 error_cat_type error_cat;
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER <= 1900
-# pragma warning( pop )
+#if BOOST_CAPY_WORKAROUND(_MSC_VER, <= 1900)
+BOOST_CAPY_MSVC_WARNING_POP
 #endif
 
 } // detail

--- a/test/unit/test_helpers.hpp
+++ b/test/unit/test_helpers.hpp
@@ -272,15 +272,11 @@ struct stop_only_awaitable
     // When ~jthread calls request_stop() before join(), the
     // destructor's _M_reset (on the requesting thread) races with
     // emplace's _M_engaged write (on the registering thread).
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable: 4324) // padded due to alignas
-#endif
+    BOOST_CAPY_MSVC_WARNING_PUSH
+    BOOST_CAPY_MSVC_WARNING_DISABLE(4324) // padded due to alignas
     alignas(stop_resume_callback)
         unsigned char stop_cb_buf_[sizeof(stop_resume_callback)]{};
-#ifdef _MSC_VER
-# pragma warning(pop)
-#endif
+    BOOST_CAPY_MSVC_WARNING_POP
     std::atomic<bool> active_{false};
 
     ~stop_only_awaitable()


### PR DESCRIPTION
Closes #144 

Add a standalone BOOST_CAPY_WORKAROUND(symbol, test) macro to detail/config.hpp, modeled on Boost.Config's BOOST_WORKAROUND. The guard mechanism evaluates to 0 when the compiler symbol is undefined, making workaround sites safe and self-documenting across compilers.

Also add BOOST_CAPY_MSVC_WARNING_PUSH/DISABLE/POP helpers that use __pragma() on MSVC and expand to nothing elsewhere, replacing the repetitive 4-line #ifdef/#pragma/#endif sandwich pattern.

Feature-detection sites (_MSC_VER for TLS keyword, __forceinline, RTTI, __FUNCSIG__) are intentionally left as raw checks since they are not bug workarounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated compiler warning handling into project-wide macros and introduced a unified compiler workaround mechanism for improved consistency and portability; no functional or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->