### PR TITLE
Add beman-execution benchmark and fix thread_pool spurious wakeups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,13 @@ option(BOOST_CAPY_BUILD_BENCH "Build boost::capy benchmarks" ${BOOST_CAPY_IS_ROO
 option(BOOST_CAPY_BUILD_P2300_EXAMPLES "Build examples that depend on beman-execution (P2300)" OFF)
 option(BOOST_CAPY_MRDOCS_BUILD "Build the target for MrDocs: see mrdocs.yml" OFF)
 
+if(BOOST_CAPY_BUILD_P2300_EXAMPLES)
+    if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 23)
+        message(FATAL_ERROR
+            "BOOST_CAPY_BUILD_P2300_EXAMPLES requires CMAKE_CXX_STANDARD >= 23")
+    endif()
+endif()
+
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 if(BOOST_CAPY_IS_ROOT AND BUILD_SHARED_LIBS)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -8,7 +8,8 @@
 #
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES
-    CMakeLists.txt bench.cpp allocation.cpp)
+    CMakeLists.txt bench.cpp allocation.cpp
+    beman/main.cpp beman/beman_env.hpp beman/bench_pool.hpp)
 
 add_executable(boost_capy_bench bench.cpp)
 target_link_libraries(boost_capy_bench PRIVATE Boost::capy)
@@ -16,6 +17,24 @@ target_include_directories(boost_capy_bench PRIVATE .)
 
 add_executable(boost_capy_bench_allocation allocation.cpp)
 target_link_libraries(boost_capy_bench_allocation PRIVATE Boost::capy)
+
+if(BOOST_CAPY_BUILD_P2300_EXAMPLES)
+    include(FetchContent)
+    FetchContent_Declare(
+        beman-task
+        GIT_REPOSITORY https://github.com/bemanproject/task
+        GIT_TAG 6163df9
+        SYSTEM
+        FIND_PACKAGE_ARGS
+            NAMES beman.task
+    )
+    FetchContent_MakeAvailable(beman-task)
+
+    add_executable(boost_capy_bench_beman beman/main.cpp)
+    target_compile_features(boost_capy_bench_beman PRIVATE cxx_std_23)
+    target_link_libraries(boost_capy_bench_beman PRIVATE
+        Boost::capy beman::task beman::execution_headers)
+endif()
 
 if(BUILD_SHARED_LIBS)
     include(FetchContent)

--- a/bench/beman/awt_any_stream.hpp
+++ b/bench/beman/awt_any_stream.hpp
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_AWT_ANY_STREAM_HPP
+#define BOOST_CAPY_BENCH_AWT_ANY_STREAM_HPP
+
+#include "awt_stream_base.hpp"
+
+/// Type-erased plain awaitable stream. Delegates to awt_stream
+/// through the awt_stream_base virtual interface.
+template <class Ex>
+struct awt_any_stream : awt_stream_base<Ex>
+{
+    awt_stream<Ex> stream_;
+
+    explicit awt_any_stream(Ex ex) noexcept
+        : stream_{ex} {}
+
+    typename awt_stream<Ex>::read_awaitable
+        read_some(boost::capy::mutable_buffer buf) override
+    {
+        return stream_.read_some(buf);
+    }
+};
+
+#endif

--- a/bench/beman/awt_stream.hpp
+++ b/bench/beman/awt_stream.hpp
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+//
+// No-op plain awaitable stream for benchmarks.
+//
+// Uses the standard await_suspend(coroutine_handle<>) signature —
+// no IoAwaitable, no io_env. Gets the executor at construction
+// time, stored by value. Used by Column D's frame_cb sender
+// pipeline.
+//
+
+#ifndef BOOST_CAPY_BENCH_AWT_STREAM_HPP
+#define BOOST_CAPY_BENCH_AWT_STREAM_HPP
+
+#include "thread_pool.hpp"
+
+#include <coroutine>
+#include <cstddef>
+
+template <class Ex>
+struct awt_stream
+{
+    Ex ex_;
+
+    struct read_awaitable : work_item
+    {
+        Ex ex_;
+        std::coroutine_handle<> h_{};
+
+        explicit read_awaitable(Ex ex) noexcept : ex_(ex) {}
+
+        bool await_ready() const noexcept { return false; }
+
+        void await_suspend(std::coroutine_handle<> h)
+        {
+            h_ = h;
+            ex_.enqueue(this);
+        }
+
+        std::size_t await_resume() noexcept { return 0; }
+
+        void execute() noexcept override { h_.resume(); }
+    };
+
+    read_awaitable read_some(auto)
+    {
+        return read_awaitable{ex_};
+    }
+};
+
+#endif

--- a/bench/beman/awt_stream_base.hpp
+++ b/bench/beman/awt_stream_base.hpp
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_AWT_STREAM_BASE_HPP
+#define BOOST_CAPY_BENCH_AWT_STREAM_BASE_HPP
+
+#include "awt_stream.hpp"
+
+#include <boost/capy/buffers.hpp>
+
+/// Virtual base class for type-erased plain awaitable streams.
+template <class Ex>
+struct awt_stream_base
+{
+    virtual typename awt_stream<Ex>::read_awaitable
+        read_some(boost::capy::mutable_buffer) = 0;
+    virtual ~awt_stream_base() = default;
+};
+
+#endif

--- a/bench/beman/d4126_bridge.hpp
+++ b/bench/beman/d4126_bridge.hpp
@@ -1,0 +1,106 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+//
+// D4126 bridge: wraps a plain awaitable as a sender.
+//
+// Uses frame_cb — a synthetic coroutine frame whose layout matches
+// MSVC/GCC/Clang — to drive the awaitable through await_suspend(h)
+// without a real coroutine. The op_state is stored inline; no
+// heap allocation occurs in connect or start.
+//
+
+#ifndef BOOST_CAPY_BENCH_D4126_BRIDGE_HPP
+#define BOOST_CAPY_BENCH_D4126_BRIDGE_HPP
+
+#include <beman/execution/execution.hpp>
+
+#include <coroutine>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace ex = beman::execution;
+
+namespace detail {
+
+struct frame_cb
+{
+    void (*resume)(frame_cb*);
+    void (*destroy)(frame_cb*);
+    void* data;
+};
+
+} // namespace detail
+
+template <class Aw>
+struct d4126_connect_sender
+{
+    using sender_concept = ex::sender_t;
+    using completion_signatures =
+        ex::completion_signatures<ex::set_value_t(std::size_t)>;
+
+    Aw aw_;
+
+    template <ex::receiver Receiver>
+    struct op_state
+    {
+        using operation_state_concept = ex::operation_state_t;
+
+        Aw aw_;
+        std::remove_cvref_t<Receiver> rcvr_;
+        detail::frame_cb cb_{};
+
+        op_state(Aw aw, Receiver rcvr)
+            : aw_(std::move(aw))
+            , rcvr_(std::move(rcvr))
+        {}
+
+        op_state(op_state const&) = delete;
+        op_state(op_state&&) = delete;
+        op_state& operator=(op_state const&) = delete;
+        op_state& operator=(op_state&&) = delete;
+
+        static void on_resume(detail::frame_cb* p) noexcept
+        {
+            auto* self = static_cast<op_state*>(p->data);
+            auto result = self->aw_.await_resume();
+            ex::set_value(std::move(self->rcvr_), result);
+        }
+
+        static void on_destroy(detail::frame_cb*) noexcept {}
+
+        void start() & noexcept
+        {
+            if (aw_.await_ready())
+            {
+                auto result = aw_.await_resume();
+                ex::set_value(std::move(rcvr_), result);
+                return;
+            }
+
+            cb_.resume = &on_resume;
+            cb_.destroy = &on_destroy;
+            cb_.data = this;
+
+            auto h = std::coroutine_handle<>::from_address(
+                static_cast<void*>(&cb_));
+            aw_.await_suspend(h);
+        }
+    };
+
+    template <ex::receiver Receiver>
+    auto connect(Receiver rcvr) &&
+        -> op_state<std::remove_cvref_t<Receiver>>
+    {
+        return {std::move(aw_), std::move(rcvr)};
+    }
+};
+
+#endif

--- a/bench/beman/ioaw_any_stream.hpp
+++ b/bench/beman/ioaw_any_stream.hpp
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_IOAW_ANY_STREAM_HPP
+#define BOOST_CAPY_BENCH_IOAW_ANY_STREAM_HPP
+
+#include "ioaw_stream_base.hpp"
+
+/// Type-erased IoAwaitable stream. Delegates to ioaw_stream
+/// through the ioaw_stream_base virtual interface.
+struct ioaw_any_stream : ioaw_stream_base
+{
+    ioaw_stream stream_;
+
+    ioaw_stream::read_awaitable
+        read_some(boost::capy::mutable_buffer buf) override
+    {
+        return stream_.read_some(buf);
+    }
+};
+
+#endif

--- a/bench/beman/ioaw_stream.hpp
+++ b/bench/beman/ioaw_stream.hpp
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_IOAW_STREAM_HPP
+#define BOOST_CAPY_BENCH_IOAW_STREAM_HPP
+
+#include <boost/capy/buffers.hpp>
+#include <boost/capy/concept/io_awaitable.hpp>
+#include <boost/capy/continuation.hpp>
+#include <boost/capy/ex/io_env.hpp>
+#include <coroutine>
+#include <cstddef>
+
+/// No-op IoAwaitable stream for benchmarking.
+///
+/// Uses the executor from io_env (passed by capy::task's
+/// transform_awaiter) to post the coroutine back. No separate
+/// pool reference needed — the executor is the capy::thread_pool's.
+struct ioaw_stream
+{
+    struct read_awaitable
+    {
+        boost::capy::continuation cont_{};
+
+        bool await_ready() const noexcept { return false; }
+
+        std::coroutine_handle<>
+        await_suspend(
+            std::coroutine_handle<> h,
+            boost::capy::io_env const* env)
+        {
+            cont_.h = h;
+            env->executor.post(cont_);
+            return std::noop_coroutine();
+        }
+
+        std::size_t await_resume() noexcept { return 0; }
+    };
+
+    static_assert(boost::capy::IoAwaitable<read_awaitable>);
+
+    read_awaitable read_some(boost::capy::mutable_buffer)
+    {
+        return {};
+    }
+};
+
+#endif

--- a/bench/beman/ioaw_stream_base.hpp
+++ b/bench/beman/ioaw_stream_base.hpp
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_IOAW_STREAM_BASE_HPP
+#define BOOST_CAPY_BENCH_IOAW_STREAM_BASE_HPP
+
+#include "ioaw_stream.hpp"
+
+/// Virtual base class for type-erased IoAwaitable streams.
+struct ioaw_stream_base
+{
+    virtual ioaw_stream::read_awaitable
+        read_some(boost::capy::mutable_buffer) = 0;
+    virtual ~ioaw_stream_base() = default;
+};
+
+#endif

--- a/bench/beman/main.cpp
+++ b/bench/beman/main.cpp
@@ -1,0 +1,399 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+//
+// Type Erasure Benchmark
+//
+// Measures per-operation overhead of type erasure for async I/O
+// through a null stream (no real I/O, just posts to the executor).
+// 100M read_some calls per column, single thread.
+//
+// Column A — Awaitable + virtual stream
+//   Virtual base returns an awaitable. coroutine_handle<> is already
+//   type-erased, so no per-operation allocation is needed.
+//   One session instantiation.
+//
+// Column B — Sender, monomorphized (control)
+//   Concrete stream, template session. Zero allocation but requires
+//   one instantiation per stream type.
+//
+// Column C — Sender + type-erased (any_read_sender)
+//   Virtual base returns any_read_sender. connect() must heap-allocate
+//   the operation state because its type is erased.
+//   One session instantiation, one allocation per read_some.
+//
+// Column D — D4126 pure sender pipeline (no coroutine body)
+//   Virtual base returns an awaitable. The D4126 bridge wraps it as
+//   a sender with connect() that uses frame_cb — a synthetic
+//   coroutine frame matching compiler ABI. The session loop is
+//   driven by connect/start and a callback receiver, no coroutine.
+//   The op_state is stored inline and reused each iteration.
+//   Zero per-operation allocation, one instantiation.
+//   This is the column that justifies as_sender: the awaitable is
+//   consumed by the sender protocol, not by a coroutine.
+//
+
+#include "awt_any_stream.hpp"
+#include "d4126_bridge.hpp"
+#include "ioaw_any_stream.hpp"
+#include "sender_any_stream.hpp"
+#include "sender_io_env.hpp"
+#include "sender_stream.hpp"
+
+#include <boost/capy.hpp>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <latch>
+#include <memory>
+
+namespace bex = beman::execution;
+namespace capy = boost::capy;
+
+
+
+// ===================================================================
+// allocation counter
+// ===================================================================
+
+static std::atomic<int64_t> g_alloc_count{0};
+
+void* operator new(std::size_t n)
+{
+    g_alloc_count.fetch_add(1, std::memory_order_relaxed);
+    void* p = std::malloc(n);
+    if (!p)
+        throw std::bad_alloc();
+    return p;
+}
+
+void operator delete(void* p) noexcept
+{
+    std::free(p);
+}
+
+void operator delete(void* p, std::size_t) noexcept
+{
+    std::free(p);
+}
+
+// ===================================================================
+// Column A — Awaitable + virtual stream (capy::thread_pool)
+//
+// Virtual base returns an IoAwaitable. The awaitable gets the
+// executor from io_env (passed by capy::task's transform_awaiter)
+// and calls executor.post(h). Uses capy::thread_pool — the real
+// production executor. One session instantiation.
+// ===================================================================
+
+capy::task<> inner_a(ioaw_stream_base& stream)
+{
+    char buf[64];
+    for (int i = 0; i < 10'000; ++i)
+        (void)co_await stream.read_some(
+            capy::mutable_buffer(buf, sizeof(buf)));
+}
+
+capy::task<> benchmark_a()
+{
+    ioaw_any_stream stream;
+
+    auto before = g_alloc_count.load(std::memory_order_relaxed);
+    auto start = std::chrono::steady_clock::now();
+
+    for (int i = 0; i < 10'000; ++i)
+        co_await inner_a(stream);
+
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto after = g_alloc_count.load(std::memory_order_relaxed);
+    auto us = std::chrono::duration_cast<
+        std::chrono::microseconds>(elapsed).count();
+    auto allocs = after - before;
+
+    std::printf(
+        "A  awaitable + virtual    %10lld us  %5.1f ns/op  "
+        "%lld allocs (%4.2f/op)\n",
+        static_cast<long long>(us),
+        static_cast<double>(us) * 1000.0 / 100'000'000.0,
+        static_cast<long long>(allocs),
+        static_cast<double>(allocs) / 100'000'000.0);
+}
+
+// ===================================================================
+// Column B — Sender, monomorphized (control)
+//
+// Concrete stream, template session function. The sender's op_state
+// is inline (embeds work_item). Zero per-operation allocation, but
+// each stream type requires a separate session instantiation.
+// ===================================================================
+
+using sender_stream_t = sender_stream<sender_executor>;
+
+template <class Stream>
+auto inner_b(
+    Stream& stream,
+    std::allocator_arg_t,
+    std::pmr::polymorphic_allocator<std::byte>) -> io_task<>
+{
+    char buf[64];
+    for (int i = 0; i < 10'000; ++i)
+        (void)co_await stream.read_some(buf);
+}
+
+template <class Stream>
+auto benchmark_b(
+    sender_thread_pool* pool,
+    Stream& stream,
+    std::allocator_arg_t,
+    std::pmr::polymorphic_allocator<std::byte> alloc) -> io_task<>
+{
+    auto before = g_alloc_count.load(std::memory_order_relaxed);
+    auto start = std::chrono::steady_clock::now();
+
+    for (int i = 0; i < 10'000; ++i)
+        co_await inner_b(stream, std::allocator_arg, alloc);
+
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto after = g_alloc_count.load(std::memory_order_relaxed);
+    auto us = std::chrono::duration_cast<
+        std::chrono::microseconds>(elapsed).count();
+    auto allocs = after - before;
+
+    std::printf(
+        "B  sender monomorphized   %10lld us  %5.1f ns/op  "
+        "%lld allocs (%4.2f/op)\n",
+        static_cast<long long>(us),
+        static_cast<double>(us) * 1000.0 / 100'000'000.0,
+        static_cast<long long>(allocs),
+        static_cast<double>(allocs) / 100'000'000.0);
+}
+
+// ===================================================================
+// Column C — Sender + type-erased (any_read_sender)
+//
+// Virtual base returns any_read_sender which wraps a concrete sender
+// in an inline buffer. When consumed, a factory function calls
+// ex::connect through a type-erased receiver (callback_receiver)
+// and heap-allocates the resulting operation state. This is the
+// structural cost of type-erasing a sender: connect(sender, receiver)
+// produces op_state<S, R> whose type depends on both arguments, so
+// type erasure forces a heap allocation.
+// ===================================================================
+
+auto inner_c(
+    sender_stream_base& stream,
+    std::allocator_arg_t,
+    std::pmr::polymorphic_allocator<std::byte>) -> io_task<>
+{
+    char buf[64];
+    for (int i = 0; i < 10'000; ++i)
+        (void)co_await stream.read_some(
+            capy::mutable_buffer(buf, sizeof(buf)));
+}
+
+auto benchmark_c(
+    sender_thread_pool* pool,
+    sender_stream_base& stream,
+    std::allocator_arg_t,
+    std::pmr::polymorphic_allocator<std::byte> alloc) -> io_task<>
+{
+    auto before = g_alloc_count.load(std::memory_order_relaxed);
+    auto start = std::chrono::steady_clock::now();
+
+    for (int i = 0; i < 10'000; ++i)
+        co_await inner_c(stream, std::allocator_arg, alloc);
+
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto after = g_alloc_count.load(std::memory_order_relaxed);
+    auto us = std::chrono::duration_cast<
+        std::chrono::microseconds>(elapsed).count();
+    auto allocs = after - before;
+
+    std::printf(
+        "C  sender type-erased     %10lld us  %5.1f ns/op  "
+        "%lld allocs (%4.2f/op)\n",
+        static_cast<long long>(us),
+        static_cast<double>(us) * 1000.0 / 100'000'000.0,
+        static_cast<long long>(allocs),
+        static_cast<double>(allocs) / 100'000'000.0);
+}
+
+// ===================================================================
+// Column D — D4126 pure sender pipeline (no coroutine body)
+//
+// Virtual base returns an awaitable. The D4126 bridge wraps it as
+// a sender with connect() that uses frame_cb — a synthetic
+// coroutine frame matching compiler ABI. The session loop is
+// driven by connect/start and a callback receiver, no coroutine.
+// The op_state is stored inline and reused each iteration.
+// Zero per-operation allocation, one instantiation.
+//
+// This is the column that justifies as_sender: the awaitable is
+// consumed by the sender protocol, not by a coroutine.
+// ===================================================================
+
+using awt_stream_t = awt_stream<sender_executor>;
+using awt_any_stream_t = awt_any_stream<sender_executor>;
+using awt_stream_base_t = awt_stream_base<sender_executor>;
+
+struct pipeline_runner;
+
+struct pipeline_receiver
+{
+    using receiver_concept = bex::receiver_t;
+    pipeline_runner* runner_;
+
+    struct env_t {};
+    auto get_env() const noexcept -> env_t { return {}; }
+
+    void set_value(std::size_t) && noexcept;
+    void set_stopped() && noexcept {}
+
+    template <class E>
+    void set_error(E&&) && noexcept { std::terminate(); }
+};
+
+using d_sender_t = d4126_connect_sender<awt_stream_t::read_awaitable>;
+using d_op_t = d_sender_t::op_state<pipeline_receiver>;
+
+struct pipeline_runner
+{
+    awt_stream_base_t& stream_;
+    int remaining_;
+    std::latch& done_;
+    int64_t alloc_before_;
+    std::chrono::steady_clock::time_point start_time_;
+
+    alignas(d_op_t) char op_buf_[sizeof(d_op_t)];
+    bool op_active_ = false;
+
+    void destroy_op()
+    {
+        if (op_active_)
+        {
+            reinterpret_cast<d_op_t*>(op_buf_)->~d_op_t();
+            op_active_ = false;
+        }
+    }
+
+    void run_one()
+    {
+        if (remaining_ <= 0)
+        {
+            destroy_op();
+            auto elapsed =
+                std::chrono::steady_clock::now() - start_time_;
+            auto allocs =
+                g_alloc_count.load(std::memory_order_relaxed)
+                - alloc_before_;
+            auto us = std::chrono::duration_cast<
+                std::chrono::microseconds>(elapsed).count();
+
+            std::printf(
+                "D  D4126 pipeline         %10lld us  %5.1f ns/op  "
+                "%lld allocs (%4.2f/op)\n",
+                static_cast<long long>(us),
+                static_cast<double>(us) * 1000.0 / 100'000'000.0,
+                static_cast<long long>(allocs),
+                static_cast<double>(allocs) / 100'000'000.0);
+            done_.count_down();
+            return;
+        }
+        --remaining_;
+
+        destroy_op();
+
+        char buf[64];
+        auto* op = ::new (op_buf_) d_op_t(
+            d_sender_t{stream_.read_some(
+                capy::mutable_buffer(buf, sizeof(buf)))}
+            .connect(pipeline_receiver{this}));
+        op_active_ = true;
+        bex::start(*op);
+    }
+};
+
+void pipeline_receiver::set_value(std::size_t) && noexcept
+{
+    runner_->run_one();
+}
+
+// ===================================================================
+// main
+// ===================================================================
+
+int main()
+{
+    std::printf(
+        "type erasure benchmark: "
+        "100,000,000 read_some calls per column\n\n");
+
+    std::printf(
+        "   %-24s %12s %10s  %s\n",
+        "description", "time", "ns/op", "allocations");
+    std::printf(
+        "   %-24s %12s %10s  %s\n",
+        "------------------------", "----------",
+        "----------", "-------------------");
+
+    // Column A — awaitable + virtual stream (capy::thread_pool)
+    {
+        capy::thread_pool pool(1);
+        capy::run_async(pool.get_executor())(benchmark_a());
+        pool.join();
+    }
+
+    // Column B — sender, monomorphized
+    {
+        sender_thread_pool pool(1);
+        auto ex = pool.get_executor();
+        sender_stream_t stream{ex};
+        pool_scheduler sched{ex};
+        auto* mr = capy::get_recycling_memory_resource();
+        bex::sync_wait(bex::starts_on(sched,
+            benchmark_b(
+                &pool, stream,
+                std::allocator_arg,
+                std::pmr::polymorphic_allocator<std::byte>(mr))));
+        pool.join();
+    }
+
+    // Column C — sender, type-erased
+    {
+        sender_thread_pool pool(1);
+        auto ex = pool.get_executor();
+        sender_any_stream<sender_stream_t> stream{ex};
+        pool_scheduler sched{ex};
+        auto* mr = capy::get_recycling_memory_resource();
+        bex::sync_wait(bex::starts_on(sched,
+            benchmark_c(
+                &pool, stream,
+                std::allocator_arg,
+                std::pmr::polymorphic_allocator<std::byte>(mr))));
+        pool.join();
+    }
+
+    // Column D — D4126 pure sender pipeline
+    {
+        sender_thread_pool pool(1);
+        awt_any_stream_t stream{pool.get_executor()};
+        std::latch done(1);
+        pipeline_runner runner{
+            stream, 100'000'000, done,
+            g_alloc_count.load(std::memory_order_relaxed),
+            std::chrono::steady_clock::now()};
+        runner.run_one();
+        done.wait();
+        pool.join();
+    }
+
+    return 0;
+}

--- a/bench/beman/sender_any_sender.hpp
+++ b/bench/beman/sender_any_sender.hpp
@@ -1,0 +1,188 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+//
+// Type-erased sender for benchmarks.
+//
+// any_read_sender wraps a concrete sender behind a virtual interface.
+// connect() heap-allocates the operation state because its type is
+// erased. This is the structural cost of type-erasing a sender:
+// connect(sender, receiver) produces op_state<S, R> whose type
+// depends on both arguments.
+//
+
+#ifndef BOOST_CAPY_BENCH_SENDER_ANY_SENDER_HPP
+#define BOOST_CAPY_BENCH_SENDER_ANY_SENDER_HPP
+
+#include <beman/execution/execution.hpp>
+
+#include <coroutine>
+#include <cstddef>
+#include <cstring>
+#include <memory>
+#include <utility>
+
+namespace ex = beman::execution;
+
+class any_read_sender
+{
+    struct callback_receiver
+    {
+        using receiver_concept = ex::receiver_t;
+
+        void* data_;
+        void (*on_value_)(void*, std::size_t) noexcept;
+        void (*on_stopped_)(void*) noexcept;
+
+        struct env_t {};
+        auto get_env() const noexcept -> env_t { return {}; }
+
+        void set_value(std::size_t n) && noexcept
+        {
+            on_value_(data_, n);
+        }
+
+        void set_stopped() && noexcept
+        {
+            on_stopped_(data_);
+        }
+
+        template <class E>
+        void set_error(E&&) && noexcept
+        {
+            std::terminate();
+        }
+    };
+
+    struct op_base
+    {
+        virtual void start() noexcept = 0;
+        virtual ~op_base() = default;
+    };
+
+    using factory_fn = std::unique_ptr<op_base>(*)(
+        void* sender_buf, callback_receiver cr);
+    using destroy_fn = void(*)(void* sender_buf) noexcept;
+
+    static constexpr std::size_t buf_size = 64;
+    alignas(std::max_align_t) char buf_[buf_size];
+    factory_fn factory_;
+    destroy_fn destroy_;
+
+public:
+    using sender_concept = ex::sender_t;
+    using completion_signatures =
+        ex::completion_signatures<ex::set_value_t(std::size_t)>;
+
+    template <class Sender>
+    explicit any_read_sender(Sender s)
+    {
+        static_assert(sizeof(Sender) <= buf_size);
+        static_assert(alignof(Sender) <= alignof(std::max_align_t));
+        new (buf_) Sender(std::move(s));
+
+        factory_ = +[](void* stor,
+            callback_receiver r) -> std::unique_ptr<op_base>
+        {
+            auto& sndr = *static_cast<Sender*>(stor);
+
+            using inner_op_t = decltype(ex::connect(
+                std::declval<Sender>(),
+                std::declval<callback_receiver>()));
+
+            struct concrete_op : op_base
+            {
+                inner_op_t inner_;
+                concrete_op(Sender s, callback_receiver r)
+                    : inner_(ex::connect(
+                        std::move(s), std::move(r))) {}
+                void start() noexcept override
+                {
+                    ex::start(inner_);
+                }
+            };
+
+            return std::make_unique<concrete_op>(
+                std::move(sndr), std::move(r));
+        };
+
+        destroy_ = +[](void* stor) noexcept {
+            static_cast<Sender*>(stor)->~Sender();
+        };
+    }
+
+    ~any_read_sender() { destroy_(buf_); }
+
+    any_read_sender(any_read_sender const&) = delete;
+    any_read_sender& operator=(any_read_sender const&) = delete;
+
+    any_read_sender(any_read_sender&& o) noexcept
+        : factory_(o.factory_), destroy_(o.destroy_)
+    {
+        std::memcpy(buf_, o.buf_, buf_size);
+        o.destroy_ = +[](void*) noexcept {};
+    }
+
+    any_read_sender& operator=(any_read_sender&&) = delete;
+
+    template <typename Promise>
+    auto as_awaitable(Promise&)
+    {
+        struct aw
+        {
+            alignas(std::max_align_t) char buf_[buf_size];
+            factory_fn factory_;
+            destroy_fn destroy_;
+            std::unique_ptr<op_base> inner_;
+            std::coroutine_handle<> cont_{};
+            std::size_t result_{};
+
+            explicit aw(any_read_sender& sndr)
+                : factory_(sndr.factory_)
+                , destroy_(sndr.destroy_)
+            {
+                std::memcpy(buf_, sndr.buf_, buf_size);
+                sndr.destroy_ = +[](void*) noexcept {};
+            }
+
+            ~aw() { destroy_(buf_); }
+
+            aw(aw const&) = delete;
+            aw(aw&&) = delete;
+            aw& operator=(aw const&) = delete;
+            aw& operator=(aw&&) = delete;
+
+            bool await_ready() const noexcept { return false; }
+
+            void await_suspend(
+                std::coroutine_handle<> h) noexcept
+            {
+                cont_ = h;
+                inner_ = factory_(buf_, callback_receiver{
+                    this,
+                    +[](void* p, std::size_t n) noexcept {
+                        auto* a = static_cast<aw*>(p);
+                        a->result_ = n;
+                        a->cont_.resume();
+                    },
+                    +[](void* p) noexcept {
+                        auto* a = static_cast<aw*>(p);
+                        a->cont_.resume();
+                    }
+                });
+                inner_->start();
+            }
+
+            std::size_t await_resume() noexcept { return result_; }
+        };
+        return aw{*this};
+    }
+};
+
+#endif

--- a/bench/beman/sender_any_stream.hpp
+++ b/bench/beman/sender_any_stream.hpp
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_SENDER_ANY_STREAM_HPP
+#define BOOST_CAPY_BENCH_SENDER_ANY_STREAM_HPP
+
+#include "sender_stream_base.hpp"
+
+/// Type-erased sender stream. Wraps a concrete sender stream
+/// behind sender_stream_base. Each read_some constructs the
+/// concrete sender and wraps it in any_read_sender, which
+/// heap-allocates on connect.
+template <class Stream>
+struct sender_any_stream : sender_stream_base
+{
+    Stream stream_;
+
+    template <class... Args>
+    explicit sender_any_stream(Args&&... args)
+        : stream_{std::forward<Args>(args)...} {}
+
+    any_read_sender
+        read_some(boost::capy::mutable_buffer buf) override
+    {
+        return any_read_sender{stream_.read_some(buf)};
+    }
+};
+
+#endif

--- a/bench/beman/sender_io_env.hpp
+++ b/bench/beman/sender_io_env.hpp
@@ -1,0 +1,147 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+//
+// Beman execution environment for benchmarks.
+//
+// Provides a minimal scheduler, executor, and io_env that bridge
+// sender_thread_pool to beman::execution::task. Used by any
+// benchmark that co_awaits senders from an io_task.
+//
+
+#ifndef BOOST_CAPY_BENCH_SENDER_IO_ENV_HPP
+#define BOOST_CAPY_BENCH_SENDER_IO_ENV_HPP
+
+#include "sender_thread_pool.hpp"
+
+#include <beman/execution/execution.hpp>
+#include <beman/task/task.hpp>
+
+#include <coroutine>
+#include <memory_resource>
+#include <type_traits>
+#include <utility>
+
+namespace ex = beman::execution;
+
+struct pool_scheduler
+{
+    using scheduler_concept = ex::scheduler_t;
+
+    sender_executor ex_;
+
+    struct env
+    {
+        sender_executor ex_;
+        auto query(
+            ex::get_completion_scheduler_t<ex::set_value_t> const&
+        ) const noexcept
+        {
+            return pool_scheduler{ex_};
+        }
+    };
+
+    template <ex::receiver Receiver>
+    struct op_state : work_item
+    {
+        using operation_state_concept = ex::operation_state_t;
+
+        std::remove_cvref_t<Receiver> rcvr_;
+        sender_executor ex_;
+
+        op_state(Receiver rcvr, sender_executor ex)
+            : rcvr_(std::move(rcvr))
+            , ex_(ex)
+        {}
+
+        op_state(op_state const&) = delete;
+        op_state(op_state&&) = delete;
+        op_state& operator=(op_state const&) = delete;
+        op_state& operator=(op_state&&) = delete;
+
+        void execute() noexcept override
+        {
+            ex::set_value(std::move(rcvr_));
+        }
+
+        void start() & noexcept
+        {
+            ex_.enqueue(this);
+        }
+    };
+
+    struct sender
+    {
+        using sender_concept = ex::sender_t;
+        using completion_signatures =
+            ex::completion_signatures<ex::set_value_t()>;
+
+        sender_executor ex_;
+
+        auto get_env() const noexcept { return env{ex_}; }
+
+        template <ex::receiver Receiver>
+        auto connect(Receiver&& rcvr)
+            -> op_state<std::remove_cvref_t<Receiver>>
+        {
+            return {std::forward<Receiver>(rcvr), ex_};
+        }
+    };
+
+    auto schedule() -> sender { return {ex_}; }
+    bool operator==(pool_scheduler const&) const = default;
+};
+
+struct get_sender_executor_t
+{
+    constexpr bool query(
+        ex::forwarding_query_t const&) const noexcept
+    {
+        return true;
+    }
+
+    template <typename Env>
+        requires requires(Env const& env) {
+            env.query(std::declval<get_sender_executor_t const&>());
+        }
+    auto operator()(Env const& env) const noexcept
+    {
+        return env.query(*this);
+    }
+};
+inline constexpr get_sender_executor_t get_sender_executor{};
+
+struct io_env
+{
+    using scheduler_type = pool_scheduler;
+    using allocator_type = std::pmr::polymorphic_allocator<std::byte>;
+
+    sender_executor executor;
+
+    auto query(
+        get_sender_executor_t const&) const noexcept -> sender_executor
+    {
+        return executor;
+    }
+
+    io_env() = default;
+
+    template <typename Env>
+        requires requires(Env const& e) {
+            pool_scheduler{ex::get_scheduler(e)};
+        }
+    io_env(Env const& e)
+        : executor(pool_scheduler{ex::get_scheduler(e)}.ex_)
+    {}
+};
+
+template <typename T = void>
+using io_task = ex::task<T, io_env>;
+
+#endif

--- a/bench/beman/sender_stream.hpp
+++ b/bench/beman/sender_stream.hpp
@@ -1,0 +1,119 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+//
+// No-op sender stream for benchmarks.
+//
+// Template parameter Ex is an executor type with enqueue(work_item*)
+// (e.g. sender_executor). Stored by value — the stream holds a
+// handle, not a context. The sender provides both as_awaitable
+// (for coroutine consumption) and connect (for sender pipeline
+// consumption via any_read_sender or D4126).
+//
+
+#ifndef BOOST_CAPY_BENCH_SENDER_STREAM_HPP
+#define BOOST_CAPY_BENCH_SENDER_STREAM_HPP
+
+#include "thread_pool.hpp"
+
+#include <beman/execution/execution.hpp>
+
+#include <coroutine>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace ex = beman::execution;
+
+template <class Ex>
+struct sender_stream
+{
+    Ex ex_;
+
+    struct read_sender
+    {
+        using sender_concept = ex::sender_t;
+        using completion_signatures =
+            ex::completion_signatures<ex::set_value_t(std::size_t)>;
+
+        Ex ex_;
+
+        // awaitable path (co_awaited from io_task via as_awaitable)
+        template <typename Promise>
+        struct awaitable : work_item
+        {
+            Ex ex_;
+            std::coroutine_handle<> h_{};
+
+            explicit awaitable(Ex ex) noexcept : ex_(ex) {}
+
+            bool await_ready() const noexcept { return false; }
+
+            void await_suspend(std::coroutine_handle<> h)
+            {
+                h_ = h;
+                ex_.enqueue(this);
+            }
+
+            std::size_t await_resume() noexcept { return 0; }
+
+            void execute() noexcept override { h_.resume(); }
+        };
+
+        template <typename Promise>
+        auto as_awaitable(Promise&) -> awaitable<Promise>
+        {
+            return awaitable<Promise>{ex_};
+        }
+
+        // sender path (consumed via ex::connect)
+        template <ex::receiver Receiver>
+        struct op_state : work_item
+        {
+            using operation_state_concept = ex::operation_state_t;
+
+            std::remove_cvref_t<Receiver> rcvr_;
+            Ex ex_;
+
+            op_state(Receiver rcvr, Ex ex)
+                : rcvr_(std::move(rcvr))
+                , ex_(ex)
+            {}
+
+            op_state(op_state const&) = delete;
+            op_state(op_state&&) = delete;
+            op_state& operator=(op_state const&) = delete;
+            op_state& operator=(op_state&&) = delete;
+
+            void execute() noexcept override
+            {
+                ex::set_value(std::move(rcvr_), std::size_t{0});
+            }
+
+            void start() & noexcept
+            {
+                ex_.enqueue(this);
+            }
+        };
+
+        template <ex::receiver Receiver>
+        auto connect(Receiver&& rcvr)
+            -> op_state<std::remove_cvref_t<Receiver>>
+        {
+            return {std::forward<Receiver>(rcvr), ex_};
+        }
+    };
+
+    read_sender read_some(auto)
+    {
+        return {ex_};
+    }
+};
+
+#endif

--- a/bench/beman/sender_stream_base.hpp
+++ b/bench/beman/sender_stream_base.hpp
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_SENDER_STREAM_BASE_HPP
+#define BOOST_CAPY_BENCH_SENDER_STREAM_BASE_HPP
+
+#include "sender_any_sender.hpp"
+
+#include <boost/capy/buffers.hpp>
+
+/// Virtual base class for type-erased sender streams.
+struct sender_stream_base
+{
+    virtual any_read_sender
+        read_some(boost::capy::mutable_buffer) = 0;
+    virtual ~sender_stream_base() = default;
+};
+
+#endif

--- a/bench/beman/sender_thread_pool.hpp
+++ b/bench/beman/sender_thread_pool.hpp
@@ -1,0 +1,215 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+//
+// Minimal thread pool + executor for sender benchmarks.
+//
+// sender_thread_pool is the execution context.
+// sender_executor is the lightweight handle obtained via
+// get_executor(). Streams hold the executor, not the pool.
+//
+
+#ifndef BOOST_CAPY_BENCH_SENDER_THREAD_POOL_HPP
+#define BOOST_CAPY_BENCH_SENDER_THREAD_POOL_HPP
+
+#include "thread_pool.hpp"
+
+#include <atomic>
+#include <condition_variable>
+#include <coroutine>
+#include <cstddef>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+class sender_thread_pool;
+
+/// Lightweight executor handle referencing a sender_thread_pool.
+struct sender_executor
+{
+    sender_thread_pool* pool_ = nullptr;
+
+    void post(std::coroutine_handle<> h) const;
+    void enqueue(work_item* w) const;
+
+    auto dispatch(std::coroutine_handle<> h) const
+        -> std::coroutine_handle<>;
+
+    bool operator==(
+        sender_executor const&) const noexcept = default;
+};
+
+class sender_thread_pool
+{
+    struct coro_work : work_item
+    {
+        std::coroutine_handle<> h_;
+
+        explicit coro_work(std::coroutine_handle<> h) noexcept
+            : h_(h) {}
+
+        void execute() noexcept override
+        {
+            auto h = h_;
+            delete this;
+            h.resume();
+        }
+    };
+
+    std::mutex mutex_;
+    std::condition_variable work_cv_;
+    std::condition_variable done_cv_;
+    intrusive_queue<work_item> q_;
+    std::vector<std::thread> threads_;
+    std::atomic<std::size_t> outstanding_work_{0};
+    bool stop_{false};
+    bool joined_{false};
+    std::size_t num_threads_;
+    std::once_flag start_flag_;
+
+    void ensure_started()
+    {
+        std::call_once(start_flag_, [this] {
+            threads_.reserve(num_threads_);
+            for (std::size_t i = 0; i < num_threads_; ++i)
+                threads_.emplace_back([this] { run(); });
+        });
+    }
+
+    void run()
+    {
+        for (;;)
+        {
+            work_item* w = nullptr;
+            {
+                std::unique_lock lock(mutex_);
+                work_cv_.wait(lock, [this] {
+                    return !q_.empty() || stop_;
+                });
+                if (stop_)
+                    return;
+                w = q_.pop();
+            }
+            if (w)
+                w->execute();
+        }
+    }
+
+public:
+    using executor_type = sender_executor;
+
+    explicit sender_thread_pool(std::size_t num_threads = 0)
+        : num_threads_(num_threads == 0
+            ? (std::max)(std::thread::hardware_concurrency(), 1u)
+            : num_threads)
+    {}
+
+    ~sender_thread_pool()
+    {
+        stop();
+        join();
+    }
+
+    sender_thread_pool(sender_thread_pool const&) = delete;
+    sender_thread_pool& operator=(sender_thread_pool const&) = delete;
+
+    sender_executor get_executor() noexcept
+    {
+        return sender_executor{this};
+    }
+
+    void enqueue(work_item* w)
+    {
+        ensure_started();
+        {
+            std::lock_guard lock(mutex_);
+            q_.push(w);
+        }
+        work_cv_.notify_one();
+    }
+
+    void post(std::coroutine_handle<> h)
+    {
+        enqueue(new coro_work(h));
+    }
+
+    void on_work_started() noexcept
+    {
+        outstanding_work_.fetch_add(1, std::memory_order_acq_rel);
+    }
+
+    void on_work_finished() noexcept
+    {
+        if (outstanding_work_.fetch_sub(
+            1, std::memory_order_acq_rel) == 1)
+        {
+            std::lock_guard lock(mutex_);
+            if (joined_ && !stop_)
+                stop_ = true;
+            done_cv_.notify_all();
+            work_cv_.notify_all();
+        }
+    }
+
+    void join() noexcept
+    {
+        {
+            std::unique_lock lock(mutex_);
+            if (joined_)
+                return;
+            joined_ = true;
+
+            if (outstanding_work_.load(
+                std::memory_order_acquire) == 0)
+            {
+                stop_ = true;
+                work_cv_.notify_all();
+            }
+            else
+            {
+                done_cv_.wait(lock, [this] { return stop_; });
+            }
+        }
+
+        for (auto& t : threads_)
+            if (t.joinable())
+                t.join();
+    }
+
+    void stop() noexcept
+    {
+        {
+            std::lock_guard lock(mutex_);
+            stop_ = true;
+        }
+        work_cv_.notify_all();
+        done_cv_.notify_all();
+    }
+};
+
+// sender_executor inline definitions (need sender_thread_pool complete)
+
+inline void sender_executor::post(std::coroutine_handle<> h) const
+{
+    pool_->post(h);
+}
+
+inline void sender_executor::enqueue(work_item* w) const
+{
+    pool_->enqueue(w);
+}
+
+inline auto sender_executor::dispatch(std::coroutine_handle<> h) const
+    -> std::coroutine_handle<>
+{
+    pool_->post(h);
+    return std::noop_coroutine();
+}
+
+#endif

--- a/bench/beman/thread_pool.hpp
+++ b/bench/beman/thread_pool.hpp
@@ -1,0 +1,69 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+//
+// Intrusive queue and work_item base for benchmarks.
+//
+
+#ifndef BOOST_CAPY_BENCH_THREAD_POOL_HPP
+#define BOOST_CAPY_BENCH_THREAD_POOL_HPP
+
+#include <cstddef>
+
+template <typename T>
+class intrusive_queue
+{
+public:
+    class node
+    {
+        friend class intrusive_queue;
+        T* next_;
+    };
+
+private:
+    T* head_ = nullptr;
+    T* tail_ = nullptr;
+
+public:
+    intrusive_queue() = default;
+    intrusive_queue(intrusive_queue const&) = delete;
+    intrusive_queue& operator=(intrusive_queue const&) = delete;
+
+    bool empty() const noexcept { return head_ == nullptr; }
+
+    void push(T* w) noexcept
+    {
+        w->next_ = nullptr;
+        if (tail_)
+            tail_->next_ = w;
+        else
+            head_ = w;
+        tail_ = w;
+    }
+
+    T* pop() noexcept
+    {
+        if (!head_)
+            return nullptr;
+        T* w = head_;
+        head_ = head_->next_;
+        if (!head_)
+            tail_ = nullptr;
+        return w;
+    }
+};
+
+struct work_item : intrusive_queue<work_item>::node
+{
+    virtual void execute() noexcept = 0;
+protected:
+    ~work_item() = default;
+};
+
+#endif

--- a/example/awaitable-sender/CMakeLists.txt
+++ b/example/awaitable-sender/CMakeLists.txt
@@ -10,12 +10,12 @@
 include(FetchContent)
 
 FetchContent_Declare(
-    beman-execution
+    execution
     GIT_REPOSITORY https://github.com/bemanproject/execution.git
     GIT_TAG main
     SYSTEM
 )
-FetchContent_MakeAvailable(beman-execution)
+FetchContent_MakeAvailable(execution)
 
 file(GLOB_RECURSE PFILES CONFIGURE_DEPENDS *.cpp *.hpp
     CMakeLists.txt

--- a/example/sender-bridge/CMakeLists.txt
+++ b/example/sender-bridge/CMakeLists.txt
@@ -10,12 +10,12 @@
 include(FetchContent)
 
 FetchContent_Declare(
-    beman-execution
+    execution
     GIT_REPOSITORY https://github.com/bemanproject/execution.git
     GIT_TAG main
     SYSTEM
 )
-FetchContent_MakeAvailable(beman-execution)
+FetchContent_MakeAvailable(execution)
 
 file(GLOB_RECURSE PFILES CONFIGURE_DEPENDS *.cpp *.hpp
     CMakeLists.txt

--- a/example/sender-bridge/sender_awaitable.hpp
+++ b/example/sender-bridge/sender_awaitable.hpp
@@ -10,6 +10,7 @@
 #ifndef BOOST_CAPY_EXAMPLE_SENDER_AWAITABLE_HPP
 #define BOOST_CAPY_EXAMPLE_SENDER_AWAITABLE_HPP
 
+#include <boost/capy/continuation.hpp>
 #include <boost/capy/error.hpp>
 #include <boost/capy/ex/io_env.hpp>
 #include <boost/capy/io_result.hpp>
@@ -113,7 +114,7 @@ struct bridge_receiver
         beman::execution::receiver_t;
 
     result_variant<ValueTuple, HasEc>* result_;
-    std::coroutine_handle<>            cont_;
+    continuation                       cont_;
     io_env const*                      env_;
 
     auto get_env() const noexcept -> bridge_env
@@ -258,7 +259,7 @@ struct [[nodiscard]] sender_awaitable
             beman::execution::connect(
                 std::move(sndr_),
                 receiver_type{
-                    &result_, h, env}));
+                    &result_, {h}, env}));
         op_constructed_ = true;
         beman::execution::start(
             *std::launder(

--- a/src/ex/thread_pool.cpp
+++ b/src/ex/thread_pool.cpp
@@ -82,7 +82,8 @@ class thread_pool::impl
     }
 
     std::mutex mutex_;
-    std::condition_variable cv_;
+    std::condition_variable work_cv_;
+    std::condition_variable done_cv_;
     std::vector<std::thread> threads_;
     std::atomic<std::size_t> outstanding_work_{0};
     bool stop_{false};
@@ -130,7 +131,7 @@ public:
             std::lock_guard<std::mutex> lock(mutex_);
             push(&c);
         }
-        cv_.notify_one();
+        work_cv_.notify_one();
     }
 
     void
@@ -148,7 +149,8 @@ public:
             std::lock_guard<std::mutex> lock(mutex_);
             if(joined_ && !stop_)
                 stop_ = true;
-            cv_.notify_all();
+            done_cv_.notify_all();
+            work_cv_.notify_all();
         }
     }
 
@@ -165,11 +167,11 @@ public:
                 std::memory_order_acquire) == 0)
             {
                 stop_ = true;
-                cv_.notify_all();
+                work_cv_.notify_all();
             }
             else
             {
-                cv_.wait(lock, [this]{
+                done_cv_.wait(lock, [this]{
                     return stop_;
                 });
             }
@@ -187,7 +189,8 @@ public:
             std::lock_guard<std::mutex> lock(mutex_);
             stop_ = true;
         }
-        cv_.notify_all();
+        work_cv_.notify_all();
+        done_cv_.notify_all();
     }
 
 private:
@@ -214,7 +217,7 @@ private:
             continuation* c = nullptr;
             {
                 std::unique_lock<std::mutex> lock(mutex_);
-                cv_.wait(lock, [this]{
+                work_cv_.wait(lock, [this]{
                     return !empty() ||
                         stop_;
                 });


### PR DESCRIPTION
Add a benchmark comparing capy's awaitable-based type erasure against beman::execution sender-based approaches across four columns: virtual awaitable stream, monomorphized sender, type-erased sender, and D4126 sender pipeline.

Split thread_pool's single condition_variable into work_cv_ (worker notification) and done_cv_ (join completion) to eliminate spurious futex wakeups when join() sleeps on the same CV as worker threads. Apply the same fix to the bench thread pool.

Fix FetchContent name collision between beman-task and example dependencies by unifying on the "execution" name, and update example sender_awaitable to use continuation for the new executor::post interface.

Gate BOOST_CAPY_BUILD_P2300_EXAMPLES on CMAKE_CXX_STANDARD
>= 23 at the project level. Pin beman-task to 6163df9 for
API stability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enforced C++23 standard requirement for P2300 examples; builds will fail if standard version is not met or undefined.
  * Updated build dependency naming conventions across example projects.

* **Refactor**
  * Improved thread pool synchronization mechanisms.
  * Refined internal continuation handling in sender-awaitable implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->