### PR TITLE
Align Executor concept and executor_ref with P4003

### DIFF
--- a/include/boost/capy/concept/executor.hpp
+++ b/include/boost/capy/concept/executor.hpp
@@ -166,7 +166,7 @@ template<class E>
 concept Executor =
     std::is_nothrow_copy_constructible_v<E> &&
     std::is_nothrow_move_constructible_v<E> &&
-    requires(E& e, E const& ce, E const& ce2, continuation c) {
+    requires(E& e, E const& ce, E const& ce2, continuation& c) {
         { ce == ce2 } noexcept -> std::convertible_to<bool>;
         { ce.context() } noexcept;
         requires std::is_lvalue_reference_v<decltype(ce.context())> &&

--- a/include/boost/capy/ex/executor_ref.hpp
+++ b/include/boost/capy/ex/executor_ref.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/capy/detail/config.hpp>
 #include <boost/capy/detail/type_id.hpp>
+#include <boost/capy/concept/executor.hpp>
 #include <boost/capy/continuation.hpp>
 #include <concepts>
 #include <coroutine>
@@ -149,7 +150,8 @@ public:
             std::decay_t<Ex>, executor_ref>, int> = 0>
 #else
     template<class Ex>
-        requires (!std::same_as<std::decay_t<Ex>, executor_ref>)
+        requires (!std::same_as<std::decay_t<Ex>, executor_ref>
+            && Executor<Ex>)
 #endif
     executor_ref(Ex const& ex) noexcept
         : ex_(&ex)
@@ -266,7 +268,7 @@ public:
             `nullptr` if the type does not match.
     */
     template< typename Executor >
-    const Executor* target() const
+    const Executor* target() const noexcept
     {
         if ( *vt_->type_id == detail::type_id< Executor >() )
            return static_cast< Executor const* >( ex_ );
@@ -275,7 +277,7 @@ public:
 
     /// @copydoc target() const
     template< typename Executor>
-    Executor* target()
+    Executor* target() noexcept
     {
         if ( *vt_->type_id == detail::type_id< Executor >() )
            return const_cast< Executor* >(


### PR DESCRIPTION
- Executor concept: pass continuation by reference in requires-expression to match stable-address semantics of all implementations
- executor_ref constructor: constrain to Executor to reject non-conforming types at the call site instead of deferring to vtable instantiation
- executor_ref::target(): add noexcept to both overloads (trivially non-throwing type-id comparison and static_cast)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated executor concept parameter binding requirements
  * Enhanced exception safety with noexcept annotations to executor reference methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->