### PR TITLE
ci: drop -fvisibility=hidden workaround for Apple Clang 21+

### DIFF
--- a/.github/compilers.json
+++ b/.github/compilers.json
@@ -146,7 +146,6 @@
       "cxx": "clang++",
       "cc": "clang",
       "b2_toolset": "clang",
-      "cxxflags": "-fvisibility=hidden -fvisibility-inlines-hidden",
       "is_latest": true
     }
   ]


### PR DESCRIPTION
The macos-26 runner ships Xcode 26.5 / Apple Clang 21, so the CMake build no longer needs the visibility workaround there. macos-15 (Apple Clang 17) is still affected and keeps the flag. The workaround only ever mattered for CMake builds; b2 defaults to hidden visibility and is unaffected.

Closes #194