### PR TITLE
ci: block merges that drop coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,12 +12,12 @@ codecov:
     after_n_builds: 1
     wait_for_ci: yes
 
-# Make coverage checks informational (report but never fail CI)
 coverage:
   status:
     project:
       default:
-        informational: true
+        target: auto
+        threshold: 0%
     patch:
       default:
         informational: true


### PR DESCRIPTION
Make the codecov project status a failing check (target auto, 0% threshold) instead of informational, so any drop in include/ + src/ coverage fails it. Requires the check to be marked required in branch protection. ci.yml already uploads coverage on every PR.