### PR TITLE
fix(ex): propagate handler exceptions out of run_async

### DIFF
--- a/include/boost/capy/detail/run_callbacks.hpp
+++ b/include/boost/capy/detail/run_callbacks.hpp
@@ -11,6 +11,7 @@
 #define BOOST_CAPY_DETAIL_RUN_CALLBACKS_HPP
 
 #include <boost/capy/detail/config.hpp>
+#include <boost/capy/detail/stop_requested_exception.hpp>
 
 #include <concepts>
 #include <exception>
@@ -34,8 +35,16 @@ struct default_handler
 
     void operator()(std::exception_ptr ep) const
     {
-        if(ep)
+        if(!ep)
+            return;
+        try
+        {
             std::rethrow_exception(ep);
+        }
+        catch(stop_requested_exception const&)
+        {
+            // Cancellation is a normal completion, not an error.
+        }
     }
 };
 
@@ -92,7 +101,7 @@ struct handler_pair<H1, default_handler>
         if constexpr(std::invocable<H1, std::exception_ptr>)
             h1_(ep);
         else
-            std::rethrow_exception(ep);
+            default_handler{}(ep);
     }
 };
 

--- a/include/boost/capy/ex/run_async.hpp
+++ b/include/boost/capy/ex/run_async.hpp
@@ -167,7 +167,7 @@ struct BOOST_CAPY_CORO_DESTROY_WHEN_COMPLETE run_async_trampoline
         {
         }
 
-        void unhandled_exception() noexcept {} // LCOV_EXCL_LINE unsupported: throwing task with no error handler
+        void unhandled_exception() { throw; }
     };
 
     std::coroutine_handle<promise_type> h_;
@@ -261,9 +261,7 @@ struct BOOST_CAPY_CORO_DESTROY_WHEN_COMPLETE
         {
         }
 
-        void unhandled_exception() noexcept
-        {
-        }
+        void unhandled_exception() { throw; }
     };
 
     std::coroutine_handle<promise_type> h_;
@@ -414,7 +412,18 @@ public:
         // safe_resume is not needed here: TLS is already saved in the
         // constructor (saved_tls_) and restored in the destructor.
         p.task_cont_.h = task_h;
-        p.wg_.executor().dispatch(p.task_cont_).resume();
+        auto tr = tr_.h_;
+        try
+        {
+            p.wg_.executor().dispatch(p.task_cont_).resume();
+        }
+        catch(...)
+        {
+            // A propagating handler leaves the trampoline suspended at its
+            // final suspend point instead of self-destroying; reclaim it.
+            tr.destroy();
+            throw;
+        }
     }
 };
 
@@ -427,11 +436,19 @@ public:
     storing the wrapper and calling it later violates LIFO ordering.
 
     Uses the default recycling frame allocator for coroutine frames.
-    With no handlers, the result is discarded and exceptions are rethrown.
+    With no handlers, the result is discarded. An exception that escapes
+    a handler is not swallowed: it propagates out of the call that
+    resumes the task. Cooperative cancellation via the stop token is a
+    normal completion and is not propagated.
 
     @par Thread Safety
     The wrapper and handlers may be called from any thread where the
     executor schedules work.
+
+    @par Exception Safety
+    An exception escaping a handler (including a rethrowing error
+    handler or the default handler) propagates out of the call that
+    resumes the task rather than being swallowed.
 
     @par Example
     @code

--- a/test/unit/ex/run_async.cpp
+++ b/test/unit/ex/run_async.cpp
@@ -236,6 +236,21 @@ struct run_async_test
     }
 
     void
+    testValueAllocatorPropagates()
+    {
+        // Value-allocator trampoline: with no error handler the default
+        // handler rethrows, exercising propagation through the primary
+        // template (the memory_resource* specialization is covered by
+        // testDefaultHandlerPropagates).
+        int dispatch_count = 0;
+        sync_executor d(dispatch_count);
+
+        BOOST_TEST_THROWS(
+            run_async(d, std::allocator<std::byte>{})(throws_exception()),
+            test_exception);
+    }
+
+    void
     testVoidTaskResultHandler()
     {
         int dispatch_count = 0;
@@ -305,10 +320,37 @@ struct run_async_test
         co_return;
     }
 
-    // Note: testDefaultRethrow removed - if no error handler is provided
-    // and the task throws, the exception goes to unhandled_exception which
-    // is undefined behavior. Users must provide an error handler if they
-    // want to handle exceptions.
+    void
+    testDefaultHandlerPropagates()
+    {
+        // No error handler: the default handler rethrows the task's
+        // exception, which propagates out of the resuming run() call
+        // (here the inline sync dispatch).
+        int dispatch_count = 0;
+        sync_executor d(dispatch_count);
+
+        BOOST_TEST_THROWS(
+            run_async(d)(throws_exception()), test_exception);
+    }
+
+    void
+    testRethrowingHandlerPropagates()
+    {
+        // An error handler that rethrows propagates out of the call
+        // that resumes the task instead of being swallowed.
+        int dispatch_count = 0;
+        sync_executor d(dispatch_count);
+
+        BOOST_TEST_THROWS(
+            run_async(d,
+                [](int) {},
+                [](std::exception_ptr ep) {
+                    if(ep)
+                        std::rethrow_exception(ep);
+                }
+            )(throws_exception()),
+            test_exception);
+    }
 
     void
     testErrorHandlerReceivesException()
@@ -708,12 +750,15 @@ struct run_async_test
         testNoHandlers();
         testValueAllocator();
         testValueAllocatorException();
+        testValueAllocatorPropagates();
         testResultHandler();
         testVoidTaskResultHandler();
         testDualHandlers();
         testOverloadedHandler();
 
         // Exception Handling
+        testDefaultHandlerPropagates();
+        testRethrowingHandlerPropagates();
         testErrorHandlerReceivesException();
         testOverloadedHandlerException();
 

--- a/test/unit/quitter.cpp
+++ b/test/unit/quitter.cpp
@@ -144,6 +144,27 @@ struct quitter_test
         BOOST_TEST_EQ(dtor_count, 0);
     }
 
+    void
+    testStopWithDefaultHandler()
+    {
+        // With no error handler, a stopped quitter must complete
+        // silently: cooperative cancellation is a normal outcome, so
+        // the default handler discards the stop sentinel rather than
+        // rethrowing it (which would escape run() and terminate).
+        int dispatch_count = 0;
+        test_executor ex(dispatch_count);
+        std::stop_source source;
+        source.request_stop();
+
+        int dtor_count = 0;
+        bool reached = false;
+
+        run_async(ex, source.get_token())(quitter_with_raii(dtor_count));
+
+        reached = true;
+        BOOST_TEST(reached);
+    }
+
     //----------------------------------------------------------
     // 5. Stop during I/O
     //----------------------------------------------------------
@@ -863,6 +884,7 @@ struct quitter_test
         testVoidCompletion();
         testExceptionPropagation();
         testStopBeforeFirstAwait();
+        testStopWithDefaultHandler();
         testStopDuringIO();
         testStopPropagationChain();
         testMixingQuitterAndTask();


### PR DESCRIPTION
Resolves #259.

The run_async trampoline caught and discarded every exception in its unhandled_exception(), so an error handler that rethrew (and the default handler, which rethrows by design) had no way to surface a task failure. The documented "exceptions are rethrown" behavior never happened.

Rethrow from the trampoline instead, so an exception escaping a handler propagates out of the call that resumes the task rather than being swallowed.

A rethrowing unhandled_exception leaves the trampoline suspended at its final suspend point, so the suspend_never final_suspend never self-destroys the frame. Fire-and-forget launch has no later owner, so operator() reclaims the frame when the inline dispatch unwinds, before propagating.

Cooperative cancellation is reported by quitter as a stop_requested_exception sentinel through the same exception() channel. That is a normal completion, not an error, so the default handler discards the sentinel and rethrows everything else; otherwise a stopped quitter with no error handler would terminate. The result-only handler delegates to the same logic.

Add tests covering propagation through both trampoline allocators (default memory_resource and value allocator), a rethrowing error handler, and a stopped quitter under the default handler.