### PR TITLE
feat(bench): add stdexec benchmark mirroring bench/beman/

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -9,7 +9,19 @@
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES
     CMakeLists.txt bench.cpp allocation.cpp
-    beman/main.cpp beman/beman_env.hpp beman/bench_pool.hpp)
+    beman/main.cpp beman/beman_env.hpp beman/bench_pool.hpp
+    stdexec/main.cpp
+    stdexec/allocation_tracker.hpp
+    stdexec/awaitable_sender.hpp
+    stdexec/ioaw_io_read_stream.hpp
+    stdexec/ioaw_read_stream.hpp
+    stdexec/ioaw_sync_read_stream.hpp
+    stdexec/sender_awaitable.hpp
+    stdexec/sender_io_env.hpp
+    stdexec/sndr_any_read_stream.hpp
+    stdexec/sndr_io_read_stream.hpp
+    stdexec/sndr_read_stream.hpp
+    stdexec/sndr_sync_read_stream.hpp)
 
 add_executable(boost_capy_bench bench.cpp)
 target_link_libraries(boost_capy_bench PRIVATE Boost::capy)
@@ -34,6 +46,24 @@ if(BOOST_CAPY_BUILD_P2300_EXAMPLES)
     target_compile_features(boost_capy_bench_beman PRIVATE cxx_std_23)
     target_link_libraries(boost_capy_bench_beman PRIVATE
         Boost::capy beman::task beman::execution_headers)
+endif()
+
+if(BOOST_CAPY_BUILD_STDEXEC_EXAMPLES)
+    include(FetchContent)
+    FetchContent_Declare(
+        stdexec
+        GIT_REPOSITORY https://github.com/NVIDIA/stdexec
+        GIT_TAG 307b83c5689ea7c2e5b31561cdc428697705333e
+        SYSTEM
+        FIND_PACKAGE_ARGS
+            NAMES stdexec
+    )
+    FetchContent_MakeAvailable(stdexec)
+
+    add_executable(boost_capy_bench_stdexec stdexec/main.cpp)
+    target_compile_features(boost_capy_bench_stdexec PRIVATE cxx_std_23)
+    target_link_libraries(boost_capy_bench_stdexec PRIVATE
+        Boost::capy STDEXEC::stdexec)
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/bench/stdexec/allocation_tracker.hpp
+++ b/bench/stdexec/allocation_tracker.hpp
@@ -1,0 +1,71 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_ALLOCATION_TRACKER_HPP
+#define BOOST_CAPY_BENCH_ALLOCATION_TRACKER_HPP
+
+#include <atomic>
+#include <cstddef>
+#include <cstdlib>
+#include <memory_resource>
+#include <new>
+
+static std::atomic<int64_t> g_alloc_count{0};
+
+/// Counts every allocate call, then delegates to upstream.
+class counting_memory_resource
+    : public std::pmr::memory_resource
+{
+    std::pmr::memory_resource* upstream_;
+
+    void* do_allocate(
+        std::size_t n, std::size_t align) override
+    {
+        g_alloc_count.fetch_add(1, std::memory_order_relaxed);
+        return upstream_->allocate(n, align);
+    }
+
+    void do_deallocate(
+        void* p, std::size_t n, std::size_t align) override
+    {
+        upstream_->deallocate(p, n, align);
+    }
+
+    bool do_is_equal(
+        memory_resource const& other) const noexcept override
+    {
+        return this == &other;
+    }
+
+public:
+    explicit counting_memory_resource(
+        std::pmr::memory_resource* upstream) noexcept
+        : upstream_(upstream) {}
+};
+
+void* operator new(std::size_t n)
+{
+    g_alloc_count.fetch_add(1, std::memory_order_relaxed);
+    void* p = std::malloc(n);
+    if (!p)
+        throw std::bad_alloc();
+    return p;
+}
+
+void operator delete(void* p) noexcept
+{
+    std::free(p);
+}
+
+void operator delete(void* p, std::size_t) noexcept
+{
+    std::free(p);
+}
+
+#endif

--- a/bench/stdexec/awaitable_sender.hpp
+++ b/bench/stdexec/awaitable_sender.hpp
@@ -1,0 +1,567 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_STDEXEC_AWAITABLE_SENDER_HPP
+#define BOOST_CAPY_BENCH_STDEXEC_AWAITABLE_SENDER_HPP
+
+#include <boost/capy/concept/io_awaitable.hpp>
+#include <boost/capy/detail/await_suspend_helper.hpp>
+#include <boost/capy/ex/executor_ref.hpp>
+#include <boost/capy/ex/io_env.hpp>
+#include <boost/capy/io_result.hpp>
+
+#include <stdexec/execution.hpp>
+
+#include <concepts>
+#include <coroutine>
+#include <exception>
+#include <stop_token>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace boost::capy {
+
+// Query CPO for obtaining a Capy-compatible executor
+// from a P2300 environment. The returned object must
+// satisfy Capy's Executor concept. Environments that
+// host IoAwaitables via the as_sender bridge must
+// answer this query.
+struct get_io_executor_t
+{
+    static consteval auto query(
+        stdexec::forwarding_query_t) noexcept -> bool
+    {
+        return true;
+    }
+
+    template<class Env>
+        requires requires(Env const& env) {
+            env.query(
+                std::declval<get_io_executor_t const&>());
+        }
+    auto operator()(Env const& env) const noexcept
+    {
+        return env.query(*this);
+    }
+};
+
+inline constexpr get_io_executor_t get_io_executor{};
+
+namespace detail {
+
+template<class T, class = void>
+struct has_tuple_protocol : std::false_type {};
+
+template<class T>
+struct has_tuple_protocol<T,
+    std::void_t<
+        typename std::tuple_size<T>::type,
+        typename std::tuple_element<0, T>::type>>
+    : std::true_type {};
+
+template<class T, bool = has_tuple_protocol<T>::value>
+struct is_ec_outcome : std::is_same<T, std::error_code> {};
+
+template<class T>
+struct is_ec_outcome<T, true>
+    : std::bool_constant<
+        std::tuple_size_v<T> == 1 &&
+        std::is_same_v<
+            std::tuple_element_t<0, T>,
+            std::error_code>>
+{};
+
+template<class T>
+constexpr bool is_ec_outcome_v =
+    std::is_same_v<T, std::error_code> ||
+    is_ec_outcome<T>::value;
+
+template<class T, bool = has_tuple_protocol<T>::value>
+struct is_compound_ec_result : std::false_type {};
+
+template<class T>
+struct is_compound_ec_result<T, true>
+    : std::bool_constant<
+        std::tuple_size_v<T> >= 2 &&
+        std::is_same_v<
+            std::tuple_element_t<0, T>,
+            std::error_code>>
+{};
+
+template<class T>
+constexpr bool is_compound_ec_result_v =
+    is_compound_ec_result<T>::value;
+
+struct frame_cb
+{
+    void (*resume)(frame_cb*);
+    void (*destroy)(frame_cb*);
+    void* data;
+};
+
+// Return the concrete executor by value, trying get_io_executor
+// on the env first, then falling back to the start scheduler.
+template<class Env>
+auto resolve_executor(Env const& env)
+{
+    if constexpr (requires { get_io_executor(env); })
+        return get_io_executor(env);
+    else
+        return stdexec::get_start_scheduler(env)
+            .query(get_io_executor_t{});
+}
+
+} // namespace detail
+
+/** Sender that wraps an IoAwaitable.
+
+    When connected or co_awaited, the bridge queries
+    the receiver's or promise's environment for a
+    Capy-compatible executor via get_io_executor.
+    The executor is stored by value in the operation
+    state and used to construct the io_env passed to
+    the IoAwaitable's await_suspend.
+
+    @tparam IoAw The IoAwaitable type.
+*/
+template<class IoAw>
+struct awaitable_sender
+{
+    using sender_concept = stdexec::sender_tag;
+
+    using result_type = decltype(
+        std::declval<std::decay_t<IoAw>&>().await_resume());
+
+    static auto make_sigs()
+    {
+        if constexpr (std::is_void_v<result_type>)
+            return stdexec::completion_signatures<
+                stdexec::set_value_t(),
+                stdexec::set_error_t(std::exception_ptr),
+                stdexec::set_stopped_t()>{};
+        else if constexpr (
+            detail::is_compound_ec_result_v<result_type>)
+            return stdexec::completion_signatures<
+                stdexec::set_value_t(
+                    std::tuple_element_t<1, result_type>),
+                stdexec::set_error_t(std::error_code),
+                stdexec::set_error_t(std::exception_ptr),
+                stdexec::set_stopped_t()>{};
+        else if constexpr (
+            detail::is_ec_outcome_v<result_type>)
+            return stdexec::completion_signatures<
+                stdexec::set_value_t(),
+                stdexec::set_error_t(std::error_code),
+                stdexec::set_error_t(std::exception_ptr),
+                stdexec::set_stopped_t()>{};
+        else
+            return stdexec::completion_signatures<
+                stdexec::set_value_t(result_type),
+                stdexec::set_error_t(std::exception_ptr),
+                stdexec::set_stopped_t()>{};
+    }
+
+    using completion_signatures = decltype(make_sigs());
+
+    IoAw aw_;
+
+    template<class Receiver>
+    struct op_state
+    {
+        using operation_state_concept =
+            stdexec::operation_state_tag;
+
+        // Concrete executor type deduced from the receiver's
+        // environment. Stored by value to avoid the dangling
+        // pointer that executor_ref would produce when the
+        // source is a temporary (scheduler query or prop).
+        using executor_type = decltype(
+            detail::resolve_executor(
+                stdexec::get_env(
+                    std::declval<Receiver const&>())));
+
+        IoAw aw_;
+        Receiver rcvr_;
+        executor_type ex_;
+        io_env env_;
+        detail::frame_cb cb_;
+
+        op_state(IoAw aw, Receiver rcvr)
+            : aw_(std::move(aw))
+            , rcvr_(std::move(rcvr))
+            , ex_{}
+            , cb_{}
+        {
+        }
+
+        op_state(op_state const&) = delete;
+        op_state(op_state&&) = delete;
+        op_state& operator=(op_state const&) = delete;
+        op_state& operator=(op_state&&) = delete;
+
+        static void
+        on_resume(detail::frame_cb* p) noexcept
+        {
+            auto* self = static_cast<op_state*>(p->data);
+            self->complete();
+        }
+
+        static void
+        on_destroy(detail::frame_cb*) noexcept
+        {
+        }
+
+        void complete() noexcept
+        {
+            try
+            {
+                if constexpr (std::is_void_v<result_type>)
+                {
+                    aw_.await_resume();
+                    if(env_.stop_token.stop_requested())
+                        stdexec::set_stopped(
+                            std::move(rcvr_));
+                    else
+                        stdexec::set_value(
+                            std::move(rcvr_));
+                }
+                else if constexpr (
+                    detail::is_compound_ec_result_v<result_type>)
+                {
+                    auto result = aw_.await_resume();
+                    if(env_.stop_token.stop_requested())
+                    {
+                        stdexec::set_stopped(
+                            std::move(rcvr_));
+                    }
+                    else
+                    {
+                        auto ec = get<0>(result);
+                        if(!ec)
+                            stdexec::set_value(
+                                std::move(rcvr_),
+                                get<1>(std::move(result)));
+                        else
+                            stdexec::set_error(
+                                std::move(rcvr_), ec);
+                    }
+                }
+                else if constexpr (
+                    detail::is_ec_outcome_v<result_type>)
+                {
+                    auto result = aw_.await_resume();
+                    if(env_.stop_token.stop_requested())
+                    {
+                        stdexec::set_stopped(
+                            std::move(rcvr_));
+                    }
+                    else
+                    {
+                        std::error_code ec;
+                        if constexpr (std::is_same_v<
+                            result_type, std::error_code>)
+                            ec = result;
+                        else
+                            ec = get<0>(result);
+                        if(!ec)
+                            stdexec::set_value(
+                                std::move(rcvr_));
+                        else
+                            stdexec::set_error(
+                                std::move(rcvr_), ec);
+                    }
+                }
+                else
+                {
+                    auto result = aw_.await_resume();
+                    if(env_.stop_token.stop_requested())
+                        stdexec::set_stopped(
+                            std::move(rcvr_));
+                    else
+                        stdexec::set_value(
+                            std::move(rcvr_),
+                            std::move(result));
+                }
+            }
+            catch(...)
+            {
+                stdexec::set_error(
+                    std::move(rcvr_),
+                    std::current_exception());
+            }
+        }
+
+        void start() noexcept
+        {
+            auto renv = stdexec::get_env(rcvr_);
+            ex_ = detail::resolve_executor(renv);
+
+            std::stop_token st;
+            if constexpr (requires {
+                { renv.query(stdexec::get_stop_token_t{}) }
+                    -> std::convertible_to<std::stop_token>; })
+            {
+                st = renv.query(
+                    stdexec::get_stop_token_t{});
+            }
+
+            env_ = io_env{ex_, st, nullptr};
+
+            if(aw_.await_ready())
+            {
+                complete();
+                return;
+            }
+
+            cb_.resume = &on_resume;
+            cb_.destroy = &on_destroy;
+            cb_.data = this;
+
+            auto h = std::coroutine_handle<>::from_address(
+                static_cast<void*>(&cb_));
+
+            auto resumed = detail::call_await_suspend(
+                &aw_, h, &env_);
+            if(resumed == h)
+                complete();
+        }
+    };
+
+    template<class Receiver>
+    auto connect(Receiver rcvr) &&
+        -> op_state<Receiver>
+    {
+        return op_state<Receiver>(
+            std::move(aw_), std::move(rcvr));
+    }
+
+    template<class Receiver>
+    auto connect(Receiver rcvr) const&
+        -> op_state<Receiver>
+    {
+        return op_state<Receiver>(aw_, std::move(rcvr));
+    }
+
+    // Bypass stdexec's sender_awaitable when co_awaited
+    // from a coroutine that provides get_io_executor or
+    // a start scheduler with get_io_executor. Adapts the
+    // IoAwaitable's 2-arg await_suspend to the standard
+    // 1-arg protocol.
+    template<class Promise>
+    auto as_awaitable(Promise& promise) &&
+    {
+        auto penv = promise.get_env();
+        auto ex = detail::resolve_executor(penv);
+
+        std::stop_token st;
+        if constexpr (requires {
+            { penv.query(stdexec::get_stop_token_t{}) }
+                -> std::convertible_to<std::stop_token>; })
+        {
+            st = penv.query(
+                stdexec::get_stop_token_t{});
+        }
+
+        using executor_type = decltype(ex);
+
+        struct aw
+        {
+            IoAw aw_;
+            executor_type ex_;
+            std::stop_token st_;
+            io_env env_;
+
+            bool await_ready() noexcept
+            {
+                return aw_.await_ready();
+            }
+
+            std::coroutine_handle<>
+            await_suspend(std::coroutine_handle<> h)
+            {
+                env_ = io_env{ex_, st_, nullptr};
+                return aw_.await_suspend(h, &env_);
+            }
+
+            auto await_resume()
+            {
+                return aw_.await_resume();
+            }
+        };
+
+        return aw{std::move(aw_), std::move(ex), st, {}};
+    }
+};
+
+/** Create a stdexec sender from an IoAwaitable.
+
+    The bridge routes the awaitable's result through sender
+    channels based on its type:
+
+    - `void` - calls `set_value()`.
+    - `error_code` (or a single-element tuple-like whose
+      element 0 is `error_code`) - calls `set_value()`
+      when the code is zero, `set_error(ec)` otherwise.
+    - Any other single value `T` - calls `set_value(T)`.
+    - Compound results whose element 0 is `error_code`
+      with additional elements are rejected at compile
+      time. Wrap the operation in a `task<error_code>`
+      that inspects the compound result and returns the
+      error code.
+
+    When connected or co_awaited, the bridge queries the
+    receiver's or promise's environment for a Capy executor
+    via get_io_executor. The environment must answer this
+    query with an object satisfying Capy's Executor concept.
+
+    @param aw The IoAwaitable to wrap.
+    @return A sender whose completion channels reflect
+        the awaitable's result type.
+*/
+template<class IoAw>
+auto as_sender(IoAw&& aw)
+{
+    return awaitable_sender<std::decay_t<IoAw>>{
+        std::forward<IoAw>(aw)};
+}
+
+// split_ec: sender adapter that routes error_code to
+// set_value() or set_error(ec) at runtime.
+
+namespace detail {
+
+template<class Sender>
+struct split_ec_sender
+{
+    using sender_concept = stdexec::sender_tag;
+
+    using completion_signatures =
+        stdexec::completion_signatures<
+            stdexec::set_value_t(),
+            stdexec::set_error_t(std::error_code),
+            stdexec::set_error_t(std::exception_ptr),
+            stdexec::set_stopped_t()>;
+
+    Sender sndr_;
+
+    template<class Receiver>
+    struct ec_receiver
+    {
+        using receiver_concept = stdexec::receiver_tag;
+
+        Receiver rcvr_;
+
+        auto get_env() const noexcept
+        {
+            return stdexec::get_env(rcvr_);
+        }
+
+        void set_value(std::error_code ec) && noexcept
+        {
+            if (!ec)
+                stdexec::set_value(
+                    std::move(rcvr_));
+            else
+                stdexec::set_error(
+                    std::move(rcvr_), ec);
+        }
+
+        void set_value() && noexcept
+        {
+            stdexec::set_value(
+                std::move(rcvr_));
+        }
+
+        template<class E>
+        void set_error(E&& e) && noexcept
+        {
+            stdexec::set_error(
+                std::move(rcvr_),
+                std::forward<E>(e));
+        }
+
+        void set_stopped() && noexcept
+        {
+            stdexec::set_stopped(
+                std::move(rcvr_));
+        }
+    };
+
+    template<class Receiver>
+    struct op_state
+    {
+        using operation_state_concept =
+            stdexec::operation_state_tag;
+
+        using inner_op_t = decltype(
+            stdexec::connect(
+                std::declval<Sender>(),
+                std::declval<ec_receiver<Receiver>>()));
+
+        inner_op_t op_;
+
+        op_state(Sender sndr, Receiver rcvr)
+            : op_(stdexec::connect(
+                std::move(sndr),
+                ec_receiver<Receiver>{std::move(rcvr)}))
+        {
+        }
+
+        op_state(op_state const&) = delete;
+        op_state(op_state&&) = delete;
+        op_state& operator=(op_state const&) = delete;
+        op_state& operator=(op_state&&) = delete;
+
+        void start() noexcept
+        {
+            stdexec::start(op_);
+        }
+    };
+
+    template<class Receiver>
+    auto connect(Receiver rcvr) &&
+        -> op_state<Receiver>
+    {
+        return op_state<Receiver>(
+            std::move(sndr_), std::move(rcvr));
+    }
+
+    template<class Receiver>
+    auto connect(Receiver rcvr) const&
+        -> op_state<Receiver>
+    {
+        return op_state<Receiver>(
+            sndr_, std::move(rcvr));
+    }
+};
+
+} // namespace detail
+
+/** Split an `error_code` value channel into success and error channels.
+
+    Takes a sender that completes with `set_value(error_code)` and
+    routes it at runtime: `set_value()` when the code is zero,
+    `set_error(ec)` otherwise. No exceptions.
+
+    @param sndr The predecessor sender.
+    @return A sender completing with `set_value()`,
+        `set_error(error_code)`, or `set_stopped()`.
+*/
+template<class Sender>
+auto split_ec(Sender&& sndr)
+{
+    return detail::split_ec_sender<
+        std::decay_t<Sender>>{
+            std::forward<Sender>(sndr)};
+}
+
+} // namespace boost::capy
+
+#endif

--- a/bench/stdexec/ioaw_io_read_stream.hpp
+++ b/bench/stdexec/ioaw_io_read_stream.hpp
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_STDEXEC_IOAW_IO_READ_STREAM_HPP
+#define BOOST_CAPY_BENCH_STDEXEC_IOAW_IO_READ_STREAM_HPP
+
+#include "ioaw_read_stream.hpp"
+
+/// Abstract interface for IoAwaitable read streams.
+struct ioaw_io_read_stream
+{
+    virtual ioaw_read_stream::read_awaitable
+        read_some(boost::capy::mutable_buffer) = 0;
+    virtual ~ioaw_io_read_stream() = default;
+};
+
+/// Concrete implementation of ioaw_io_read_stream wrapping
+/// an ioaw_read_stream.
+struct ioaw_io_read_stream_impl : ioaw_io_read_stream
+{
+    ioaw_read_stream stream_;
+
+    ioaw_read_stream::read_awaitable
+        read_some(boost::capy::mutable_buffer buf) override
+    {
+        return stream_.read_some(buf);
+    }
+};
+
+#endif

--- a/bench/stdexec/ioaw_read_stream.hpp
+++ b/bench/stdexec/ioaw_read_stream.hpp
@@ -1,0 +1,57 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_STDEXEC_IOAW_READ_STREAM_HPP
+#define BOOST_CAPY_BENCH_STDEXEC_IOAW_READ_STREAM_HPP
+
+#include <boost/capy/buffers.hpp>
+#include <boost/capy/concept/read_stream.hpp>
+#include <boost/capy/continuation.hpp>
+#include <boost/capy/ex/io_env.hpp>
+#include <boost/capy/io_result.hpp>
+#include <coroutine>
+#include <cstddef>
+
+/// No-op ReadStream for benchmarking.
+///
+/// Uses the executor from io_env (passed by capy::task's
+/// transform_awaiter) to post the coroutine back. Satisfies
+/// ReadStream so it can be wrapped by capy::any_read_stream.
+struct ioaw_read_stream
+{
+    struct read_awaitable
+    {
+        boost::capy::continuation cont_{};
+
+        bool await_ready() const noexcept { return false; }
+
+        std::coroutine_handle<>
+        await_suspend(
+            std::coroutine_handle<> h,
+            boost::capy::io_env const* env)
+        {
+            cont_.h = h;
+            env->executor.post(cont_);
+            return std::noop_coroutine();
+        }
+
+        boost::capy::io_result<std::size_t>
+        await_resume() noexcept { return {{}, 0}; }
+    };
+
+    template <boost::capy::MutableBufferSequence MB>
+    read_awaitable read_some(MB)
+    {
+        return {};
+    }
+};
+
+static_assert(boost::capy::ReadStream<ioaw_read_stream>);
+
+#endif

--- a/bench/stdexec/ioaw_sync_read_stream.hpp
+++ b/bench/stdexec/ioaw_sync_read_stream.hpp
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+//
+// Synchronous-completion IoAwaitable stream.
+//
+// Every read completes immediately via symmetric
+// transfer — await_suspend returns the coroutine
+// handle, causing an inline resume with no scheduler
+// round-trip.
+//
+
+#ifndef BOOST_CAPY_BENCH_STDEXEC_IOAW_SYNC_READ_STREAM_HPP
+#define BOOST_CAPY_BENCH_STDEXEC_IOAW_SYNC_READ_STREAM_HPP
+
+#include <boost/capy/ex/io_env.hpp>
+#include <boost/capy/io_result.hpp>
+
+#include <coroutine>
+#include <cstddef>
+
+struct ioaw_sync_read_stream
+{
+    struct read_awaitable
+    {
+        bool await_ready() const noexcept
+        {
+            return false;
+        }
+
+        std::coroutine_handle<>
+        await_suspend(
+            std::coroutine_handle<> h,
+            boost::capy::io_env const*)
+        {
+            // Data already buffered — resume inline
+            return h;
+        }
+
+        boost::capy::io_result<std::size_t>
+        await_resume() noexcept
+        {
+            return {{}, 0};
+        }
+    };
+
+    read_awaitable read_some(auto)
+    {
+        return {};
+    }
+};
+
+#endif

--- a/bench/stdexec/main.cpp
+++ b/bench/stdexec/main.cpp
@@ -1,0 +1,815 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+//
+// I/O Read Stream Benchmark (stdexec edition)
+//
+// Compares three execution models across four stream
+// abstraction levels. 20M read_some calls per cell,
+// single thread.
+//
+// Table 1: sender pipeline   (connect/start)
+// Table 2: capy::task        (capy::thread_pool)
+// Table 3: exec::task        (exec::static_thread_pool)
+//
+// Each table has four rows:
+//   Native      - concrete stream, full visibility
+//   Abstract    - virtual dispatch, implementation hidden
+//   Type erased - value-type erasure (exec::any_sender)
+//   Synchronous - no scheduler trip
+//
+
+#include "allocation_tracker.hpp"
+#include "awaitable_sender.hpp"
+#include "ioaw_io_read_stream.hpp"
+#include "ioaw_read_stream.hpp"
+#include "ioaw_sync_read_stream.hpp"
+#include <exec/repeat_until.hpp>
+#include "sender_awaitable.hpp"
+#include "sender_io_env.hpp"
+#include "sndr_any_read_stream.hpp"
+#include "sndr_io_read_stream.hpp"
+#include "sndr_read_stream.hpp"
+#include "sndr_sync_read_stream.hpp"
+
+#include <boost/capy.hpp>
+#include <boost/capy/io/any_read_stream.hpp>
+
+#include <exec/function.hpp>
+#include <exec/static_thread_pool.hpp>
+#include <exec/task.hpp>
+#include <stdexec/execution.hpp>
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <latch>
+#include <memory>
+
+namespace capy = boost::capy;
+
+static counting_memory_resource g_counting_resource{
+    capy::get_recycling_memory_resource()};
+
+auto get_counting_resource() -> std::pmr::memory_resource*
+{
+    return &g_counting_resource;
+}
+
+struct cell_result
+{
+    long long ns = 0;
+    int64_t allocs = 0;
+};
+
+static constexpr int OPS_PER_CELL = 20'000'000;
+static constexpr int OUTER_LOOPS  = 2'000;
+static constexpr int INNER_LOOPS  = 10'000;
+
+static constexpr int NUM_RUNS    = 5;
+static constexpr int NUM_TABLES  = 3;
+static constexpr int NUM_STREAMS = 4;
+static constexpr int NUM_COLUMNS = 2;
+
+static constexpr int SENDER_RECEIVER = 0;
+static constexpr int CAPY_TASK       = 1;
+static constexpr int EXEC_TASK       = 2;
+
+static constexpr int NATIVE_STREAM      = 0;
+static constexpr int ABSTRACT_STREAM    = 1;
+static constexpr int TYPE_ERASED_STREAM = 2;
+static constexpr int SYNC_STREAM        = 3;
+
+static constexpr int NATIVE_EXEC_MODEL  = 0;
+static constexpr int BRIDGED_EXEC_MODEL = 1;
+
+// -----------------------------------------------------------
+// Table 2: capy::task - Column A (awaitable, native)
+// -----------------------------------------------------------
+
+template <class Stream>
+capy::task<> capy_session(Stream& stream)
+{
+    char buf[64];
+    for (int i = 0; i < INNER_LOOPS; ++i)
+        (void)co_await stream.read_some(
+            capy::mutable_buffer(buf, sizeof(buf)));
+}
+
+template <class Stream>
+capy::task<> capy_accept(Stream& stream, cell_result& out)
+{
+    auto before = g_alloc_count.load(std::memory_order_relaxed);
+    auto start = std::chrono::steady_clock::now();
+
+    for (int i = 0; i < OUTER_LOOPS; ++i)
+        co_await capy_session(stream);
+
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto after = g_alloc_count.load(std::memory_order_relaxed);
+    out = {std::chrono::duration_cast<
+        std::chrono::nanoseconds>(elapsed).count(),
+        after - before};
+}
+
+// -----------------------------------------------------------
+// Table 2: capy::task - Column B (sender via await_sender)
+// -----------------------------------------------------------
+
+template <class Stream>
+capy::task<> capy_session_sndr(Stream& stream)
+{
+    char buf[64];
+    for (int i = 0; i < INNER_LOOPS; ++i)
+        (void)co_await capy::await_sender(
+            stream.read_some(
+                capy::mutable_buffer(buf, sizeof(buf))));
+}
+
+template <class Stream>
+capy::task<> capy_accept_sndr(Stream& stream, cell_result& out)
+{
+    auto before = g_alloc_count.load(std::memory_order_relaxed);
+    auto start = std::chrono::steady_clock::now();
+
+    for (int i = 0; i < OUTER_LOOPS; ++i)
+        co_await capy_session_sndr(stream);
+
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto after = g_alloc_count.load(std::memory_order_relaxed);
+    out = {std::chrono::duration_cast<
+        std::chrono::nanoseconds>(elapsed).count(),
+        after - before};
+}
+
+// -----------------------------------------------------------
+// Table 3: exec::task - Column A (sender, native)
+// -----------------------------------------------------------
+
+template <class Stream>
+auto exec_session(Stream& stream) -> exec::task<void>
+{
+    char buf[64];
+    for (int i = 0; i < INNER_LOOPS; ++i)
+        (void)co_await stream.read_some(
+            capy::mutable_buffer(buf, sizeof(buf)));
+}
+
+template <class Stream>
+auto exec_accept(Stream& stream, cell_result& out)
+    -> exec::task<void>
+{
+    auto before = g_alloc_count.load(std::memory_order_relaxed);
+    auto start = std::chrono::steady_clock::now();
+
+    for (int i = 0; i < OUTER_LOOPS; ++i)
+        co_await exec_session(stream);
+
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto after = g_alloc_count.load(std::memory_order_relaxed);
+    out = {std::chrono::duration_cast<
+        std::chrono::nanoseconds>(elapsed).count(),
+        after - before};
+}
+
+// -----------------------------------------------------------
+// Table 3: exec::task - Column B (awaitable via as_sender)
+//
+// exec::task's promise env carries only get_start_scheduler
+// (type-erased __any_scheduler), which does not propagate
+// custom queries like get_io_executor. We supply the
+// executor explicitly and inject it into each per-call env
+// via write_env so the awaitable_sender bridge can find it.
+// -----------------------------------------------------------
+
+template <class Stream>
+auto exec_session_ioaw(
+    Stream& stream,
+    sender_as_capy_executor ex) -> exec::task<void>
+{
+    char buf[64];
+    for (int i = 0; i < INNER_LOOPS; ++i)
+        (void)co_await stdexec::write_env(
+            capy::as_sender(
+                stream.read_some(
+                    capy::mutable_buffer(buf, sizeof(buf)))),
+            stdexec::prop{capy::get_io_executor, ex});
+}
+
+template <class Stream>
+auto exec_accept_ioaw(
+    Stream& stream,
+    sender_as_capy_executor ex,
+    cell_result& out) -> exec::task<void>
+{
+    auto before = g_alloc_count.load(std::memory_order_relaxed);
+    auto start = std::chrono::steady_clock::now();
+
+    for (int i = 0; i < OUTER_LOOPS; ++i)
+        co_await exec_session_ioaw(stream, ex);
+
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto after = g_alloc_count.load(std::memory_order_relaxed);
+    out = {std::chrono::duration_cast<
+        std::chrono::nanoseconds>(elapsed).count(),
+        after - before};
+}
+
+int main()
+{
+    cell_result grid[NUM_RUNS + 1][NUM_TABLES][NUM_STREAMS][NUM_COLUMNS]{};
+
+    // run 0 is a warmup pass (results discarded);
+    // measured runs are 1..NUM_RUNS
+    for (int run = 0; run <= NUM_RUNS; ++run)
+    {
+
+    // -----------------------------------------------------------
+    // Table 1: sender/receiver pipeline (repeat_until)
+    //
+    // All Table 1 cells use exec::static_thread_pool(2) instead of (1).
+    // exec::repeat_until synchronously emplaces iteration N+1 inside
+    // iteration N's set_value cascade. With a single-worker pool the
+    // worker is stuck in that cascade and can't dispatch the post the
+    // cascade just queued, deadlocking. A second worker drains the
+    // queue while the first is in the cascade. Tables 2 and 3 stay at
+    // pool(1) because co_await suspension releases the worker between
+    // iterations and avoids the issue.
+    // -----------------------------------------------------------
+
+    // Col A: Sender (native)
+
+    // Native - sndr_read_stream
+    {
+        exec::static_thread_pool pool(2);
+        static_pool_context ctx;
+        sndr_read_stream stream{&pool};
+        pool_scheduler sched{&pool, &ctx};
+        int count = OPS_PER_CELL;
+        char buf[64];
+        auto before = g_alloc_count.load(std::memory_order_relaxed);
+        auto start = std::chrono::steady_clock::now();
+        stdexec::sync_wait(stdexec::starts_on(sched,
+            exec::repeat_until(
+                stdexec::let_value(stdexec::just(), [&]() {
+                    return stream.read_some(
+                        capy::mutable_buffer(buf, sizeof(buf)));
+                })
+                | stdexec::then([&count](std::size_t) { return --count == 0; }))));
+        pool.request_stop();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        auto after = g_alloc_count.load(std::memory_order_relaxed);
+        grid[run][SENDER_RECEIVER][NATIVE_STREAM][NATIVE_EXEC_MODEL] = {
+            std::chrono::duration_cast<
+                std::chrono::nanoseconds>(elapsed).count(),
+            after - before};
+    }
+
+    // Abstract - sndr_io_read_stream
+    {
+        exec::static_thread_pool pool(2);
+        static_pool_context ctx;
+        sndr_io_read_stream_impl stream{&pool};
+        pool_scheduler sched{&pool, &ctx};
+        int count = OPS_PER_CELL;
+        char buf[64];
+        auto* mr = get_counting_resource();
+        std::pmr::polymorphic_allocator<std::byte> alloc(mr);
+        auto before = g_alloc_count.load(std::memory_order_relaxed);
+        auto start = std::chrono::steady_clock::now();
+        stdexec::sync_wait(
+            stdexec::write_env(
+                stdexec::starts_on(sched,
+                    exec::repeat_until(
+                        stdexec::let_value(stdexec::just(), [&]() {
+                            return static_cast<sndr_io_read_stream&>(
+                                stream).read_some(
+                                    capy::mutable_buffer(buf, sizeof(buf)));
+                        })
+                        | stdexec::then([&count](std::size_t) { return --count == 0; }))),
+                stdexec::prop{exec::get_frame_allocator, alloc}));
+        pool.request_stop();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        auto after = g_alloc_count.load(std::memory_order_relaxed);
+        grid[run][SENDER_RECEIVER][ABSTRACT_STREAM][NATIVE_EXEC_MODEL] = {
+            std::chrono::duration_cast<
+                std::chrono::nanoseconds>(elapsed).count(),
+            after - before};
+    }
+
+    // Type erased - sndr_any_read_stream
+    {
+        exec::static_thread_pool pool(2);
+        static_pool_context ctx;
+        sndr_any_read_stream stream(sndr_read_stream{&pool});
+        pool_scheduler sched{&pool, &ctx};
+        int count = OPS_PER_CELL;
+        char buf[64];
+        auto* mr = get_counting_resource();
+        std::pmr::polymorphic_allocator<std::byte> alloc(mr);
+        auto before = g_alloc_count.load(std::memory_order_relaxed);
+        auto start = std::chrono::steady_clock::now();
+        stdexec::sync_wait(
+            stdexec::write_env(
+                stdexec::starts_on(sched,
+                    exec::repeat_until(
+                        stdexec::let_value(stdexec::just(), [&]() {
+                            return stream.read_some(
+                                capy::mutable_buffer(buf, sizeof(buf)));
+                        })
+                        | stdexec::then([&count](std::size_t) { return --count == 0; }))),
+                stdexec::prop{exec::get_frame_allocator, alloc}));
+        pool.request_stop();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        auto after = g_alloc_count.load(std::memory_order_relaxed);
+        grid[run][SENDER_RECEIVER][TYPE_ERASED_STREAM][NATIVE_EXEC_MODEL] = {
+            std::chrono::duration_cast<
+                std::chrono::nanoseconds>(elapsed).count(),
+            after - before};
+    }
+
+    // Synchronous - sndr_sync_read_stream (Col A)
+    {
+        exec::static_thread_pool pool(2);
+        static_pool_context ctx;
+        sndr_sync_read_stream stream;
+        pool_scheduler sched{&pool, &ctx};
+        int count = OPS_PER_CELL;
+        char buf[64];
+        auto before = g_alloc_count.load(std::memory_order_relaxed);
+        auto start = std::chrono::steady_clock::now();
+        stdexec::sync_wait(stdexec::starts_on(sched,
+            exec::repeat_until(
+                stdexec::let_value(stdexec::just(), [&]() {
+                    return stream.read_some(
+                        capy::mutable_buffer(buf, sizeof(buf)));
+                })
+                | stdexec::then([&count](std::size_t) { return --count == 0; }))));
+        pool.request_stop();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        auto after = g_alloc_count.load(std::memory_order_relaxed);
+        grid[run][SENDER_RECEIVER][SYNC_STREAM][NATIVE_EXEC_MODEL] = {
+            std::chrono::duration_cast<
+                std::chrono::nanoseconds>(elapsed).count(),
+            after - before};
+    }
+
+    // Col B: Awaitable (via as_sender bridge)
+
+    // Native - ioaw_read_stream
+    {
+        exec::static_thread_pool pool(2);
+        static_pool_context ctx;
+        ioaw_read_stream stream;
+        pool_scheduler sched{&pool, &ctx};
+        sender_as_capy_executor adapter{&pool, &ctx};
+        int count = OPS_PER_CELL;
+        char buf[64];
+        auto before = g_alloc_count.load(std::memory_order_relaxed);
+        auto start = std::chrono::steady_clock::now();
+        stdexec::sync_wait(stdexec::starts_on(sched,
+            exec::repeat_until(
+                stdexec::let_value(stdexec::just(), [&]() {
+                    return stdexec::write_env(
+                        capy::as_sender(stream.read_some(
+                            capy::mutable_buffer(buf, sizeof(buf)))),
+                        stdexec::prop{capy::get_io_executor, adapter});
+                })
+                | stdexec::then([&count](std::size_t) { return --count == 0; }))));
+        pool.request_stop();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        auto after = g_alloc_count.load(std::memory_order_relaxed);
+        grid[run][SENDER_RECEIVER][NATIVE_STREAM][BRIDGED_EXEC_MODEL] = {
+            std::chrono::duration_cast<
+                std::chrono::nanoseconds>(elapsed).count(),
+            after - before};
+    }
+
+    // Abstract - ioaw_io_read_stream
+    {
+        exec::static_thread_pool pool(2);
+        static_pool_context ctx;
+        ioaw_io_read_stream_impl stream;
+        pool_scheduler sched{&pool, &ctx};
+        sender_as_capy_executor adapter{&pool, &ctx};
+        int count = OPS_PER_CELL;
+        char buf[64];
+        auto before = g_alloc_count.load(std::memory_order_relaxed);
+        auto start = std::chrono::steady_clock::now();
+        stdexec::sync_wait(stdexec::starts_on(sched,
+            exec::repeat_until(
+                stdexec::let_value(stdexec::just(), [&]() {
+                    return stdexec::write_env(
+                        capy::as_sender(
+                            static_cast<ioaw_io_read_stream&>(
+                                stream).read_some(
+                                    capy::mutable_buffer(
+                                        buf, sizeof(buf)))),
+                        stdexec::prop{capy::get_io_executor, adapter});
+                })
+                | stdexec::then([&count](std::size_t) { return --count == 0; }))));
+        pool.request_stop();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        auto after = g_alloc_count.load(std::memory_order_relaxed);
+        grid[run][SENDER_RECEIVER][ABSTRACT_STREAM][BRIDGED_EXEC_MODEL] = {
+            std::chrono::duration_cast<
+                std::chrono::nanoseconds>(elapsed).count(),
+            after - before};
+    }
+
+    // Type erased - capy::any_read_stream
+    {
+        exec::static_thread_pool pool(2);
+        static_pool_context ctx;
+        ioaw_read_stream concrete;
+        capy::any_read_stream stream(&concrete);
+        pool_scheduler sched{&pool, &ctx};
+        sender_as_capy_executor adapter{&pool, &ctx};
+        int count = OPS_PER_CELL;
+        char buf[64];
+        auto before = g_alloc_count.load(std::memory_order_relaxed);
+        auto start = std::chrono::steady_clock::now();
+        stdexec::sync_wait(stdexec::starts_on(sched,
+            exec::repeat_until(
+                stdexec::let_value(stdexec::just(), [&]() {
+                    return stdexec::write_env(
+                        capy::as_sender(stream.read_some(
+                            capy::mutable_buffer(buf, sizeof(buf)))),
+                        stdexec::prop{capy::get_io_executor, adapter});
+                })
+                | stdexec::then([&count](std::size_t) { return --count == 0; }))));
+        pool.request_stop();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        auto after = g_alloc_count.load(std::memory_order_relaxed);
+        grid[run][SENDER_RECEIVER][TYPE_ERASED_STREAM][BRIDGED_EXEC_MODEL] = {
+            std::chrono::duration_cast<
+                std::chrono::nanoseconds>(elapsed).count(),
+            after - before};
+    }
+
+    // Synchronous - ioaw_sync_read_stream (Col B)
+    {
+        exec::static_thread_pool pool(2);
+        static_pool_context ctx;
+        ioaw_sync_read_stream stream;
+        pool_scheduler sched{&pool, &ctx};
+        sender_as_capy_executor adapter{&pool, &ctx};
+        int count = OPS_PER_CELL;
+        char buf[64];
+        auto before = g_alloc_count.load(std::memory_order_relaxed);
+        auto start = std::chrono::steady_clock::now();
+        stdexec::sync_wait(stdexec::starts_on(sched,
+            exec::repeat_until(
+                stdexec::let_value(stdexec::just(), [&]() {
+                    return stdexec::write_env(
+                        capy::as_sender(stream.read_some(
+                            capy::mutable_buffer(buf, sizeof(buf)))),
+                        stdexec::prop{capy::get_io_executor, adapter});
+                })
+                | stdexec::then([&count](std::size_t) { return --count == 0; }))));
+        pool.request_stop();
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        auto after = g_alloc_count.load(std::memory_order_relaxed);
+        grid[run][SENDER_RECEIVER][SYNC_STREAM][BRIDGED_EXEC_MODEL] = {
+            std::chrono::duration_cast<
+                std::chrono::nanoseconds>(elapsed).count(),
+            after - before};
+    }
+
+    // -----------------------------------------------------------
+    // Table 2: capy::task (capy::thread_pool)
+    // -----------------------------------------------------------
+
+    // Col A: Awaitable (native)
+
+    // Native - ioaw_read_stream
+    {
+        capy::thread_pool pool(1);
+        ioaw_read_stream stream;
+        capy::run_async(pool.get_executor())(
+            capy_accept(stream,
+                grid[run][CAPY_TASK][NATIVE_STREAM][NATIVE_EXEC_MODEL]));
+        pool.join();
+    }
+
+    // Abstract - ioaw_io_read_stream
+    {
+        capy::thread_pool pool(1);
+        ioaw_io_read_stream_impl stream;
+        capy::run_async(pool.get_executor())(
+            capy_accept(static_cast<ioaw_io_read_stream&>(stream),
+                grid[run][CAPY_TASK][ABSTRACT_STREAM][NATIVE_EXEC_MODEL]));
+        pool.join();
+    }
+
+    // Type erased - capy::any_read_stream
+    {
+        capy::thread_pool pool(1);
+        ioaw_read_stream concrete;
+        capy::any_read_stream stream(&concrete);
+        capy::run_async(pool.get_executor())(
+            capy_accept(stream,
+                grid[run][CAPY_TASK][TYPE_ERASED_STREAM][NATIVE_EXEC_MODEL]));
+        pool.join();
+    }
+
+    // Synchronous - ioaw_sync_read_stream
+    {
+        capy::thread_pool pool(1);
+        ioaw_sync_read_stream stream;
+        capy::run_async(pool.get_executor())(
+            capy_accept(stream,
+                grid[run][CAPY_TASK][SYNC_STREAM][NATIVE_EXEC_MODEL]));
+        pool.join();
+    }
+
+    // Col B: Sender (via await_sender bridge)
+
+    // Native - sndr_read_stream
+    {
+        exec::static_thread_pool pool(1);
+        static_pool_context ctx;
+        sender_as_capy_executor adapter{&pool, &ctx};
+        sndr_read_stream stream{&pool};
+        std::latch done(1);
+        capy::run_async(adapter,
+            [&done](auto&&...) noexcept { done.count_down(); })(
+            capy_accept_sndr(stream,
+                grid[run][CAPY_TASK][NATIVE_STREAM][BRIDGED_EXEC_MODEL]));
+        done.wait();
+        pool.request_stop();
+    }
+
+    // Abstract - sndr_io_read_stream
+    {
+        exec::static_thread_pool pool(1);
+        static_pool_context ctx;
+        sender_as_capy_executor adapter{&pool, &ctx};
+        sndr_io_read_stream_impl stream{&pool};
+        std::latch done(1);
+        capy::run_async(adapter,
+            [&done](auto&&...) noexcept { done.count_down(); })(
+            capy_accept_sndr(
+                static_cast<sndr_io_read_stream&>(stream),
+                grid[run][CAPY_TASK][ABSTRACT_STREAM][BRIDGED_EXEC_MODEL]));
+        done.wait();
+        pool.request_stop();
+    }
+
+    // Type erased - sndr_any_read_stream
+    {
+        exec::static_thread_pool pool(1);
+        static_pool_context ctx;
+        sender_as_capy_executor adapter{&pool, &ctx};
+        sndr_any_read_stream stream(sndr_read_stream{&pool});
+        std::latch done(1);
+        capy::run_async(adapter,
+            [&done](auto&&...) noexcept { done.count_down(); })(
+            capy_accept_sndr(stream,
+                grid[run][CAPY_TASK][TYPE_ERASED_STREAM][BRIDGED_EXEC_MODEL]));
+        done.wait();
+        pool.request_stop();
+    }
+
+    // Synchronous - sndr_sync_read_stream
+    {
+        exec::static_thread_pool pool(1);
+        static_pool_context ctx;
+        sender_as_capy_executor adapter{&pool, &ctx};
+        sndr_sync_read_stream stream;
+        std::latch done(1);
+        capy::run_async(adapter,
+            [&done](auto&&...) noexcept { done.count_down(); })(
+            capy_accept_sndr(stream,
+                grid[run][CAPY_TASK][SYNC_STREAM][BRIDGED_EXEC_MODEL]));
+        done.wait();
+        pool.request_stop();
+    }
+
+    // -----------------------------------------------------------
+    // Table 3: exec::task (exec::static_thread_pool)
+    // -----------------------------------------------------------
+
+    // Col A: Sender (native)
+
+    // Native - sndr_read_stream
+    {
+        exec::static_thread_pool pool(1);
+        static_pool_context ctx;
+        pool_scheduler sched{&pool, &ctx};
+        sndr_read_stream stream{&pool};
+        stdexec::sync_wait(stdexec::starts_on(sched,
+            exec_accept(stream,
+                grid[run][EXEC_TASK][NATIVE_STREAM][NATIVE_EXEC_MODEL])));
+        pool.request_stop();
+    }
+
+    // Abstract - sndr_io_read_stream
+    {
+        exec::static_thread_pool pool(1);
+        static_pool_context ctx;
+        pool_scheduler sched{&pool, &ctx};
+        sndr_io_read_stream_impl stream{&pool};
+        auto* mr = get_counting_resource();
+        std::pmr::polymorphic_allocator<std::byte> alloc(mr);
+        stdexec::sync_wait(
+            stdexec::write_env(
+                stdexec::starts_on(sched,
+                    exec_accept(
+                        static_cast<sndr_io_read_stream&>(stream),
+                        grid[run][EXEC_TASK][ABSTRACT_STREAM][NATIVE_EXEC_MODEL])),
+                stdexec::prop{exec::get_frame_allocator, alloc}));
+        pool.request_stop();
+    }
+
+    // Type erased - sndr_any_read_stream
+    {
+        exec::static_thread_pool pool(1);
+        static_pool_context ctx;
+        pool_scheduler sched{&pool, &ctx};
+        sndr_any_read_stream stream(sndr_read_stream{&pool});
+        auto* mr = get_counting_resource();
+        std::pmr::polymorphic_allocator<std::byte> alloc(mr);
+        stdexec::sync_wait(
+            stdexec::write_env(
+                stdexec::starts_on(sched,
+                    exec_accept(stream,
+                        grid[run][EXEC_TASK][TYPE_ERASED_STREAM][NATIVE_EXEC_MODEL])),
+                stdexec::prop{exec::get_frame_allocator, alloc}));
+        pool.request_stop();
+    }
+
+    // Synchronous - sndr_sync_read_stream
+    {
+        exec::static_thread_pool pool(1);
+        static_pool_context ctx;
+        pool_scheduler sched{&pool, &ctx};
+        sndr_sync_read_stream stream;
+        stdexec::sync_wait(stdexec::starts_on(sched,
+            exec_accept(stream,
+                grid[run][EXEC_TASK][SYNC_STREAM][NATIVE_EXEC_MODEL])));
+        pool.request_stop();
+    }
+
+    // Col B: Awaitable (via as_sender bridge)
+
+    // Native - ioaw_read_stream
+    {
+        exec::static_thread_pool pool(1);
+        static_pool_context ctx;
+        pool_scheduler sched{&pool, &ctx};
+        sender_as_capy_executor adapter{&pool, &ctx};
+        ioaw_read_stream stream;
+        stdexec::sync_wait(stdexec::starts_on(sched,
+            exec_accept_ioaw(stream, adapter,
+                grid[run][EXEC_TASK][NATIVE_STREAM][BRIDGED_EXEC_MODEL])));
+        pool.request_stop();
+    }
+
+    // Abstract - ioaw_io_read_stream
+    {
+        exec::static_thread_pool pool(1);
+        static_pool_context ctx;
+        pool_scheduler sched{&pool, &ctx};
+        sender_as_capy_executor adapter{&pool, &ctx};
+        ioaw_io_read_stream_impl stream;
+        stdexec::sync_wait(stdexec::starts_on(sched,
+            exec_accept_ioaw(
+                static_cast<ioaw_io_read_stream&>(stream),
+                adapter,
+                grid[run][EXEC_TASK][ABSTRACT_STREAM][BRIDGED_EXEC_MODEL])));
+        pool.request_stop();
+    }
+
+    // Type erased - capy::any_read_stream
+    {
+        exec::static_thread_pool pool(1);
+        static_pool_context ctx;
+        pool_scheduler sched{&pool, &ctx};
+        sender_as_capy_executor adapter{&pool, &ctx};
+        ioaw_read_stream concrete;
+        capy::any_read_stream stream(&concrete);
+        auto* mr = get_counting_resource();
+        std::pmr::polymorphic_allocator<std::byte> alloc(mr);
+        stdexec::sync_wait(
+            stdexec::write_env(
+                stdexec::starts_on(sched,
+                    exec_accept_ioaw(stream, adapter,
+                        grid[run][EXEC_TASK][TYPE_ERASED_STREAM][BRIDGED_EXEC_MODEL])),
+                stdexec::prop{exec::get_frame_allocator, alloc}));
+        pool.request_stop();
+    }
+
+    // Synchronous - ioaw_sync_read_stream
+    {
+        exec::static_thread_pool pool(1);
+        static_pool_context ctx;
+        pool_scheduler sched{&pool, &ctx};
+        sender_as_capy_executor adapter{&pool, &ctx};
+        ioaw_sync_read_stream stream;
+        stdexec::sync_wait(stdexec::starts_on(sched,
+            exec_accept_ioaw(stream, adapter,
+                grid[run][EXEC_TASK][SYNC_STREAM][BRIDGED_EXEC_MODEL])));
+        pool.request_stop();
+    }
+
+    } // for (run)
+
+    // -----------------------------------------------------------
+    // Print results
+    // -----------------------------------------------------------
+
+    constexpr double ops = static_cast<double>(OPS_PER_CELL);
+
+    std::printf(
+        "I/O read stream benchmark (stdexec): "
+        "%d read_some calls per cell, %d runs\n",
+        OPS_PER_CELL, NUM_RUNS);
+
+    char const* row_labels[] = {
+        "Native", "Abstract", "Type-erased", "Synchronous"};
+
+    auto print_table = [&](
+        char const* title,
+        int table,
+        char const* col_a_label,
+        char const* col_b_label)
+    {
+        std::printf("\n  %s\n", title);
+        std::printf(
+            "  %-18s  %-30s  %-30s\n",
+            "", col_a_label, col_b_label);
+        std::printf(
+            "  %-18s  %-30s  %-30s\n",
+            "------------------",
+            "------------------------------",
+            "------------------------------");
+
+        for (int s = 0; s < NUM_STREAMS; ++s)
+        {
+            double sum[NUM_COLUMNS]{};
+            double sum2[NUM_COLUMNS]{};
+            double al[NUM_COLUMNS]{};
+            for (int c = 0; c < NUM_COLUMNS; ++c)
+            {
+                for (int r = 1; r <= NUM_RUNS; ++r)
+                {
+                    double v = static_cast<double>(
+                        grid[r][table][s][c].ns) / ops;
+                    sum[c] += v;
+                    sum2[c] += v * v;
+                    al[c] += static_cast<double>(
+                        grid[r][table][s][c].allocs);
+                }
+            }
+
+            double mean[NUM_COLUMNS];
+            double sd[NUM_COLUMNS];
+            double mean_al[NUM_COLUMNS];
+            for (int c = 0; c < NUM_COLUMNS; ++c)
+            {
+                mean[c] = sum[c] / NUM_RUNS;
+                double var = sum2[c] / NUM_RUNS -
+                    mean[c] * mean[c];
+                sd[c] = std::sqrt(var > 0 ? var : 0);
+                mean_al[c] = al[c] / (NUM_RUNS * ops);
+            }
+
+            std::printf(
+                "  %-18s"
+                "  %5.1f +/- %3.1f ns/op  %1.0f al/op"
+                "    %5.1f +/- %3.1f ns/op  %1.0f al/op"
+                "\n",
+                row_labels[s],
+                mean[0], sd[0], mean_al[0],
+                mean[1], sd[1], mean_al[1]);
+        }
+    };
+
+    print_table(
+        "sender/receiver pipeline",
+        SENDER_RECEIVER,
+        "A: sender (native)",
+        "B: awaitable (bridge)");
+
+    print_table(
+        "capy::task",
+        CAPY_TASK,
+        "A: awaitable (native)",
+        "B: sender (bridge)");
+
+    print_table(
+        "exec::task",
+        EXEC_TASK,
+        "A: sender (native)",
+        "B: awaitable (bridge)");
+
+    return 0;
+}

--- a/bench/stdexec/sender_awaitable.hpp
+++ b/bench/stdexec/sender_awaitable.hpp
@@ -1,0 +1,428 @@
+//
+// Copyright (c) 2026 Vinnie Falco (vinnie.falco@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_STDEXEC_SENDER_AWAITABLE_HPP
+#define BOOST_CAPY_BENCH_STDEXEC_SENDER_AWAITABLE_HPP
+
+#include <boost/capy/error.hpp>
+#include <boost/capy/ex/io_env.hpp>
+#include <boost/capy/io_result.hpp>
+
+#include <stdexec/execution.hpp>
+
+#include <atomic>
+#include <coroutine>
+#include <exception>
+#include <new>
+#include <stop_token>
+#include <system_error>
+#include <tuple>
+#include <type_traits>
+#include <variant>
+
+namespace boost::capy {
+
+namespace detail {
+
+struct stopped_t {};
+
+struct operation_cancelled {};
+
+struct bridge_env
+{
+    std::stop_token st_;
+
+    auto query(
+        stdexec::get_stop_token_t const&)
+            const noexcept
+    {
+        return st_;
+    }
+};
+
+template<class Sender>
+using sender_single_value_t =
+    stdexec::value_types_of_t<
+        Sender,
+        bridge_env,
+        std::tuple,
+        std::type_identity_t>;
+
+// Detect whether a sender can complete with
+// set_error(std::error_code).
+template<class Sender>
+struct has_error_code_completion
+{
+    template<class... Es>
+    struct checker
+    {
+        static constexpr bool value =
+            (std::is_same_v<
+                Es, std::error_code> || ...);
+    };
+
+    static constexpr bool value =
+        stdexec::error_types_of_t<
+            Sender,
+            bridge_env,
+            checker>::value;
+};
+
+template<class Sender>
+constexpr bool has_error_code_v =
+    has_error_code_completion<Sender>::value;
+
+// Variant when sender can complete with
+// set_error(error_code): separate slot so
+// error_code is not wrapped in exception_ptr.
+template<class ValueTuple>
+using ec_result_variant = std::variant<
+    std::monostate,
+    ValueTuple,
+    std::error_code,
+    std::exception_ptr,
+    stopped_t>;
+
+// Variant when sender does not complete with
+// set_error(error_code).
+template<class ValueTuple>
+using no_ec_result_variant = std::variant<
+    std::monostate,
+    ValueTuple,
+    std::exception_ptr,
+    stopped_t>;
+
+template<class ValueTuple, bool HasEc>
+using result_variant = std::conditional_t<
+    HasEc,
+    ec_result_variant<ValueTuple>,
+    no_ec_result_variant<ValueTuple>>;
+
+// Bridge receiver that stores the sender's
+// completion result and resumes the coroutine.
+// Uses an atomic flag shared with await_suspend
+// to handle synchronous completion safely:
+// whichever side (set_value or await_suspend)
+// arrives second is responsible for resumption.
+template<class ValueTuple, bool HasEc>
+struct bridge_receiver
+{
+    using receiver_concept =
+        stdexec::receiver_t;
+
+    result_variant<ValueTuple, HasEc>* result_;
+    std::coroutine_handle<>            cont_;
+    std::stop_token                    st_;
+    std::atomic<bool>*                 done_;
+
+    auto get_env() const noexcept -> bridge_env
+    {
+        return {st_};
+    }
+
+    void resume_if_ready() noexcept
+    {
+        if(done_->exchange(
+            true, std::memory_order_acq_rel))
+            cont_.resume();
+    }
+
+    template<class... Args>
+    void set_value(Args&&... args) && noexcept
+    {
+        result_->template emplace<1>(
+            std::forward<Args>(args)...);
+        resume_if_ready();
+    }
+
+    template<class E>
+    void set_error(E&& e) && noexcept
+    {
+        if constexpr (
+            HasEc &&
+            std::is_same_v<
+                std::decay_t<E>,
+                std::error_code>)
+            result_->template emplace<2>(
+                std::forward<E>(e));
+        else if constexpr (
+            std::is_same_v<
+                std::decay_t<E>,
+                std::exception_ptr>)
+        {
+            constexpr auto idx = HasEc ? 3 : 2;
+            result_->template emplace<idx>(
+                std::forward<E>(e));
+        }
+        else
+        {
+            constexpr auto idx = HasEc ? 3 : 2;
+            result_->template emplace<idx>(
+                std::make_exception_ptr(
+                    std::forward<E>(e)));
+        }
+        resume_if_ready();
+    }
+
+    void set_stopped() && noexcept
+    {
+        constexpr auto idx = HasEc ? 4 : 3;
+        result_->template emplace<idx>(
+            stopped_t{});
+        resume_if_ready();
+    }
+};
+
+} // namespace detail
+
+/** Awaitable that bridges a stdexec sender
+    into a Capy coroutine.
+
+    Satisfies IoAwaitable. When co_awaited inside
+    a capy::task, connects the sender to a bridge
+    receiver, starts the operation, and resumes
+    the coroutine when the sender completes.
+
+    Uses an atomic exchange protocol to handle
+    senders that complete synchronously during
+    start(): whichever side arrives second
+    (receiver or await_suspend) resumes the
+    coroutine.
+
+    The bridge inspects the sender's error
+    completion signatures at compile time. If the
+    sender can complete with
+    set_error(std::error_code), await_resume
+    returns io_result so the error code is a
+    value, not an exception. Otherwise
+    await_resume returns the value directly and
+    genuine exceptions are rethrown.
+
+    @tparam Sender The stdexec sender type.
+*/
+template<class Sender>
+struct [[nodiscard]] sender_awaitable
+{
+    static constexpr bool has_ec =
+        detail::has_error_code_v<Sender>;
+
+    using value_tuple =
+        detail::sender_single_value_t<Sender>;
+    using variant_type =
+        detail::result_variant<
+            value_tuple, has_ec>;
+    using receiver_type =
+        detail::bridge_receiver<
+            value_tuple, has_ec>;
+    using op_state_type = decltype(
+        stdexec::connect(
+            std::declval<Sender>(),
+            std::declval<receiver_type>()));
+
+    Sender sndr_;
+    variant_type result_{};
+
+    alignas(op_state_type)
+    unsigned char op_buf_[sizeof(op_state_type)];
+    bool op_constructed_ = false;
+    std::atomic<bool> done_{false};
+
+    explicit sender_awaitable(Sender sndr)
+        : sndr_(std::move(sndr))
+    {
+    }
+
+    sender_awaitable(sender_awaitable&& o)
+        noexcept(
+            std::is_nothrow_move_constructible_v<
+                Sender>)
+        : sndr_(std::move(o.sndr_))
+    {
+    }
+
+    sender_awaitable(
+        sender_awaitable const&) = delete;
+    sender_awaitable& operator=(
+        sender_awaitable const&) = delete;
+    sender_awaitable& operator=(
+        sender_awaitable&&) = delete;
+
+    ~sender_awaitable()
+    {
+        if(op_constructed_)
+            std::launder(
+                reinterpret_cast<op_state_type*>(
+                    op_buf_))->~op_state_type();
+    }
+
+    bool await_ready() const noexcept
+    {
+        return false;
+    }
+
+    std::coroutine_handle<>
+    await_suspend(
+        std::coroutine_handle<> h,
+        io_env const* env)
+    {
+        ::new(op_buf_) op_state_type(
+            stdexec::connect(
+                std::move(sndr_),
+                receiver_type{
+                    &result_, h,
+                    env->stop_token, &done_}));
+        op_constructed_ = true;
+        stdexec::start(
+            *std::launder(
+                reinterpret_cast<
+                    op_state_type*>(
+                        op_buf_)));
+
+        // If the sender completed during start(),
+        // the receiver already stored the result.
+        // Return h to resume without suspending.
+        if(done_.exchange(
+            true, std::memory_order_acq_rel))
+            return h;
+        return std::noop_coroutine();
+    }
+
+    auto await_resume()
+    {
+        if constexpr (has_ec)
+            return await_resume_ec();
+        else
+            return await_resume_no_ec();
+    }
+
+private:
+    // Sender can complete with
+    // set_error(error_code). Return io_result
+    // so the error code is a value, not an
+    // exception.
+    auto await_resume_ec()
+    {
+        // exception_ptr at index 3
+        if(result_.index() == 3)
+            std::rethrow_exception(
+                std::get<3>(result_));
+
+        if constexpr (
+            std::tuple_size_v<
+                value_tuple> == 0)
+        {
+            // stopped at index 4
+            if(result_.index() == 4)
+                return io_result<>{
+                    make_error_code(
+                        error::canceled)};
+            if(result_.index() == 2)
+                return io_result<>{
+                    std::get<2>(result_)};
+            return io_result<>{};
+        }
+        else if constexpr (
+            std::tuple_size_v<
+                value_tuple> == 1)
+        {
+            using T = std::tuple_element_t<
+                0, value_tuple>;
+            if(result_.index() == 4)
+                return io_result<T>{
+                    make_error_code(
+                        error::canceled), T{}};
+            if(result_.index() == 2)
+                return io_result<T>{
+                    std::get<2>(result_), T{}};
+            return io_result<T>{
+                {},
+                std::get<0>(
+                    std::get<1>(
+                        std::move(result_)))};
+        }
+        else
+        {
+            if(result_.index() == 4)
+                return io_result<value_tuple>{
+                    make_error_code(
+                        error::canceled), value_tuple{}};
+            if(result_.index() == 2)
+                return io_result<value_tuple>{
+                    std::get<2>(result_), value_tuple{}};
+            return io_result<value_tuple>{
+                {},
+                std::get<1>(
+                    std::move(result_))};
+        }
+    }
+
+    // Sender does not complete with
+    // set_error(error_code). Return the value
+    // directly; rethrow exceptions.
+    auto await_resume_no_ec()
+    {
+        // exception_ptr at index 2
+        if(result_.index() == 2)
+            std::rethrow_exception(
+                std::get<2>(result_));
+        // stopped at index 3
+        if(result_.index() == 3)
+            throw detail::operation_cancelled{};
+
+        if constexpr (
+            std::tuple_size_v<
+                value_tuple> == 0)
+            return;
+        else if constexpr (
+            std::tuple_size_v<
+                value_tuple> == 1)
+            return std::get<0>(
+                std::get<1>(
+                    std::move(result_)));
+        else
+            return std::get<1>(
+                std::move(result_));
+    }
+};
+
+/** Create an IoAwaitable from a stdexec sender.
+
+    If the sender can complete with
+    set_error(std::error_code), the returned
+    awaitable yields io_result so the error code
+    is a value, not an exception. Otherwise the
+    awaitable yields the value directly.
+
+    @par Example
+    @code
+    capy::task<int> compute(auto sched)
+    {
+        auto result = co_await await_sender(
+            stdexec::schedule(sched)
+                | stdexec::then(
+                    [] { return 42; }));
+        co_return result;
+    }
+    @endcode
+
+    @param sndr The sender to bridge.
+    @return An IoAwaitable that can be co_awaited
+        in a capy::task.
+*/
+template<class Sender>
+auto await_sender(Sender&& sndr)
+{
+    return sender_awaitable<
+        std::decay_t<Sender>>(
+            std::forward<Sender>(sndr));
+}
+
+} // namespace boost::capy
+
+#endif

--- a/bench/stdexec/sender_io_env.hpp
+++ b/bench/stdexec/sender_io_env.hpp
@@ -1,0 +1,175 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+//
+// stdexec execution environment for benchmarks.
+//
+// Provides the capy executor adapter wrapping exec::static_thread_pool,
+// so capy::task can run on it.
+//
+
+#ifndef BOOST_CAPY_BENCH_STDEXEC_SENDER_IO_ENV_HPP
+#define BOOST_CAPY_BENCH_STDEXEC_SENDER_IO_ENV_HPP
+
+#include "awaitable_sender.hpp"
+
+#include <boost/capy/continuation.hpp>
+#include <boost/capy/ex/execution_context.hpp>
+
+#include <stdexec/execution.hpp>
+#include <exec/static_thread_pool.hpp>
+#include <exec/start_detached.hpp>
+
+#include <coroutine>
+
+// Minimal execution_context shell for exec::static_thread_pool.
+// exec::static_thread_pool does not inherit from capy's
+// execution_context, but the Executor concept requires context()
+// to return one. This stub satisfies the requirement without
+// any service machinery.
+struct static_pool_context
+    : boost::capy::execution_context
+{
+    static_pool_context()
+        : boost::capy::execution_context(this)
+    {}
+
+    ~static_pool_context()
+    {
+        shutdown();
+        destroy();
+    }
+
+    static_pool_context(static_pool_context const&) = delete;
+    static_pool_context& operator=(static_pool_context const&) = delete;
+};
+
+// Adapter making exec::static_thread_pool satisfy capy's
+// Executor concept so capy::task can run on it.
+struct sender_as_capy_executor
+{
+    exec::static_thread_pool* pool_;
+    static_pool_context* ctx_;
+
+    boost::capy::execution_context& context() const noexcept
+    {
+        return *ctx_;
+    }
+
+    void on_work_started() const noexcept {}
+    void on_work_finished() const noexcept {}
+
+    void post(boost::capy::continuation& cont) const;
+
+    // Return the handle for symmetric transfer so the
+    // caller resumes the coroutine inline.
+    std::coroutine_handle<>
+    dispatch(boost::capy::continuation& c) const
+    {
+        return c.h;
+    }
+
+    bool operator==(
+        sender_as_capy_executor const&) const noexcept = default;
+};
+
+// Heap-allocated trampoline; not zero-alloc by design.
+// Honest reflection of what exec::static_thread_pool costs.
+inline void sender_as_capy_executor::post(
+    boost::capy::continuation& cont) const
+{
+    // upon_error eats the set_error_t(exception_ptr) channel
+    // that stdexec::then advertises so start_detached's
+    // no-error precondition is satisfied at the type level.
+    exec::start_detached(
+        stdexec::schedule(pool_->get_scheduler())
+        | stdexec::then([&cont]() noexcept { cont.h.resume(); })
+        | stdexec::upon_error([](auto&&) noexcept {}));
+}
+
+// Forward declaration needed so pool_schedule_sender can name pool_scheduler.
+struct pool_scheduler;
+
+// Custom schedule-sender for pool_scheduler. Wraps the pool's native
+// schedule sender but reports pool_scheduler as the completion scheduler,
+// which stdexec's starts_on adapter requires.
+struct pool_schedule_sender
+{
+    using sender_concept = stdexec::sender_tag;
+
+    exec::static_thread_pool* pool_;
+    pool_scheduler const* sched_;
+
+    // exec::static_thread_pool::scheduler completes with set_value_t()
+    // and set_stopped_t() (when the receiver carries a stop token).
+    template<class Self, class Env>
+    static consteval auto get_completion_signatures() noexcept
+    {
+        return stdexec::completion_signatures<
+            stdexec::set_value_t(),
+            stdexec::set_stopped_t()>{};
+    }
+
+    struct env_t
+    {
+        pool_scheduler const* sched_;
+
+        auto query(stdexec::get_completion_scheduler_t<
+                   stdexec::set_value_t> const&) const noexcept
+            -> pool_scheduler const&
+        {
+            return *sched_;
+        }
+    };
+
+    env_t get_env() const noexcept { return {sched_}; }
+
+    template<class Receiver>
+    auto connect(Receiver&& rcvr) &&
+    {
+        return stdexec::connect(
+            pool_->get_scheduler().schedule(),
+            std::forward<Receiver>(rcvr));
+    }
+
+    template<class Receiver>
+    auto connect(Receiver&& rcvr) const&
+    {
+        return stdexec::connect(
+            pool_->get_scheduler().schedule(),
+            std::forward<Receiver>(rcvr));
+    }
+};
+
+// Scheduler wrapper that delegates schedule() to exec::static_thread_pool
+// but answers boost::capy's get_io_executor_t query. Required by the
+// capy::as_sender bridge in awaitable_sender.hpp, which queries the
+// receiver-env scheduler for the capy executor at instantiation time.
+struct pool_scheduler
+{
+    using scheduler_concept = stdexec::scheduler_t;
+
+    exec::static_thread_pool* pool_;
+    static_pool_context* ctx_;
+
+    pool_schedule_sender schedule() const noexcept
+    {
+        return {pool_, this};
+    }
+
+    auto query(boost::capy::get_io_executor_t const&) const noexcept
+        -> sender_as_capy_executor
+    {
+        return sender_as_capy_executor{pool_, ctx_};
+    }
+
+    bool operator==(pool_scheduler const&) const = default;
+};
+
+#endif

--- a/bench/stdexec/sndr_any_read_stream.hpp
+++ b/bench/stdexec/sndr_any_read_stream.hpp
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_STDEXEC_SNDR_ANY_READ_STREAM_HPP
+#define BOOST_CAPY_BENCH_STDEXEC_SNDR_ANY_READ_STREAM_HPP
+
+#include <boost/capy/buffers.hpp>
+
+#include <exec/any_sender_of.hpp>
+#include <stdexec/execution.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <system_error>
+#include <utility>
+
+/// Type-erased sender returned from any_read_stream::read_some.
+using any_read_sender =
+    exec::any_sender<exec::any_receiver<stdexec::completion_signatures<
+        stdexec::set_value_t(std::size_t),
+        stdexec::set_error_t(std::error_code),
+        stdexec::set_error_t(std::exception_ptr),
+        stdexec::set_stopped_t()>>>;
+
+/// Value-type-erased read stream.
+///
+/// Holds a concrete stream by value via a polymorphic
+/// model. read_some returns any_read_sender so the
+/// concrete stream's sender type is hidden at the
+/// stream's API boundary.
+class sndr_any_read_stream
+{
+    struct concept_t
+    {
+        virtual any_read_sender read_some(
+            boost::capy::mutable_buffer) = 0;
+        virtual ~concept_t() = default;
+    };
+
+    template <class Stream>
+    struct model_t : concept_t
+    {
+        Stream stream_;
+
+        explicit model_t(Stream s) : stream_(std::move(s)) {}
+
+        any_read_sender read_some(
+            boost::capy::mutable_buffer buf) override
+        {
+            return any_read_sender(stream_.read_some(buf));
+        }
+    };
+
+    std::unique_ptr<concept_t> impl_;
+
+public:
+    template <class Stream>
+    explicit sndr_any_read_stream(Stream s)
+        : impl_(new model_t<Stream>(std::move(s)))
+    {}
+
+    any_read_sender read_some(boost::capy::mutable_buffer buf)
+    {
+        return impl_->read_some(buf);
+    }
+};
+
+#endif

--- a/bench/stdexec/sndr_io_read_stream.hpp
+++ b/bench/stdexec/sndr_io_read_stream.hpp
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_STDEXEC_SNDR_IO_READ_STREAM_HPP
+#define BOOST_CAPY_BENCH_STDEXEC_SNDR_IO_READ_STREAM_HPP
+
+#include "sndr_any_read_stream.hpp"
+#include "sndr_read_stream.hpp"
+
+#include <boost/capy/buffers.hpp>
+
+/// Abstract interface for sender-based read streams.
+struct sndr_io_read_stream
+{
+    virtual any_read_sender
+        read_some(boost::capy::mutable_buffer) = 0;
+    virtual ~sndr_io_read_stream() = default;
+};
+
+/// Concrete implementation wrapping sndr_read_stream.
+struct sndr_io_read_stream_impl : sndr_io_read_stream
+{
+    sndr_read_stream stream_;
+
+    explicit sndr_io_read_stream_impl(
+        exec::static_thread_pool* pool)
+        : stream_{pool} {}
+
+    any_read_sender
+        read_some(boost::capy::mutable_buffer buf) override
+    {
+        return any_read_sender{stream_.read_some(buf)};
+    }
+};
+
+#endif

--- a/bench/stdexec/sndr_read_stream.hpp
+++ b/bench/stdexec/sndr_read_stream.hpp
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_STDEXEC_SNDR_READ_STREAM_HPP
+#define BOOST_CAPY_BENCH_STDEXEC_SNDR_READ_STREAM_HPP
+
+#include <boost/capy/buffers.hpp>
+
+#include <exec/static_thread_pool.hpp>
+#include <stdexec/execution.hpp>
+
+#include <cstddef>
+
+/// No-op sender stream for benchmarks.
+///
+/// Holds an exec::static_thread_pool* (analogous to how a
+/// socket holds a reference to its execution context).
+/// read_some() returns starts_on(sched, just(0)); the
+/// sender is consumable by sender pipelines via connect
+/// and by exec::task / capy::task via co_await.
+struct sndr_read_stream
+{
+    exec::static_thread_pool* pool_;
+
+    auto read_some(boost::capy::mutable_buffer)
+    {
+        return stdexec::starts_on(
+            pool_->get_scheduler(),
+            stdexec::just(std::size_t{0}));
+    }
+};
+
+#endif

--- a/bench/stdexec/sndr_sync_read_stream.hpp
+++ b/bench/stdexec/sndr_sync_read_stream.hpp
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_BENCH_STDEXEC_SNDR_SYNC_READ_STREAM_HPP
+#define BOOST_CAPY_BENCH_STDEXEC_SNDR_SYNC_READ_STREAM_HPP
+
+#include <boost/capy/buffers.hpp>
+
+#include <stdexec/execution.hpp>
+
+#include <cstddef>
+
+/// Synchronous no-op sender stream.
+///
+/// read_some returns just(0); no scheduler trip.
+/// Used as the synchronous-baseline row in the bench.
+struct sndr_sync_read_stream
+{
+    auto read_some(boost::capy::mutable_buffer)
+    {
+        return stdexec::just(std::size_t{0});
+    }
+};
+
+#endif


### PR DESCRIPTION
Parallel benchmark under bench/stdexec/ that exercises the same I/O read-stream workload as bench/beman/ but uses NVIDIA stdexec instead of beman::execution. Gated by a new CMake option
BOOST_CAPY_BUILD_STDEXEC_EXAMPLES, independent from the existing BOOST_CAPY_BUILD_P2300_EXAMPLES.

Three tables x four rows x two columns:
  Table 1: sender/receiver pipeline (exec::repeat_until)
  Table 2: capy::task (capy::thread_pool)
  Table 3: exec::task (exec::static_thread_pool)
  Rows:    Native / Abstract / Type-erased / Synchronous

Idiomatic stdexec throughout: exec::static_thread_pool, exec::task<void>, exec::any_sender<any_receiver<completion_signatures<>>> (post PR #2040), exec::repeat_until, and write_env(prop( exec::get_frame_allocator, alloc)) at type-erased pipeline roots so op-state storage routes through the counting/recycling resource.

Bridges between stdexec and capy executor model:
  - capy::as_sender(IoAwaitable)    -> stdexec sender
  - capy::await_sender(stdexec snd) -> IoAwaitable
  - sender_as_capy_executor + pool_scheduler + static_pool_context
    adapt exec::static_thread_pool to capy's Executor concept

Table 1 cells use exec::static_thread_pool(2) to work around exec::repeat_until's single-worker deadlock (it synchronously emplaces iteration N+1 inside iteration N's set_value cascade, so a single worker can't drain the queue it just posted to). Tables 2 and 3 stay at pool(1) because co_await suspension releases the worker between iterations. The header comment in main.cpp documents this trade-off.

Two stdexec gaps documented in the source comments:
  - exec::any_sender value-storage on construction can't route through get_frame_allocator (env not visible at construction time)
  - exec::task has no allocator hook for coroutine frames