### PR TITLE
docs: pin MrDocs to develop-release for the symlink path-filter fix

### DIFF
--- a/doc/local-playbook.yml
+++ b/doc/local-playbook.yml
@@ -29,6 +29,10 @@ antora:
         using-namespaces:
           - 'boost::'
     - require: '@cppalliance/antora-cpp-reference-extension'
+      # Pin MrDocs to the develop-release channel, which carries the upstream
+      # fix for the symlinked-workspace cwd bug (mrdocs 4f51471e) that broke
+      # the reference build. Without this the extension may select master-release.
+      version: develop
       dependencies:
         - name: 'boost'
           repo: 'https://github.com/boostorg/boost.git'


### PR DESCRIPTION
This is a temporary PR to test fixes on MrDocs:develop in Jenkins.