### PR TITLE
docs: bump antora-cpp-reference/tagfiles extensions to 0.1.1

### DIFF
--- a/doc/package-lock.json
+++ b/doc/package-lock.json
@@ -8,8 +8,8 @@
         "@antora/expand-path-helper": "^3.0.0",
         "@antora/lunr-extension": "^1.0.0-alpha.12",
         "@asciidoctor/tabs": "^1.0.0-beta.6",
-        "@cppalliance/antora-cpp-reference-extension": "^0.1.0",
-        "@cppalliance/antora-cpp-tagfiles-extension": "^0.1.0",
+        "@cppalliance/antora-cpp-reference-extension": "^0.1.1",
+        "@cppalliance/antora-cpp-tagfiles-extension": "^0.1.1",
         "@cppalliance/antora-downloads-extension": "^0.0.2",
         "@cppalliance/asciidoctor-boost-links": "^0.0.2",
         "@sntke/antora-mermaid-extension": "^0.0.8"
@@ -340,24 +340,24 @@
       }
     },
     "node_modules/@cppalliance/antora-cpp-reference-extension": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@cppalliance/antora-cpp-reference-extension/-/antora-cpp-reference-extension-0.1.0.tgz",
-      "integrity": "sha512-3VD/gAFebR06GiBWAy2PgEHNqyRNrvAE0FfFvotLvA0RQmHn0q+ct+j0z53N64yxuvJVj8Hl0bRRPdhh2BGjXg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@cppalliance/antora-cpp-reference-extension/-/antora-cpp-reference-extension-0.1.1.tgz",
+      "integrity": "sha512-otGW/pJNtYyji62ELGkyEc6PseHxz882HhQGB1YUxPehg+2CjzM/hqQ7aJFXtaNAedrXK0/upQ+KCCs2WPWFqg==",
       "license": "BSL-1.0",
       "dependencies": {
         "@antora/expand-path-helper": "^3.0.0",
-        "axios": "^1.13.2",
+        "axios": "^1.16.1",
         "cache-directory": "^2.0.0",
         "fast-glob": "^3.3.3",
-        "isomorphic-git": "^1.35.0",
-        "js-yaml": "^4.1.0",
-        "semver": "^7.7.3"
+        "isomorphic-git": "^1.38.1",
+        "js-yaml": "^4.1.1",
+        "semver": "^7.8.1"
       }
     },
     "node_modules/@cppalliance/antora-cpp-reference-extension/node_modules/isomorphic-git": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.35.0.tgz",
-      "integrity": "sha512-+pRiwWDld5yAjdTFFh9+668kkz4uzCZBs+mw+ZFxPAxJBX8KCqd/zAP7Zak0BK5BQ+dXVqEurR5DkEnqrLpHlQ==",
+      "version": "1.38.4",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.38.4.tgz",
+      "integrity": "sha512-Ud5vs6Ac+ET+iOZWZB1j2RruVeGQSQc7U7QUhPq6iGqzifaqOVHCgRpG/8c0LwIP39R+Mr+lzR4escmCuhjONQ==",
       "license": "MIT",
       "dependencies": {
         "async-lock": "^1.4.1",
@@ -379,6 +379,28 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/@cppalliance/antora-cpp-reference-extension/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@cppalliance/antora-cpp-reference-extension/node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -396,9 +418,9 @@
       }
     },
     "node_modules/@cppalliance/antora-cpp-tagfiles-extension": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@cppalliance/antora-cpp-tagfiles-extension/-/antora-cpp-tagfiles-extension-0.1.0.tgz",
-      "integrity": "sha512-YKCRpqv8srMhqwlUcY3704H6U5DHzQ8Q73JVUv1TF+MsGdUP60DDNR6v8+Xj6PLe93K/MAo6ZUgtJ+RN40YoZQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@cppalliance/antora-cpp-tagfiles-extension/-/antora-cpp-tagfiles-extension-0.1.1.tgz",
+      "integrity": "sha512-TKQ6BDWENmKmQE+iudx41/FOjb4F30Mcosz8IKEBc2b22OE9782++m5gOvEgGO6MJd8Tbib8Kdxl1QPjp6IP9A==",
       "license": "BSL-1.0",
       "dependencies": {
         "@antora/expand-path-helper": "^3.0.0",
@@ -521,6 +543,18 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/antora": {
       "version": "3.1.14",
       "resolved": "https://registry.npmjs.org/antora/-/antora-3.1.14.tgz",
@@ -596,14 +630,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -865,6 +900,23 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -1165,9 +1217,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -1200,9 +1252,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -1429,6 +1481,19 @@
         "entities": "^4.5.0"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1579,6 +1644,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -1725,6 +1791,12 @@
       "dependencies": {
         "minimist": "^1.2.5"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/multi-progress": {
       "version": "4.0.0",
@@ -1945,10 +2017,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -2111,9 +2186,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/doc/package.json
+++ b/doc/package.json
@@ -8,8 +8,8 @@
     "@antora/expand-path-helper": "^3.0.0",
     "@antora/lunr-extension": "^1.0.0-alpha.12",
     "@asciidoctor/tabs": "^1.0.0-beta.6",
-    "@cppalliance/antora-cpp-reference-extension": "^0.1.0",
-    "@cppalliance/antora-cpp-tagfiles-extension": "^0.1.0",
+    "@cppalliance/antora-cpp-reference-extension": "^0.1.1",
+    "@cppalliance/antora-cpp-tagfiles-extension": "^0.1.1",
     "@cppalliance/antora-downloads-extension": "^0.0.2",
     "@cppalliance/asciidoctor-boost-links": "^0.0.2",
     "@sntke/antora-mermaid-extension": "^0.0.8"


### PR DESCRIPTION
Update the C++ documentation toolchain to the latest published versions so npm ci installs them. Both extensions move in lockstep because they share the tagfile-registry handshake.