### PR TITLE
Replace sender_executor with P2300-realistic scheduler model

### DIFF
--- a/bench/beman/main.cpp
+++ b/bench/beman/main.cpp
@@ -246,9 +246,8 @@ int main()
     // Native — sndr_read_stream
     {
         sender_thread_pool pool(1);
-        auto ex = pool.get_executor();
-        sndr_read_stream stream{ex};
-        pool_scheduler sched{ex};
+        sndr_read_stream stream{&pool};
+        auto sched = pool.get_scheduler();
         int count = OPS_PER_CELL;
         char buf[64];
         auto before = g_alloc_count.load(
@@ -275,9 +274,8 @@ int main()
     // Abstract — sndr_io_read_stream
     {
         sender_thread_pool pool(1);
-        auto ex = pool.get_executor();
-        sndr_io_read_stream_impl stream{ex};
-        pool_scheduler sched{ex};
+        sndr_io_read_stream_impl stream{&pool};
+        auto sched = pool.get_scheduler();
         int count = OPS_PER_CELL;
         char buf[64];
         auto before = g_alloc_count.load(
@@ -305,9 +303,8 @@ int main()
     // Type erased — sndr_any_read_stream
     {
         sender_thread_pool pool(1);
-        auto ex = pool.get_executor();
-        sndr_any_read_stream stream(sndr_read_stream{ex});
-        pool_scheduler sched{ex};
+        sndr_any_read_stream stream(sndr_read_stream{&pool});
+        auto sched = pool.get_scheduler();
         int count = OPS_PER_CELL;
         char buf[64];
         auto before = g_alloc_count.load(
@@ -337,7 +334,7 @@ int main()
     {
         sender_thread_pool pool(1);
         ioaw_read_stream stream;
-        pool_scheduler sched{pool.get_executor()};
+        auto sched = pool.get_scheduler();
         int count = OPS_PER_CELL;
         char buf[64];
         auto before = g_alloc_count.load(
@@ -365,7 +362,7 @@ int main()
     {
         sender_thread_pool pool(1);
         ioaw_io_read_stream_impl stream;
-        pool_scheduler sched{pool.get_executor()};
+        auto sched = pool.get_scheduler();
         int count = OPS_PER_CELL;
         char buf[64];
         auto before = g_alloc_count.load(
@@ -397,7 +394,7 @@ int main()
         sender_thread_pool pool(1);
         ioaw_read_stream concrete;
         capy::any_read_stream stream(&concrete);
-        pool_scheduler sched{pool.get_executor()};
+        auto sched = pool.get_scheduler();
         int count = OPS_PER_CELL;
         char buf[64];
         auto before = g_alloc_count.load(
@@ -459,9 +456,8 @@ int main()
     // Native — sndr_read_stream
     {
         sender_thread_pool pool(1);
-        auto ex = pool.get_executor();
-        sender_as_capy_executor adapter{ex};
-        sndr_read_stream stream{ex};
+        sender_as_capy_executor adapter{&pool};
+        sndr_read_stream stream{&pool};
         capy::run_async(adapter)(
             capy_accept_sndr(stream, grid[run][CAPY_TASK][NATIVE_STREAM][BRIDGED_EXEC_MODEL]));
         pool.join();
@@ -470,9 +466,8 @@ int main()
     // Abstract — sndr_io_read_stream
     {
         sender_thread_pool pool(1);
-        auto ex = pool.get_executor();
-        sender_as_capy_executor adapter{ex};
-        sndr_io_read_stream_impl stream{ex};
+        sender_as_capy_executor adapter{&pool};
+        sndr_io_read_stream_impl stream{&pool};
         capy::run_async(adapter)(
             capy_accept_sndr(
                 static_cast<sndr_io_read_stream&>(stream),
@@ -483,9 +478,8 @@ int main()
     // Type erased — sndr_any_read_stream
     {
         sender_thread_pool pool(1);
-        auto ex = pool.get_executor();
-        sender_as_capy_executor adapter{ex};
-        sndr_any_read_stream stream(sndr_read_stream{ex});
+        sender_as_capy_executor adapter{&pool};
+        sndr_any_read_stream stream(sndr_read_stream{&pool});
         capy::run_async(adapter)(
             capy_accept_sndr(stream, grid[run][CAPY_TASK][TYPE_ERASED_STREAM][BRIDGED_EXEC_MODEL]));
         pool.join();
@@ -498,9 +492,8 @@ int main()
     // Native — sndr_read_stream
     {
         sender_thread_pool pool(1);
-        auto ex = pool.get_executor();
-        sndr_read_stream stream{ex};
-        pool_scheduler sched{ex};
+        sndr_read_stream stream{&pool};
+        auto sched = pool.get_scheduler();
         auto* mr = capy::get_recycling_memory_resource();
         bex::sync_wait(bex::starts_on(sched,
             bex_accept(
@@ -513,9 +506,8 @@ int main()
     // Abstract — sndr_io_read_stream
     {
         sender_thread_pool pool(1);
-        auto ex = pool.get_executor();
-        sndr_io_read_stream_impl stream{ex};
-        pool_scheduler sched{ex};
+        sndr_io_read_stream_impl stream{&pool};
+        auto sched = pool.get_scheduler();
         auto* mr = capy::get_recycling_memory_resource();
         bex::sync_wait(bex::starts_on(sched,
             bex_accept(
@@ -529,9 +521,8 @@ int main()
     // Type erased — sndr_any_read_stream
     {
         sender_thread_pool pool(1);
-        auto ex = pool.get_executor();
-        sndr_any_read_stream stream(sndr_read_stream{ex});
-        pool_scheduler sched{ex};
+        sndr_any_read_stream stream(sndr_read_stream{&pool});
+        auto sched = pool.get_scheduler();
         auto* mr = capy::get_recycling_memory_resource();
         bex::sync_wait(bex::starts_on(sched,
             bex_accept(
@@ -546,9 +537,8 @@ int main()
     // Native — ioaw_read_stream
     {
         sender_thread_pool pool(1);
-        auto ex = pool.get_executor();
         ioaw_read_stream stream;
-        pool_scheduler sched{ex};
+        auto sched = pool.get_scheduler();
         auto* mr = capy::get_recycling_memory_resource();
         bex::sync_wait(bex::starts_on(sched,
             bex_accept_ioaw(
@@ -561,9 +551,8 @@ int main()
     // Abstract — ioaw_io_read_stream
     {
         sender_thread_pool pool(1);
-        auto ex = pool.get_executor();
         ioaw_io_read_stream_impl stream;
-        pool_scheduler sched{ex};
+        auto sched = pool.get_scheduler();
         auto* mr = capy::get_recycling_memory_resource();
         bex::sync_wait(bex::starts_on(sched,
             bex_accept_ioaw(
@@ -577,10 +566,9 @@ int main()
     // Type erased — capy::any_read_stream
     {
         sender_thread_pool pool(1);
-        auto ex = pool.get_executor();
         ioaw_read_stream concrete;
         capy::any_read_stream stream(&concrete);
-        pool_scheduler sched{ex};
+        auto sched = pool.get_scheduler();
         auto* mr = capy::get_recycling_memory_resource();
         bex::sync_wait(bex::starts_on(sched,
             bex_accept_ioaw(

--- a/bench/beman/sender_io_env.hpp
+++ b/bench/beman/sender_io_env.hpp
@@ -10,9 +10,9 @@
 //
 // Beman execution environment for benchmarks.
 //
-// Provides a minimal scheduler, executor, and io_env that bridge
-// sender_thread_pool to beman::execution::task. Used by any
-// benchmark that co_awaits senders from an io_task.
+// Provides pool_scheduler (the P2300 scheduler for
+// sender_thread_pool), the capy executor adapter, and
+// the io_env for beman::execution::task.
 //
 
 #ifndef BOOST_CAPY_BENCH_SENDER_IO_ENV_HPP
@@ -32,31 +32,28 @@
 #include <type_traits>
 #include <utility>
 
-// Adapter making sender_executor satisfy capy's Executor
-// concept so capy::task can run on sender_thread_pool.
+// Adapter making sender_thread_pool satisfy capy's
+// Executor concept so capy::task can run on it.
 struct sender_as_capy_executor
 {
-    sender_executor ex_;
+    sender_thread_pool* pool_;
 
     boost::capy::execution_context& context() const noexcept
     {
-        return *ex_.pool_;
+        return *pool_;
     }
 
     void on_work_started() const noexcept
     {
-        ex_.pool_->on_work_started();
+        pool_->on_work_started();
     }
 
     void on_work_finished() const noexcept
     {
-        ex_.pool_->on_work_finished();
+        pool_->on_work_finished();
     }
 
-    void post(boost::capy::continuation& c) const
-    {
-        ex_.post(c.h);
-    }
+    void post(boost::capy::continuation& c) const;
 
     // Return the handle for symmetric transfer so the
     // caller resumes the coroutine inline. Posting would
@@ -78,17 +75,17 @@ struct pool_scheduler
 {
     using scheduler_concept = ex::scheduler_t;
 
-    sender_executor ex_;
+    sender_thread_pool* pool_;
 
     struct env
     {
-        sender_executor ex_;
+        sender_thread_pool* pool_;
 
         auto query(
             ex::get_completion_scheduler_t<ex::set_value_t> const&
         ) const noexcept
         {
-            return pool_scheduler{ex_};
+            return pool_scheduler{pool_};
         }
     };
 
@@ -98,11 +95,11 @@ struct pool_scheduler
         using operation_state_concept = ex::operation_state_t;
 
         std::remove_cvref_t<Receiver> rcvr_;
-        sender_executor ex_;
+        sender_thread_pool* pool_;
 
-        op_state(Receiver rcvr, sender_executor ex)
+        op_state(Receiver rcvr, sender_thread_pool* pool)
             : rcvr_(std::move(rcvr))
-            , ex_(ex)
+            , pool_(pool)
         {}
 
         op_state(op_state const&) = delete;
@@ -117,7 +114,7 @@ struct pool_scheduler
 
         void start() & noexcept
         {
-            ex_.enqueue(this);
+            pool_->enqueue(this);
         }
     };
 
@@ -127,15 +124,15 @@ struct pool_scheduler
         using completion_signatures =
             ex::completion_signatures<ex::set_value_t()>;
 
-        sender_executor ex_;
+        sender_thread_pool* pool_;
 
-        auto get_env() const noexcept { return env{ex_}; }
+        auto get_env() const noexcept { return env{pool_}; }
 
         template <ex::receiver Receiver>
         auto connect(Receiver&& rcvr)
             -> op_state<std::remove_cvref_t<Receiver>>
         {
-            return {std::forward<Receiver>(rcvr), ex_};
+            return {std::forward<Receiver>(rcvr), pool_};
         }
     };
 
@@ -143,19 +140,80 @@ struct pool_scheduler
         boost::capy::get_io_executor_t const&
     ) const noexcept -> sender_as_capy_executor
     {
-        return sender_as_capy_executor{ex_};
+        return sender_as_capy_executor{pool_};
     }
 
-    auto schedule() -> sender { return {ex_}; }
+    auto schedule() -> sender { return {pool_}; }
     bool operator==(pool_scheduler const&) const = default;
 };
+
+inline pool_scheduler
+sender_thread_pool::get_scheduler() noexcept
+{
+    return pool_scheduler{this};
+}
+
+// P2300 has no post(coroutine_handle<>). To resume a
+// coroutine on a scheduler you must go through
+// schedule → connect → start. The operation state
+// must be heap-allocated because the coroutine is
+// suspended and cannot host it.
+struct scheduled_resume
+{
+    struct receiver
+    {
+        using receiver_concept = ex::receiver_t;
+
+        scheduled_resume* self_;
+
+        void set_value() && noexcept
+        {
+            auto h = self_->h_;
+            delete self_;
+            h.resume();
+        }
+
+        void set_error(auto&&) && noexcept
+        {
+            std::terminate();
+        }
+
+        void set_stopped() && noexcept
+        {
+            std::terminate();
+        }
+    };
+
+    using op_state_t =
+        pool_scheduler::op_state<receiver>;
+
+    std::coroutine_handle<> h_;
+    op_state_t op_;
+
+    scheduled_resume(
+        pool_scheduler sched,
+        std::coroutine_handle<> h)
+        : h_(h)
+        , op_(ex::connect(
+            sched.schedule(),
+            receiver{this}))
+    {}
+};
+
+inline void sender_as_capy_executor::post(
+    boost::capy::continuation& c) const
+{
+    auto* p = new scheduled_resume(
+        pool_scheduler{pool_}, c.h);
+    ex::start(p->op_);
+}
 
 struct io_env
 {
     using scheduler_type = pool_scheduler;
     using allocator_type = std::pmr::polymorphic_allocator<std::byte>;
 
-    sender_executor executor;
+    sender_thread_pool* pool_ = nullptr;
 
     io_env() = default;
 
@@ -164,7 +222,7 @@ struct io_env
             pool_scheduler{ex::get_scheduler(e)};
         }
     io_env(Env const& e)
-        : executor(pool_scheduler{ex::get_scheduler(e)}.ex_)
+        : pool_(pool_scheduler{ex::get_scheduler(e)}.pool_)
     {}
 };
 

--- a/bench/beman/sender_thread_pool.hpp
+++ b/bench/beman/sender_thread_pool.hpp
@@ -8,11 +8,11 @@
 //
 
 //
-// Minimal thread pool + executor for sender benchmarks.
+// Minimal thread pool for sender benchmarks.
 //
 // sender_thread_pool is the execution context.
-// sender_executor is the lightweight handle obtained via
-// get_executor(). Streams hold the executor, not the pool.
+// pool_scheduler (defined in sender_io_env.hpp)
+// is the P2300 scheduler handle.
 //
 
 #ifndef BOOST_CAPY_BENCH_SENDER_THREAD_POOL_HPP
@@ -24,47 +24,16 @@
 
 #include <atomic>
 #include <condition_variable>
-#include <coroutine>
 #include <cstddef>
 #include <mutex>
 #include <thread>
 #include <vector>
 
-class sender_thread_pool;
-
-/// Lightweight executor handle referencing a sender_thread_pool.
-struct sender_executor
-{
-    sender_thread_pool* pool_ = nullptr;
-
-    void post(std::coroutine_handle<> h) const;
-    void enqueue(work_item* w) const;
-
-    auto dispatch(std::coroutine_handle<> h) const
-        -> std::coroutine_handle<>;
-
-    bool operator==(
-        sender_executor const&) const noexcept = default;
-};
+struct pool_scheduler;
 
 class sender_thread_pool
     : public boost::capy::execution_context
 {
-    struct coro_work : work_item
-    {
-        std::coroutine_handle<> h_;
-
-        explicit coro_work(std::coroutine_handle<> h) noexcept
-            : h_(h) {}
-
-        void execute() noexcept override
-        {
-            auto h = h_;
-            delete this;
-            h.resume();
-        }
-    };
-
     std::mutex mutex_;
     std::condition_variable work_cv_;
     std::condition_variable done_cv_;
@@ -105,8 +74,6 @@ class sender_thread_pool
     }
 
 public:
-    using executor_type = sender_executor;
-
     explicit sender_thread_pool(std::size_t num_threads = 0)
         : execution_context(this)
         , num_threads_(num_threads == 0
@@ -125,10 +92,8 @@ public:
     sender_thread_pool(sender_thread_pool const&) = delete;
     sender_thread_pool& operator=(sender_thread_pool const&) = delete;
 
-    sender_executor get_executor() noexcept
-    {
-        return sender_executor{this};
-    }
+    // Defined in sender_io_env.hpp after pool_scheduler
+    pool_scheduler get_scheduler() noexcept;
 
     void enqueue(work_item* w)
     {
@@ -138,11 +103,6 @@ public:
             q_.push(w);
         }
         work_cv_.notify_one();
-    }
-
-    void post(std::coroutine_handle<> h)
-    {
-        enqueue(new coro_work(h));
     }
 
     void on_work_started() noexcept
@@ -198,24 +158,5 @@ public:
         done_cv_.notify_all();
     }
 };
-
-// sender_executor inline definitions (need sender_thread_pool complete)
-
-inline void sender_executor::post(std::coroutine_handle<> h) const
-{
-    pool_->post(h);
-}
-
-inline void sender_executor::enqueue(work_item* w) const
-{
-    pool_->enqueue(w);
-}
-
-inline auto sender_executor::dispatch(std::coroutine_handle<> h) const
-    -> std::coroutine_handle<>
-{
-    pool_->post(h);
-    return std::noop_coroutine();
-}
 
 #endif

--- a/bench/beman/sndr_io_read_stream.hpp
+++ b/bench/beman/sndr_io_read_stream.hpp
@@ -28,8 +28,8 @@ struct sndr_io_read_stream_impl : sndr_io_read_stream
 {
     sndr_read_stream stream_;
 
-    explicit sndr_io_read_stream_impl(sender_executor ex)
-        : stream_{ex} {}
+    explicit sndr_io_read_stream_impl(sender_thread_pool* pool)
+        : stream_{pool} {}
 
     sndr_any_read_sender
         read_some(boost::capy::mutable_buffer buf) override

--- a/bench/beman/sndr_read_stream.hpp
+++ b/bench/beman/sndr_read_stream.hpp
@@ -10,11 +10,12 @@
 //
 // No-op sender stream for benchmarks.
 //
-// The stream holds a sender_executor (I/O context handle),
-// analogous to how a socket holds a reference to io_context.
-// read_some() returns a sender that captures this handle.
-// The sender provides both as_awaitable (for coroutine
-// consumption) and connect (for sender pipeline consumption).
+// The stream holds a sender_thread_pool* (I/O context
+// handle), analogous to how a socket holds a reference
+// to its execution context. read_some() returns a sender
+// that captures this handle. The sender provides both
+// as_awaitable (for coroutine consumption) and connect
+// (for sender pipeline consumption).
 //
 
 #ifndef BOOST_CAPY_BENCH_SNDR_READ_STREAM_HPP
@@ -34,7 +35,7 @@ namespace ex = beman::execution;
 
 struct sndr_read_stream
 {
-    sender_executor ex_;
+    sender_thread_pool* pool_;
 
     struct read_sender
     {
@@ -42,24 +43,24 @@ struct sndr_read_stream
         using completion_signatures =
             ex::completion_signatures<ex::set_value_t(std::size_t)>;
 
-        sender_executor ex_;
+        sender_thread_pool* pool_;
 
         // awaitable path (co_awaited from io_task via as_awaitable)
         template <typename Promise>
         struct awaitable : work_item
         {
-            sender_executor ex_;
+            sender_thread_pool* pool_;
             std::coroutine_handle<> h_{};
 
-            explicit awaitable(sender_executor ex) noexcept
-                : ex_(ex) {}
+            explicit awaitable(sender_thread_pool* pool) noexcept
+                : pool_(pool) {}
 
             bool await_ready() const noexcept { return false; }
 
             void await_suspend(std::coroutine_handle<> h)
             {
                 h_ = h;
-                ex_.enqueue(this);
+                pool_->enqueue(this);
             }
 
             std::size_t await_resume() noexcept { return 0; }
@@ -70,7 +71,7 @@ struct sndr_read_stream
         template <typename Promise>
         auto as_awaitable(Promise&) -> awaitable<Promise>
         {
-            return awaitable<Promise>{ex_};
+            return awaitable<Promise>{pool_};
         }
 
         // sender path (consumed via ex::connect)
@@ -80,11 +81,11 @@ struct sndr_read_stream
             using operation_state_concept = ex::operation_state_t;
 
             std::remove_cvref_t<Receiver> rcvr_;
-            sender_executor ex_;
+            sender_thread_pool* pool_;
 
-            op_state(Receiver rcvr, sender_executor ex)
+            op_state(Receiver rcvr, sender_thread_pool* pool)
                 : rcvr_(std::move(rcvr))
-                , ex_(ex)
+                , pool_(pool)
             {}
 
             op_state(op_state const&) = delete;
@@ -99,7 +100,7 @@ struct sndr_read_stream
 
             void start() & noexcept
             {
-                ex_.enqueue(this);
+                pool_->enqueue(this);
             }
         };
 
@@ -107,13 +108,13 @@ struct sndr_read_stream
         auto connect(Receiver&& rcvr)
             -> op_state<std::remove_cvref_t<Receiver>>
         {
-            return {std::forward<Receiver>(rcvr), ex_};
+            return {std::forward<Receiver>(rcvr), pool_};
         }
     };
 
     read_sender read_some(auto)
     {
-        return {ex_};
+        return {pool_};
     }
 };
 


### PR DESCRIPTION
Remove sender_executor (no P2300 equivalent) and replace with pool_scheduler obtained via sender_thread_pool::get_scheduler(), matching beman::net's io_context pattern. Streams hold sender_thread_pool* directly. Bridge posting now goes through schedule → connect → start via heap-allocated scheduled_resume, since P2300 has no post(coroutine_handle<>).