### PR TITLE
fix(error): map error codes to portable std conditions via default_er…

### DIFF
--- a/include/boost/capy/error.hpp
+++ b/include/boost/capy/error.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -72,6 +73,8 @@ struct BOOST_CAPY_SYMBOL_VISIBLE
         ) const noexcept override;
     BOOST_CAPY_DECL std::string message(
         int) const override;
+    BOOST_CAPY_DECL std::error_condition default_error_condition(
+        int) const noexcept override;
     constexpr error_cat_type() noexcept = default;
 };
 

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -8,6 +9,7 @@
 //
 
 #include <boost/capy/error.hpp>
+#include <boost/capy/cond.hpp>
 
 namespace boost {
 namespace capy {
@@ -35,6 +37,26 @@ message(int code) const
     case error::timeout: return "timeout";
     default:
         return "unknown";
+    }
+}
+
+// Map each capy error code to its canonical portable condition.
+// canceled and timeout have standard equivalents, so they map to the
+// generic conditions rather than capy's own cond enumerators; this is
+// what lets, e.g., error::canceled compare equal to
+// std::errc::operation_canceled.
+std::error_condition
+error_cat_type::
+default_error_condition(int code) const noexcept
+{
+    switch(static_cast<error>(code))
+    {
+    case error::eof:              return make_error_condition(cond::eof);
+    case error::canceled:         return std::make_error_condition(std::errc::operation_canceled);
+    case error::stream_truncated: return make_error_condition(cond::stream_truncated);
+    case error::not_found:        return make_error_condition(cond::not_found);
+    case error::timeout:          return std::make_error_condition(std::errc::timed_out);
+    default:                      return std::error_condition(code, *this);
     }
 }
 

--- a/test/unit/cond.cpp
+++ b/test/unit/cond.cpp
@@ -91,6 +91,10 @@ public:
         // Equivalence: stream_truncated and timeout.
         BOOST_TEST(make_error_code(error::stream_truncated) ==
             cond::stream_truncated);
+        // A non-matching code exercises cond_cat::equivalent for
+        // stream_truncated, which the positive comparison above now
+        // resolves via error_cat::default_error_condition instead.
+        BOOST_TEST(!(make_error_code(error::eof) == cond::stream_truncated));
         BOOST_TEST(make_error_code(error::timeout) == cond::timeout);
 
         // Out-of-range condition is equivalent to nothing.

--- a/test/unit/error.cpp
+++ b/test/unit/error.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -45,6 +46,21 @@ public:
 
         // Out-of-range value hits the default branch.
         BOOST_TEST(cat.message(9999) == "unknown");
+
+        // issue #267: capy error codes compare equal to their portable
+        // std conditions via default_error_condition().
+        BOOST_TEST(make_error_code(error::canceled) == std::errc::operation_canceled);
+        BOOST_TEST(make_error_code(error::timeout)  == std::errc::timed_out);
+
+        // exact repro from the issue
+        {
+            std::error_code      e = error::canceled;
+            std::error_condition c{std::errc::operation_canceled};
+            BOOST_TEST(e == c);
+        }
+
+        // non-matching codes still differ
+        BOOST_TEST(!(make_error_code(error::eof) == std::errc::operation_canceled));
     }
 };
 


### PR DESCRIPTION
…ror_condition

Override default_error_condition in error_cat so each
capy error maps to its canonical portable condition: canceled ->
std::errc::operation_canceled, timeout -> std::errc::timed_out, and eof/stream_truncated/not_found to their cond::* equivalents.

Resolves #267