### PR TITLE
Incorrectly assuming operator-> exists

### DIFF
--- a/include/boost/capy/read_until.hpp
+++ b/include/boost/capy/read_until.hpp
@@ -43,9 +43,12 @@ linearize_buffers(ConstBufferSequence auto const& data)
     linear.reserve(buffer_size(data));
     auto const end_ = end(data);
     for(auto it = begin(data); it != end_; ++it)
+    {
+        const_buffer b = *it;
         linear.append(
-            static_cast<char const*>(it->data()),
-            it->size());
+            static_cast<char const*>(b.data()),
+            b.size());
+    }
     return linear;
 } // LCOV_EXCL_LINE gcov brace artifact (linearize_buffers is exercised)
 


### PR DESCRIPTION
Not necessarily.

Consider

```c++
		char a[] = "ab";
		char b[] = "cd";

		std::array bufs
		{
			const_buffer(a, 2),
			const_buffer(b, 2)
		};

		auto seq = bufs | std::views::transform([](const_buffer x) { return x; }); // sponsored by SG9

		static_assert(ConstBufferSequence<decltype(seq)>);

		// Fails in detail::linearize_buffers because transform_view's iterator
		// does not provide operator->
		std::ignore = detail::search_buffer_for_match(seq, match_delim{"bc"});
```

Example uses `detail::API` directly to reproduce the issue, but it can also be triggered through the public exposing API as well by passing a crafted `weird_dyn_buffer` of sorts:

```c++
	struct weird_dynamic_buffer
	{
		char a[2] = {'a', 'b'};
		char b[2] = {'c', 'd'};

		std::array<const_buffer, 2> readable
		{
			const_buffer(a, 2),
			const_buffer(b, 2)
		};

		char scratch[16]{};

		static constexpr auto id = [](const_buffer x) { return x; };

		using const_buffers_type = decltype(std::declval<std::array<const_buffer, 2> const&>() | std::views::transform(id)); // sponsored by SG9

		using mutable_buffers_type = mutable_buffer;

		std::size_t size() const noexcept { return 4; }

		std::size_t max_size() const noexcept { return 16; }

		std::size_t capacity() const noexcept { return 12; }

		const_buffers_type data() const { return readable | std::views::transform(id); }

		mutable_buffers_type prepare(std::size_t n) { return mutable_buffer(scratch, n); }

		void commit(std::size_t) {}

		void consume(std::size_t) {}
	};

	static_assert(DynamicBuffer<weird_dynamic_buffer>);

	task<void> fumo_fumo()
	{
		test::read_stream rs;

		weird_dynamic_buffer db;

		std::ignore = co_await read_until(rs, db, "bc");
	}
```