### PR TITLE
cond::timeout now matches std::errc::timed_out

### DIFF
--- a/src/cond.cpp
+++ b/src/cond.cpp
@@ -64,7 +64,11 @@ equivalent(
         return ec == capy::error::not_found;
 
     case cond::timeout:
-        return ec == capy::error::timeout;
+        if(ec == capy::error::timeout)
+            return true;
+        if(ec == std::errc::timed_out)
+            return true;
+        return false;
 
     default:
         return false;

--- a/test/unit/cond.cpp
+++ b/test/unit/cond.cpp
@@ -97,6 +97,18 @@ public:
         BOOST_TEST(!(make_error_code(error::eof) == cond::stream_truncated));
         BOOST_TEST(make_error_code(error::timeout) == cond::timeout);
 
+        // Equivalence: std::errc::timed_out == cond::timeout
+        {
+            auto ec = make_error_code(std::errc::timed_out);
+            BOOST_TEST(ec == cond::timeout);
+            BOOST_TEST(!(ec == cond::eof));
+        }
+        {
+            std::error_code ec = std::make_error_code(std::errc::timed_out);
+            BOOST_TEST(ec == cond::timeout);
+            BOOST_TEST(!(ec == cond::canceled));
+        }
+
         // Out-of-range condition is equivalent to nothing.
         {
             auto ec = make_error_code(error::eof);


### PR DESCRIPTION
cond_cat::equivalent matched cond::timeout only against error::timeout, while cond::canceled also matched raw std::errc::operation_canceled. A platform or third-party timed_out code therefore compared equal to cond::canceled's analogue but not to cond::timeout.

Accept std::errc::timed_out for cond::timeout so callers can compare any timeout code against the portable condition, mirroring the canceled branch.