### PR TITLE
Coroutine codegen optimizations from coroutine analysis

### DIFF
--- a/doc/modules/ROOT/pages/4.coroutines/4g.allocators.adoc
+++ b/doc/modules/ROOT/pages/4.coroutines/4g.allocators.adoc
@@ -176,6 +176,84 @@ void process_batch(std::vector<item> const& items)
 }
 ----
 
+=== Scope Variables to Reduce Frame Size
+
+Compilers use declaration scope (braces) to decide which variables cross suspend points and must live in the coroutine frame. Variables declared in an outer scope remain in the frame even after their last use, as long as a `co_await` follows within the same scope.
+
+Wrapping buffer usage in explicit braces can dramatically reduce frame size:
+
+[source,cpp]
+----
+// BAD: buf lives in frame across all subsequent co_awaits
+task<> process(stream& s)
+{
+    char buf[4096];
+    auto [ec, n] = co_await s.read_some(buf);
+    co_await do_work(buf, n);
+    co_await s.write_some(reply);   // buf wastes 4K in frame
+}
+
+// GOOD: braces end buf's lifetime before next suspend
+task<> process(stream& s)
+{
+    std::size_t n;
+    {
+        char buf[4096];
+        auto [ec, n_] = co_await s.read_some(buf);
+        n = n_;
+        co_await do_work(buf, n);
+    }
+    co_await s.write_some(reply);  // 4K saved
+}
+----
+
+This technique also enables the compiler to *overlap* variables in the frame. When two variables have completely non-overlapping lifetimes (in separate scoped blocks), the compiler can reuse the same frame memory for both — even on Clang:
+
+[source,cpp]
+----
+// BAD: both arrays in frame simultaneously (8K)
+task<> pipeline(stream& in, stream& out)
+{
+    char read_buf[4096];
+    auto [ec1, n] = co_await in.read_some(read_buf);
+
+    char write_buf[4096];
+    prepare(write_buf, read_buf, n);
+    co_await out.write_some(write_buf);
+}
+
+// GOOD: non-overlapping scopes allow frame reuse (4K)
+task<> pipeline(stream& in, stream& out)
+{
+    std::size_t n;
+    {
+        char read_buf[4096];
+        auto [ec, n_] = co_await in.read_some(read_buf);
+        n = n_;
+    }
+    {
+        char write_buf[4096];
+        prepare(write_buf, n);
+        co_await out.write_some(write_buf);
+    }
+}
+----
+
+In the second version, `read_buf` and `write_buf` never coexist, so the compiler can place them at the same frame offset — halving the frame's buffer footprint. This optimization applies to any variables with non-overlapping lifetimes, not just arrays.
+
+=== GCC vs Clang Frame Sizes
+
+NOTE: This section draws on https://chuanqixu9.github.io/c++/2026/03/27/C++20-Coroutines-from-compiler-and-library-authors-perspective.en.html[C++20 Coroutines from compiler and library authors' perspective] by Chuanqi Xu.
+
+GCC and Clang use fundamentally different strategies for coroutine frame layout:
+
+* **Clang** performs frame layout after middle-end optimizations. Dead variables, unused temporaries, and constant-folded intermediates are eliminated before the frame is sized.
+* **GCC** performs frame layout in the frontend, before optimizations. Every local variable whose scope spans a suspend point ends up in the frame, even if optimizations would later prove it dead.
+
+The practical consequence is that GCC coroutine frames are often 5-10x larger than Clang's for the same source code. In one benchmark, the same coroutine produced a 24-byte frame on Clang and a 16,032-byte frame on GCC.
+
+For production coroutine workloads, Clang currently produces substantially better code. If you must use GCC, pay extra attention to variable scoping (above) and consider supplying a custom `memory_resource` with larger block sizes, since frames above 2048 bytes bypass the default recycling allocator's pooling.
+
 === Profile Before Optimizing
 
 Coroutine frame allocation is rarely the bottleneck. Profile your application before investing in custom allocators.
@@ -188,6 +266,9 @@ Coroutine frame allocation is rarely the bottleneck. Profile your application be
 
 | `<boost/capy/ex/frame_allocator.hpp>`
 | Frame allocator concept and utilities
+
+| `<boost/capy/ex/frame_alloc_promise.hpp>`
+| Mixin base for promise types that use the TLS frame allocator
 
 | `<boost/capy/ex/recycling_memory_resource.hpp>`
 | Default recycling allocator implementation

--- a/include/boost/capy/detail/config.hpp
+++ b/include/boost/capy/detail/config.hpp
@@ -132,11 +132,18 @@
 # define BOOST_CAPY_DECL
 #endif
 
-// Clang 20+ supports coro_await_elidable for heap elision
-#if defined(__clang__) && !defined(__apple_build_version__) && __clang_major__ >= 20
+// Heap elision: compiler may allocate elided coroutine frames on the caller's frame
+#if __has_cpp_attribute(clang::coro_await_elidable)
 #define BOOST_CAPY_CORO_AWAIT_ELIDABLE [[clang::coro_await_elidable]]
 #else
 #define BOOST_CAPY_CORO_AWAIT_ELIDABLE
+#endif
+
+// Simpler destroy codegen for coroutines that always run to completion
+#if __has_cpp_attribute(clang::coro_only_destroy_when_complete)
+#define BOOST_CAPY_CORO_DESTROY_WHEN_COMPLETE [[clang::coro_only_destroy_when_complete]]
+#else
+#define BOOST_CAPY_CORO_DESTROY_WHEN_COMPLETE
 #endif
 
 namespace boost::capy::detail {

--- a/include/boost/capy/ex/frame_alloc_mixin.hpp
+++ b/include/boost/capy/ex/frame_alloc_mixin.hpp
@@ -1,0 +1,118 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_EX_FRAME_ALLOC_MIXIN_HPP
+#define BOOST_CAPY_EX_FRAME_ALLOC_MIXIN_HPP
+
+#include <boost/capy/detail/config.hpp>
+#include <boost/capy/ex/frame_allocator.hpp>
+#include <boost/capy/ex/recycling_memory_resource.hpp>
+
+#include <cstddef>
+#include <cstring>
+#include <memory_resource>
+
+namespace boost {
+namespace capy {
+
+/** Mixin that adds frame-allocator-aware allocation to a promise type.
+
+    Inherit from this class in any coroutine promise type to opt into
+    TLS-based frame allocation with the recycling memory resource
+    fast path. The mixin provides `operator new` and `operator delete`
+    that:
+
+    1. Read the thread-local frame allocator set by `run_async` or `run`.
+    2. Bypass virtual dispatch when the allocator is the default
+       recycling memory resource.
+    3. Store the allocator pointer at the end of each frame for
+       correct deallocation even when TLS changes between allocation
+       and deallocation.
+
+    This is the same allocation strategy used by @ref
+    io_awaitable_promise_base. Use this mixin directly when your
+    promise type does not need the full environment and continuation
+    support that `io_awaitable_promise_base` provides.
+
+    @par Example
+    @code
+    struct my_internal_coroutine
+    {
+        struct promise_type : frame_alloc_mixin
+        {
+            my_internal_coroutine get_return_object();
+            std::suspend_always initial_suspend() noexcept;
+            std::suspend_always final_suspend() noexcept;
+            void return_void();
+            void unhandled_exception() noexcept;
+        };
+    };
+    @endcode
+
+    @par Thread Safety
+    The allocation fast path uses thread-local storage and requires
+    no synchronization. The global pool fallback is mutex-protected.
+
+    @see io_awaitable_promise_base, frame_allocator, recycling_memory_resource
+*/
+struct frame_alloc_mixin
+{
+    /** Allocate a coroutine frame.
+
+        Uses the thread-local frame allocator set by run_async.
+        Falls back to default memory resource if not set.
+        Stores the allocator pointer at the end of each frame for
+        correct deallocation even when TLS changes. Uses memcpy
+        to avoid alignment requirements on the trailing pointer.
+        Bypasses virtual dispatch for the recycling allocator.
+    */
+    static void* operator new(std::size_t size)
+    {
+        static auto* const rmr = get_recycling_memory_resource();
+
+        auto* mr = get_current_frame_allocator();
+        if(!mr)
+            mr = std::pmr::get_default_resource();
+
+        auto total = size + sizeof(std::pmr::memory_resource*);
+        void* raw;
+        if(mr == rmr)
+            raw = static_cast<recycling_memory_resource*>(mr)
+                ->allocate_fast(total, alignof(std::max_align_t));
+        else
+            raw = mr->allocate(total, alignof(std::max_align_t));
+        std::memcpy(static_cast<char*>(raw) + size, &mr, sizeof(mr));
+        return raw;
+    }
+
+    /** Deallocate a coroutine frame.
+
+        Reads the allocator pointer stored at the end of the frame
+        to ensure correct deallocation regardless of current TLS.
+        Bypasses virtual dispatch for the recycling allocator.
+    */
+    static void operator delete(void* ptr, std::size_t size) noexcept
+    {
+        static auto* const rmr = get_recycling_memory_resource();
+
+        std::pmr::memory_resource* mr;
+        std::memcpy(&mr, static_cast<char*>(ptr) + size, sizeof(mr));
+        auto total = size + sizeof(std::pmr::memory_resource*);
+        if(mr == rmr)
+            static_cast<recycling_memory_resource*>(mr)
+                ->deallocate_fast(ptr, total, alignof(std::max_align_t));
+        else
+            mr->deallocate(ptr, total, alignof(std::max_align_t));
+    }
+};
+
+} // namespace capy
+} // namespace boost
+
+#endif

--- a/include/boost/capy/ex/io_awaitable_promise_base.hpp
+++ b/include/boost/capy/ex/io_awaitable_promise_base.hpp
@@ -11,14 +11,12 @@
 #define BOOST_CAPY_EX_IO_AWAITABLE_PROMISE_BASE_HPP
 
 #include <boost/capy/detail/config.hpp>
+#include <boost/capy/ex/frame_alloc_mixin.hpp>
 #include <boost/capy/ex/frame_allocator.hpp>
 #include <boost/capy/ex/io_env.hpp>
-#include <boost/capy/ex/recycling_memory_resource.hpp>
 #include <boost/capy/ex/this_coro.hpp>
 
 #include <coroutine>
-#include <cstddef>
-#include <cstring>
 #include <memory_resource>
 #include <stop_token>
 #include <type_traits>
@@ -131,59 +129,12 @@ namespace capy {
 */
 template<typename Derived>
 class io_awaitable_promise_base
+    : public frame_alloc_mixin
 {
     io_env const* env_ = nullptr;
     mutable std::coroutine_handle<> cont_{std::noop_coroutine()};
 
 public:
-    /** Allocate a coroutine frame.
-
-        Uses the thread-local frame allocator set by run_async.
-        Falls back to default memory resource if not set.
-        Stores the allocator pointer at the end of each frame for
-        correct deallocation even when TLS changes. Uses memcpy
-        to avoid alignment requirements on the trailing pointer.
-        Bypasses virtual dispatch for the recycling allocator.
-    */
-    static void* operator new(std::size_t size)
-    {
-        static auto* const rmr = get_recycling_memory_resource();
-
-        auto* mr = get_current_frame_allocator();
-        if(!mr)
-            mr = std::pmr::get_default_resource();
-
-        auto total = size + sizeof(std::pmr::memory_resource*);
-        void* raw;
-        if(mr == rmr)
-            raw = static_cast<recycling_memory_resource*>(mr)
-                ->allocate_fast(total, alignof(std::max_align_t));
-        else
-            raw = mr->allocate(total, alignof(std::max_align_t));
-        std::memcpy(static_cast<char*>(raw) + size, &mr, sizeof(mr));
-        return raw;
-    }
-
-    /** Deallocate a coroutine frame.
-
-        Reads the allocator pointer stored at the end of the frame
-        to ensure correct deallocation regardless of current TLS.
-        Bypasses virtual dispatch for the recycling allocator.
-    */
-    static void operator delete(void* ptr, std::size_t size) noexcept
-    {
-        static auto* const rmr = get_recycling_memory_resource();
-
-        std::pmr::memory_resource* mr;
-        std::memcpy(&mr, static_cast<char*>(ptr) + size, sizeof(mr));
-        auto total = size + sizeof(std::pmr::memory_resource*);
-        if(mr == rmr)
-            static_cast<recycling_memory_resource*>(mr)
-                ->deallocate_fast(ptr, total, alignof(std::max_align_t));
-        else
-            mr->deallocate(ptr, total, alignof(std::max_align_t));
-    }
-
     ~io_awaitable_promise_base()
     {
         // Abnormal teardown: destroy orphaned continuation

--- a/include/boost/capy/ex/run.hpp
+++ b/include/boost/capy/ex/run.hpp
@@ -17,6 +17,7 @@
 #include <boost/capy/concept/io_runnable.hpp>
 #include <boost/capy/ex/executor_ref.hpp>
 #include <coroutine>
+#include <boost/capy/ex/frame_alloc_mixin.hpp>
 #include <boost/capy/ex/frame_allocator.hpp>
 #include <boost/capy/ex/io_env.hpp>
 
@@ -69,9 +70,10 @@ namespace boost::capy::detail {
 
     The trampoline never touches the task's result.
 */
-struct dispatch_trampoline
+struct BOOST_CAPY_CORO_DESTROY_WHEN_COMPLETE dispatch_trampoline
 {
     struct promise_type
+        : frame_alloc_mixin
     {
         executor_ref caller_ex_;
         continuation parent_;

--- a/include/boost/capy/ex/run_async.hpp
+++ b/include/boost/capy/ex/run_async.hpp
@@ -82,7 +82,7 @@ struct get_promise_awaiter
     @tparam Alloc The allocator type (value type or memory_resource*).
 */
 template<class Ex, class Handlers, class Alloc>
-struct run_async_trampoline
+struct BOOST_CAPY_CORO_DESTROY_WHEN_COMPLETE run_async_trampoline
 {
     using invoke_fn = void(*)(void*, Handlers&);
 
@@ -193,7 +193,8 @@ struct run_async_trampoline
     This avoids double indirection when the user passes a memory_resource*.
 */
 template<class Ex, class Handlers>
-struct run_async_trampoline<Ex, Handlers, std::pmr::memory_resource*>
+struct BOOST_CAPY_CORO_DESTROY_WHEN_COMPLETE
+    run_async_trampoline<Ex, Handlers, std::pmr::memory_resource*>
 {
     using invoke_fn = void(*)(void*, Handlers&);
 

--- a/include/boost/capy/task.hpp
+++ b/include/boost/capy/task.hpp
@@ -178,7 +178,7 @@ struct [[nodiscard]] BOOST_CAPY_CORO_AWAIT_ELIDABLE
             return awaiter{this};
         }
 
-        void unhandled_exception()
+        void unhandled_exception() noexcept
         {
             new (&ep_) std::exception_ptr(std::current_exception());
             has_ep_ = true;

--- a/include/boost/capy/when_all.hpp
+++ b/include/boost/capy/when_all.hpp
@@ -16,6 +16,7 @@
 #include <boost/capy/concept/executor.hpp>
 #include <boost/capy/concept/io_awaitable.hpp>
 #include <coroutine>
+#include <boost/capy/ex/frame_alloc_mixin.hpp>
 #include <boost/capy/ex/io_env.hpp>
 #include <boost/capy/ex/frame_allocator.hpp>
 #include <boost/capy/task.hpp>
@@ -207,9 +208,10 @@ struct when_all_homogeneous_state<std::tuple<>>
     @tparam StateType The state type (when_all_state or when_all_homogeneous_state).
 */
 template<typename StateType>
-struct when_all_runner
+struct BOOST_CAPY_CORO_DESTROY_WHEN_COMPLETE when_all_runner
 {
     struct promise_type
+        : frame_alloc_mixin
     {
         StateType* state_ = nullptr;
         std::size_t index_ = 0;
@@ -253,7 +255,7 @@ struct when_all_runner
 
         void return_void() noexcept {}
 
-        void unhandled_exception()
+        void unhandled_exception() noexcept
         {
             state_->core_.capture_exception(std::current_exception());
             state_->core_.stop_source_.request_stop();

--- a/include/boost/capy/when_any.hpp
+++ b/include/boost/capy/when_any.hpp
@@ -18,6 +18,7 @@
 #include <boost/capy/concept/io_awaitable.hpp>
 #include <coroutine>
 #include <boost/capy/ex/executor_ref.hpp>
+#include <boost/capy/ex/frame_alloc_mixin.hpp>
 #include <boost/capy/ex/frame_allocator.hpp>
 #include <boost/capy/ex/io_env.hpp>
 #include <boost/capy/task.hpp>
@@ -218,9 +219,10 @@ struct when_any_io_state
 // Wrapper coroutine for io_result-aware when_any children.
 // unhandled_exception records the exception but does NOT claim winner status.
 template<typename StateType>
-struct when_any_io_runner
+struct BOOST_CAPY_CORO_DESTROY_WHEN_COMPLETE when_any_io_runner
 {
     struct promise_type
+        : frame_alloc_mixin
     {
         StateType* state_ = nullptr;
         std::size_t index_ = 0;
@@ -262,7 +264,7 @@ struct when_any_io_runner
         void return_void() noexcept {}
 
         // Exceptions do NOT win in io_result when_any
-        void unhandled_exception()
+        void unhandled_exception() noexcept
         {
             state_->record_exception(std::current_exception());
         }


### PR DESCRIPTION
Extract frame_alloc_mixin as a public mixin so consuming libraries can opt promise types into TLS-based frame allocation. Runners (when_all, when_any) and dispatch_trampoline now inherit it instead of bypassing the recycling allocator via ::operator new.

- Add frame_alloc_promise mixin (public API in ex/)
- Refactor io_awaitable_promise_base to inherit from mixin
- Mark unhandled_exception() noexcept on task, when_all_runner, and when_any_runner promises (eliminates implicit try-catch)
- Add BOOST_CAPY_CORO_DESTROY_WHEN_COMPLETE attribute for internal coroutines that always run to completion (when_all_runner, when_any_runner, dispatch_trampoline, run_async_trampoline)
- Switch both coroutine attribute macros to __has_cpp_attribute for Apple Clang compatibility
- Document variable lifetime scoping and GCC vs Clang frame sizes

Based on coroutine analysis from https://chuanqixu9.github.io/c++/2026/03/27/C++20-Coroutines-from-compiler-and-library-authors-perspective.en.html 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated coroutine frame allocation logic into a reusable mixin component.
  * Refactored coroutine promise types to utilize improved frame allocation strategy.

* **Chores**
  * Improved compiler feature detection using standard feature-test macros.
  * Enhanced coroutine destruction semantics with compiler-specific attributes.
  * Strengthened exception handling contracts with noexcept specifications on exception handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->