### PR TITLE
Docs: edit-this-page link

### DIFF
--- a/doc/local-playbook.yml
+++ b/doc/local-playbook.yml
@@ -10,7 +10,7 @@ content:
   sources:
     - url: ..
       start_path: doc
-      edit_url: 'https://github.com/cppalliance/capy/edit/{refname}/{path}'
+      edit_url: 'https://github.com/cppalliance/capy/edit/develop/{path}'
 
 ui:
   bundle:


### PR DESCRIPTION
- In CI, the repo is checked out as "detached HEAD", causing the "Edit This Page" link to point to /HEAD/ ,  it's a broken link, and should point to an editable branch. 
- Another helpful side-effect of this change is suggesting the visitor edit 'develop', even when perhaps viewing 'master'.  Doc modifications are funneled through 'develop'.