### PR TITLE
feat(test): honor io_env::stop_token in capy::test awaitables (#317)

### DIFF
--- a/doc/modules/ROOT/pages/7.testing/7a.drivers.adoc
+++ b/doc/modules/ROOT/pages/7.testing/7a.drivers.adoc
@@ -120,6 +120,36 @@ context such as a thread pool.
   `on_error(ep)` on failure.
 |===
 
+=== Exercising Cancellation
+
+The stop token supplied to `run_blocking` propagates through the execution
+environment to every `capy::test` awaitable. When the token is requested, the
+next awaited test operation resolves to `error::canceled` instead of
+performing its work, so code under test can be driven down its cancellation
+paths without real I/O.
+
+[source,cpp]
+----
+std::stop_source src;
+src.request_stop();
+
+run_blocking(src.get_token())([&]() -> task<>
+{
+    read_stream rs;
+    rs.provide("ignored");
+
+    char buf[32];
+    auto [ec, n] = co_await rs.read_some(make_buffer(buf));
+    assert(ec == cond::canceled);   // honored the stop token
+}());
+----
+
+The mock sources, sinks, and buffer adapters complete synchronously, so they
+check the token up front: an outstanding stop request yields `error::canceled`
+on the next operation. A connected `stream` whose `read_some` is *blocked*
+waiting for its peer is resumed with `error::canceled` when the token fires; a
+read that can satisfy from already-buffered data is unaffected.
+
 == fuse
 
 `fuse` tests every error-handling path in a coroutine by injecting failures

--- a/include/boost/capy/test/buffer_sink.hpp
+++ b/include/boost/capy/test/buffer_sink.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -152,6 +153,10 @@ public:
 
         @return An awaitable that await-returns `(error_code)`.
 
+        @par Cancellation
+        If the environment's stop token has been requested, the commit
+        completes immediately with `error::canceled` and commits no data.
+
         @see fuse
     */
     auto
@@ -161,29 +166,31 @@ public:
         {
             buffer_sink* self_;
             std::size_t n_;
+            bool canceled_ = false;
 
-            bool await_ready() const noexcept { return true; }
+            bool await_ready() const noexcept { return false; }
 
-            // This method is required to satisfy Capy's IoAwaitable concept,
-            // but is never called because await_ready() returns true.
-            //
-            // Capy uses a two-layer awaitable system: the promise's
-            // await_transform wraps awaitables in a transform_awaiter whose
-            // standard await_suspend(coroutine_handle) calls this custom
-            // 2-argument overload, passing the io_env from the coroutine's
-            // context. For synchronous test awaitables like this one, the
-            // coroutine never suspends, so this is not invoked. The signature
-            // exists to allow the same awaitable type to work with both
-            // synchronous (test) and asynchronous (real I/O) code.
-            void await_suspend(
+            // The operation completes synchronously, but await_suspend is
+            // the only place io_env is delivered (the promise's
+            // transform_awaiter forwards it here). Returning false means
+            // the coroutine does not actually suspend; it resumes
+            // immediately, having observed the stop token. See io_env,
+            // IoAwaitable.
+            bool
+            await_suspend(
                 std::coroutine_handle<>,
-                io_env const*) const noexcept
+                io_env const* env) noexcept
             {
+                canceled_ = env->stop_token.stop_requested();
+                return false;
             }
 
             io_result<>
             await_resume()
             {
+                if(canceled_)
+                    return {error::canceled};
+
                 auto ec = self_->f_.maybe_fail();
                 if(ec)
                     return {ec};
@@ -209,6 +216,11 @@ public:
 
         @return An awaitable that await-returns `(error_code)`.
 
+        @par Cancellation
+        If the environment's stop token has been requested, the operation
+        completes immediately with `error::canceled`, commits no data, and
+        does not signal end-of-stream.
+
         @see fuse
     */
     auto
@@ -218,21 +230,27 @@ public:
         {
             buffer_sink* self_;
             std::size_t n_;
+            bool canceled_ = false;
 
-            bool await_ready() const noexcept { return true; }
+            bool await_ready() const noexcept { return false; }
 
-            // This method is required to satisfy Capy's IoAwaitable concept,
-            // but is never called because await_ready() returns true.
-            // See the comment on commit(std::size_t) for a detailed explanation.
-            void await_suspend(
+            // Reads the stop token without suspending; see the comment
+            // on commit() for details.
+            bool
+            await_suspend(
                 std::coroutine_handle<>,
-                io_env const*) const noexcept
+                io_env const* env) noexcept
             {
+                canceled_ = env->stop_token.stop_requested();
+                return false;
             }
 
             io_result<>
             await_resume()
             {
+                if(canceled_)
+                    return {error::canceled};
+
                 auto ec = self_->f_.maybe_fail();
                 if(ec)
                     return {ec};

--- a/include/boost/capy/test/buffer_source.hpp
+++ b/include/boost/capy/test/buffer_source.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -142,6 +143,10 @@ public:
 
         @return An awaitable that await-returns `(error_code,std::span<const_buffer>)`.
 
+        @par Cancellation
+        If the environment's stop token has been requested, the pull
+        completes immediately with `error::canceled` and an empty span.
+
         @see consume, fuse
     */
     auto
@@ -151,29 +156,31 @@ public:
         {
             buffer_source* self_;
             std::span<const_buffer> dest_;
+            bool canceled_ = false;
 
-            bool await_ready() const noexcept { return true; }
+            bool await_ready() const noexcept { return false; }
 
-            // This method is required to satisfy Capy's IoAwaitable concept,
-            // but is never called because await_ready() returns true.
-            //
-            // Capy uses a two-layer awaitable system: the promise's
-            // await_transform wraps awaitables in a transform_awaiter whose
-            // standard await_suspend(coroutine_handle) calls this custom
-            // 2-argument overload, passing the io_env from the coroutine's
-            // context. For synchronous test awaitables like this one, the
-            // coroutine never suspends, so this is not invoked. The signature
-            // exists to allow the same awaitable type to work with both
-            // synchronous (test) and asynchronous (real I/O) code.
-            void await_suspend(
+            // The operation completes synchronously, but await_suspend is
+            // the only place io_env is delivered (the promise's
+            // transform_awaiter forwards it here). Returning false means
+            // the coroutine does not actually suspend; it resumes
+            // immediately, having observed the stop token. See io_env,
+            // IoAwaitable.
+            bool
+            await_suspend(
                 std::coroutine_handle<>,
-                io_env const*) const noexcept
+                io_env const* env) noexcept
             {
+                canceled_ = env->stop_token.stop_requested();
+                return false;
             }
 
             io_result<std::span<const_buffer>>
             await_resume()
             {
+                if(canceled_)
+                    return {error::canceled, {}};
+
                 auto ec = self_->f_.maybe_fail();
                 if(ec)
                     return {ec, {}};

--- a/include/boost/capy/test/read_source.hpp
+++ b/include/boost/capy/test/read_source.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -123,6 +124,12 @@ public:
 
         @return An awaitable that await-returns `(error_code,std::size_t)`.
 
+        @par Cancellation
+        If the environment's stop token has been requested, the read
+        completes immediately with `error::canceled` and transfers no
+        data. An empty buffer sequence is a no-op that completes
+        successfully regardless of the stop token.
+
         @see fuse
     */
     template<MutableBufferSequence MB>
@@ -133,13 +140,23 @@ public:
         {
             read_source* self_;
             MB buffers_;
+            bool canceled_ = false;
 
-            bool await_ready() const noexcept { return true; }
+            bool await_ready() const noexcept { return false; }
 
-            void await_suspend(
+            // The operation completes synchronously, but await_suspend is
+            // the only place io_env is delivered (the promise's
+            // transform_awaiter forwards it here). Returning false means
+            // the coroutine does not actually suspend; it resumes
+            // immediately, having observed the stop token. See io_env,
+            // IoAwaitable.
+            bool
+            await_suspend(
                 std::coroutine_handle<>,
-                io_env const*) const noexcept
+                io_env const* env) noexcept
             {
+                canceled_ = env->stop_token.stop_requested();
+                return false;
             }
 
             io_result<std::size_t>
@@ -147,6 +164,9 @@ public:
             {
                 if(buffer_empty(buffers_))
                     return {{}, 0};
+
+                if(canceled_)
+                    return {error::canceled, 0};
 
                 auto ec = self_->f_.maybe_fail();
                 if(ec)
@@ -183,6 +203,12 @@ public:
 
         @return An awaitable that await-returns `(error_code,std::size_t)`.
 
+        @par Cancellation
+        If the environment's stop token has been requested, the read
+        completes immediately with `error::canceled` and transfers no
+        data. An empty buffer sequence is a no-op that completes
+        successfully regardless of the stop token.
+
         @see fuse
     */
     template<MutableBufferSequence MB>
@@ -193,13 +219,19 @@ public:
         {
             read_source* self_;
             MB buffers_;
+            bool canceled_ = false;
 
-            bool await_ready() const noexcept { return true; }
+            bool await_ready() const noexcept { return false; }
 
-            void await_suspend(
+            // Reads the stop token without suspending; see the comment
+            // on read_some() for details.
+            bool
+            await_suspend(
                 std::coroutine_handle<>,
-                io_env const*) const noexcept
+                io_env const* env) noexcept
             {
+                canceled_ = env->stop_token.stop_requested();
+                return false;
             }
 
             io_result<std::size_t>
@@ -207,6 +239,9 @@ public:
             {
                 if(buffer_empty(buffers_))
                     return {{}, 0};
+
+                if(canceled_)
+                    return {error::canceled, 0};
 
                 auto ec = self_->f_.maybe_fail();
                 if(ec)

--- a/include/boost/capy/test/read_stream.hpp
+++ b/include/boost/capy/test/read_stream.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -125,6 +126,13 @@ public:
         @par Exception Safety
         No-throw guarantee.
 
+        @par Cancellation
+        If the environment's stop token has been requested, the read
+        completes immediately with `error::canceled` and transfers no
+        data. This lets code under test exercise its cancellation paths.
+        An empty buffer sequence is a no-op that completes successfully
+        regardless of the stop token.
+
         @param buffers The mutable buffer sequence to receive data.
 
         @return An awaitable that await-returns `(error_code,std::size_t)`.
@@ -139,33 +147,35 @@ public:
         {
             read_stream* self_;
             MB buffers_;
+            bool canceled_ = false;
 
-            bool await_ready() const noexcept { return true; }
+            bool await_ready() const noexcept { return false; }
 
-            // This method is required to satisfy Capy's IoAwaitable concept,
-            // but is never called because await_ready() returns true.
-            //
-            // Capy uses a two-layer awaitable system: the promise's
-            // await_transform wraps awaitables in a transform_awaiter whose
-            // standard await_suspend(coroutine_handle) calls this custom
-            // 2-argument overload, passing the io_env from the coroutine's
-            // context. For synchronous test awaitables like this one, the
-            // coroutine never suspends, so this is not invoked. The signature
-            // exists to allow the same awaitable type to work with both
-            // synchronous (test) and asynchronous (real I/O) code.
-            void await_suspend(
+            // The operation completes synchronously, but await_suspend
+            // is the only place io_env is delivered (the promise's
+            // transform_awaiter forwards it here). Returning false means
+            // the coroutine does not actually suspend — it resumes
+            // immediately — so the read still completes synchronously
+            // while having observed the stop token. See io_env, IoAwaitable.
+            bool
+            await_suspend(
                 std::coroutine_handle<>,
-                io_env const*) const noexcept
+                io_env const* env) noexcept
             {
+                canceled_ = env->stop_token.stop_requested();
+                return false;
             }
 
             io_result<std::size_t>
             await_resume()
             {
                 // Empty buffer is a no-op regardless of
-                // stream state or fuse.
+                // stream state, stop token, or fuse.
                 if(buffer_empty(buffers_))
                     return {{}, 0};
+
+                if(canceled_)
+                    return {error::canceled, 0};
 
                 auto ec = self_->f_.maybe_fail();
                 if(ec)

--- a/include/boost/capy/test/stream.hpp
+++ b/include/boost/capy/test/stream.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -24,7 +25,9 @@
 #include <boost/capy/test/fuse.hpp>
 #include <boost/capy/test/run_blocking.hpp>
 
+#include <atomic>
 #include <memory>
+#include <new>
 #include <stop_token>
 #include <string>
 #include <string_view>
@@ -89,6 +92,10 @@ class stream
         std::size_t max_read_size = std::size_t(-1);
         continuation pending_cont_;
         executor_ref pending_ex;
+        // Points at the suspended reader's claim flag (owned by the
+        // read awaitable). Lets a peer wake coordinate with a stop
+        // callback so the parked read is resumed exactly once.
+        std::atomic<bool>* pending_claimed = nullptr;
         bool eof = false;
     };
 
@@ -103,20 +110,31 @@ class stream
         {
         }
 
+        // Resume a suspended reader on this side, if any. Claims the
+        // reader's atomic so it is never double-resumed by a racing
+        // stop callback; the loser of the race skips the post.
+        static void wake(half& side)
+        {
+            if(! side.pending_cont_.h)
+                return;
+            if(! side.pending_claimed ||
+                ! side.pending_claimed->exchange(
+                    true, std::memory_order_acq_rel))
+            {
+                side.pending_ex.post(side.pending_cont_);
+            }
+            side.pending_cont_.h = {};
+            side.pending_ex = {};
+            side.pending_claimed = nullptr;
+        }
+
         // Set closed and resume any suspended readers
         // with eof on both sides.
         void close()
         {
             closed = true;
             for(auto& side : sides)
-            {
-                if(side.pending_cont_.h)
-                {
-                    side.pending_ex.post(side.pending_cont_);
-                    side.pending_cont_.h = {};
-                    side.pending_ex = {};
-                }
-            }
+                wake(side);
         }
     };
 
@@ -166,12 +184,7 @@ public:
         int peer = 1 - index_;
         auto& side = state_->sides[peer];
         side.eof = true;
-        if(side.pending_cont_.h)
-        {
-            side.pending_ex.post(side.pending_cont_);
-            side.pending_cont_.h = {};
-            side.pending_ex = {};
-        }
+        state::wake(side);
     }
 
     /** Set the maximum bytes returned per read.
@@ -204,16 +217,105 @@ public:
 
         @return An awaitable that await-returns `(error_code,std::size_t)`.
 
+        @par Cancellation
+        Cancellation applies only to a read that would otherwise suspend:
+        if no data is available and the environment's stop token is
+        requested (before or during the wait), the read resumes with
+        `error::canceled`. A read that can complete immediately from
+        buffered data is unaffected by the stop token.
+
         @see fuse, close
     */
     template<MutableBufferSequence MB>
     auto
     read_some(MB buffers)
     {
+        // The read suspends when no data is available, parking its
+        // continuation on the side until the peer writes/closes. To
+        // support cancellation it follows the same pattern as
+        // delay_awaitable: a stop callback claims the resume (racing
+        // the peer wake via an atomic) and posts the continuation
+        // through the executor. Because it owns a std::atomic and a
+        // std::stop_callback, the awaitable needs explicit move and
+        // destruction (the task promise moves it into its
+        // transform_awaiter before awaiting).
         struct awaitable
         {
             stream* self_;
             MB buffers_;
+
+            // Declared before stop_cb_buf_: the stop callback reads
+            // these, so they must outlive a blocking stop_cb_ destructor.
+            continuation cont_;
+            executor_ref ex_;
+            half* side_ = nullptr;
+            std::atomic<bool> claimed_{false};
+            bool canceled_ = false;
+            bool stop_cb_active_ = false;
+
+            struct cancel_fn
+            {
+                awaitable* self_;
+
+                void operator()() const noexcept
+                {
+                    if(! self_->claimed_.exchange(
+                        true, std::memory_order_acq_rel))
+                    {
+                        self_->canceled_ = true;
+                        self_->ex_.post(self_->cont_);
+                    }
+                }
+            };
+
+            using stop_cb_t = std::stop_callback<cancel_fn>;
+
+            // Declared last: its destructor may block while the callback
+            // accesses the members above. A union gives correct alignment
+            // for stop_cb_t without an alignas specifier, which avoids
+            // MSVC's C4324 padding warning on this function-local class
+            // (the member-level pragma used by delay_awaitable does not
+            // suppress it here). Lifetime is managed manually: placement
+            // new in await_suspend, explicit destruction once done.
+            union { stop_cb_t stop_cb_; };
+
+            awaitable(stream* self, MB buffers) noexcept
+                : self_(self)
+                , buffers_(buffers)
+            {
+            }
+
+            /// @pre Not yet awaited (no active stop callback).
+            awaitable(awaitable&& o) noexcept
+                : self_(o.self_)
+                , buffers_(o.buffers_)
+                , cont_(o.cont_)
+                , ex_(o.ex_)
+                , side_(o.side_)
+                , claimed_(o.claimed_.load(std::memory_order_relaxed))
+                , canceled_(o.canceled_)
+                , stop_cb_active_(std::exchange(o.stop_cb_active_, false))
+            {
+            }
+
+            ~awaitable()
+            {
+                if(stop_cb_active_)
+                    stop_cb_.~stop_cb_t();
+                // Unlink from the side if still parked (e.g. the
+                // coroutine was destroyed while suspended), so a later
+                // peer wake does not dereference a freed claim flag.
+                if(side_ && side_->pending_claimed == &claimed_)
+                {
+                    side_->pending_cont_.h = {};
+                    side_->pending_ex = {};
+                    side_->pending_claimed = nullptr;
+                }
+            }
+
+            awaitable(awaitable const&) = delete;
+            awaitable& operator=(awaitable const&) = delete;
+            awaitable& operator=(awaitable&&) = delete;
 
             bool await_ready() const noexcept
             {
@@ -229,18 +331,53 @@ public:
                 std::coroutine_handle<> h,
                 io_env const* env) noexcept
             {
+                // Park the continuation, then register the stop callback.
+                // If stop is already requested, the callback fires inline
+                // during construction: it claims the resume and posts the
+                // continuation through the executor (never a symmetric
+                // self-transfer, which would leak this frame under
+                // run_async). The parked read is then resumed with
+                // error::canceled by the run loop.
                 auto& side = self_->state_->sides[
                     self_->index_];
+                cont_.h = h;
+                ex_ = env->executor;
+                side_ = &side;
                 side.pending_cont_.h = h;
                 side.pending_ex = env->executor;
+                side.pending_claimed = &claimed_;
+
+                ::new(static_cast<void*>(&stop_cb_)) stop_cb_t(
+                    env->stop_token, cancel_fn{this});
+                stop_cb_active_ = true;
+
                 return std::noop_coroutine();
             }
 
             io_result<std::size_t>
             await_resume()
             {
+                if(stop_cb_active_)
+                {
+                    stop_cb_.~stop_cb_t();
+                    stop_cb_active_ = false;
+                }
+
                 if(buffer_empty(buffers_))
                     return {{}, 0};
+
+                if(canceled_)
+                {
+                    // The stop callback posted us but left the side
+                    // untouched; unlink if a peer wake has not already.
+                    if(side_ && side_->pending_claimed == &claimed_)
+                    {
+                        side_->pending_cont_.h = {};
+                        side_->pending_ex = {};
+                        side_->pending_claimed = nullptr;
+                    }
+                    return {error::canceled, 0};
+                }
 
                 auto* st = self_->state_.get();
                 auto& side = st->sides[
@@ -287,6 +424,12 @@ public:
 
         @return An awaitable that await-returns `(error_code,std::size_t)`.
 
+        @par Cancellation
+        If the environment's stop token has been requested, the write
+        completes immediately with `error::canceled` and transfers no
+        data. An empty buffer sequence is a no-op that completes
+        successfully regardless of the stop token.
+
         @see fuse, close
     */
     template<ConstBufferSequence CB>
@@ -297,13 +440,20 @@ public:
         {
             stream* self_;
             CB buffers_;
+            bool canceled_ = false;
 
-            bool await_ready() const noexcept { return true; }
+            bool await_ready() const noexcept { return false; }
 
-            void await_suspend(
+            // The write completes synchronously; await_suspend is only
+            // used to observe the environment's stop token. Returning
+            // false means the coroutine does not actually suspend.
+            bool
+            await_suspend(
                 std::coroutine_handle<>,
-                io_env const*) const noexcept
+                io_env const* env) noexcept
             {
+                canceled_ = env->stop_token.stop_requested();
+                return false;
             }
 
             io_result<std::size_t>
@@ -312,6 +462,9 @@ public:
                 std::size_t n = buffer_size(buffers_);
                 if(n == 0)
                     return {{}, 0};
+
+                if(canceled_)
+                    return {error::canceled, 0};
 
                 auto* st = self_->state_.get();
 
@@ -333,12 +486,7 @@ public:
                     side.buf.data() + old_size, n),
                     buffers_, n);
 
-                if(side.pending_cont_.h)
-                {
-                    side.pending_ex.post(side.pending_cont_);
-                    side.pending_cont_.h = {};
-                    side.pending_ex = {};
-                }
+                state::wake(side);
 
                 return {{}, n};
             }
@@ -363,12 +511,7 @@ public:
         int peer = 1 - index_;
         auto& side = state_->sides[peer];
         side.buf.append(sv);
-        if(side.pending_cont_.h)
-        {
-            side.pending_ex.post(side.pending_cont_);
-            side.pending_cont_.h = {};
-            side.pending_ex = {};
-        }
+        state::wake(side);
     }
 
     /** Read from this stream and verify the content.

--- a/include/boost/capy/test/write_sink.hpp
+++ b/include/boost/capy/test/write_sink.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -21,7 +22,6 @@
 #include <boost/capy/test/fuse.hpp>
 
 #include <algorithm>
-#include <stop_token>
 #include <string>
 #include <string_view>
 
@@ -157,6 +157,12 @@ public:
 
         @return An awaitable that await-returns `(error_code,std::size_t)`.
 
+        @par Cancellation
+        If the environment's stop token has been requested, the write
+        completes immediately with `error::canceled` and transfers no
+        data. An empty buffer sequence is a no-op that completes
+        successfully regardless of the stop token.
+
         @see fuse
     */
     template<ConstBufferSequence CB>
@@ -167,13 +173,23 @@ public:
         {
             write_sink* self_;
             CB buffers_;
+            bool canceled_ = false;
 
-            bool await_ready() const noexcept { return true; }
+            bool await_ready() const noexcept { return false; }
 
-            void await_suspend(
+            // The operation completes synchronously, but await_suspend is
+            // the only place io_env is delivered (the promise's
+            // transform_awaiter forwards it here). Returning false means
+            // the coroutine does not actually suspend; it resumes
+            // immediately, having observed the stop token. See io_env,
+            // IoAwaitable.
+            bool
+            await_suspend(
                 std::coroutine_handle<>,
-                io_env const*) const noexcept
+                io_env const* env) noexcept
             {
+                canceled_ = env->stop_token.stop_requested();
+                return false;
             }
 
             io_result<std::size_t>
@@ -181,6 +197,9 @@ public:
             {
                 if(buffer_empty(buffers_))
                     return {{}, 0};
+
+                if(canceled_)
+                    return {error::canceled, 0};
 
                 auto ec = self_->f_.maybe_fail();
                 if(ec)
@@ -218,6 +237,11 @@ public:
 
         @return An awaitable that await-returns `(error_code,std::size_t)`.
 
+        @par Cancellation
+        If the environment's stop token has been requested, the write
+        completes immediately with `error::canceled` and transfers no
+        data.
+
         @see fuse
     */
     template<ConstBufferSequence CB>
@@ -228,18 +252,27 @@ public:
         {
             write_sink* self_;
             CB buffers_;
+            bool canceled_ = false;
 
-            bool await_ready() const noexcept { return true; }
+            bool await_ready() const noexcept { return false; }
 
-            void await_suspend(
+            // Reads the stop token without suspending; see the comment
+            // on write_some() for details.
+            bool
+            await_suspend(
                 std::coroutine_handle<>,
-                io_env const*) const noexcept
+                io_env const* env) noexcept
             {
+                canceled_ = env->stop_token.stop_requested();
+                return false;
             }
 
             io_result<std::size_t>
             await_resume()
             {
+                if(canceled_)
+                    return {error::canceled, 0};
+
                 auto ec = self_->f_.maybe_fail();
                 if(ec)
                     return {ec, 0};
@@ -279,6 +312,11 @@ public:
         @par Exception Safety
         No-throw guarantee.
 
+        @par Cancellation
+        If the environment's stop token has been requested, the operation
+        completes immediately with `error::canceled`, transfers no data,
+        and does not signal end-of-stream.
+
         @param buffers The const buffer sequence containing data to write.
 
         @return An awaitable that await-returns `(error_code,std::size_t)`.
@@ -293,18 +331,27 @@ public:
         {
             write_sink* self_;
             CB buffers_;
+            bool canceled_ = false;
 
-            bool await_ready() const noexcept { return true; }
+            bool await_ready() const noexcept { return false; }
 
-            void await_suspend(
+            // Reads the stop token without suspending; see the comment
+            // on write_some() for details.
+            bool
+            await_suspend(
                 std::coroutine_handle<>,
-                io_env const*) const noexcept
+                io_env const* env) noexcept
             {
+                canceled_ = env->stop_token.stop_requested();
+                return false;
             }
 
             io_result<std::size_t>
             await_resume()
             {
+                if(canceled_)
+                    return {error::canceled, 0};
+
                 auto ec = self_->f_.maybe_fail();
                 if(ec)
                     return {ec, 0};
@@ -343,6 +390,11 @@ public:
         @par Exception Safety
         No-throw guarantee.
 
+        @par Cancellation
+        If the environment's stop token has been requested, the operation
+        completes immediately with `error::canceled` and does not signal
+        end-of-stream.
+
         @return An awaitable that await-returns `(error_code)`.
 
         @see fuse
@@ -353,21 +405,27 @@ public:
         struct awaitable
         {
             write_sink* self_;
+            bool canceled_ = false;
 
-            bool await_ready() const noexcept { return true; }
+            bool await_ready() const noexcept { return false; }
 
-            // This method is required to satisfy Capy's IoAwaitable concept,
-            // but is never called because await_ready() returns true.
-            // See the comment on write(CB buffers) for a detailed explanation.
-            void await_suspend(
+            // Reads the stop token without suspending; see the comment
+            // on write_some() for details.
+            bool
+            await_suspend(
                 std::coroutine_handle<>,
-                io_env const*) const noexcept
+                io_env const* env) noexcept
             {
+                canceled_ = env->stop_token.stop_requested();
+                return false;
             }
 
             io_result<>
             await_resume()
             {
+                if(canceled_)
+                    return {error::canceled};
+
                 auto ec = self_->f_.maybe_fail();
                 if(ec)
                     return {ec};

--- a/include/boost/capy/test/write_stream.hpp
+++ b/include/boost/capy/test/write_stream.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -142,6 +143,12 @@ public:
         @par Exception Safety
         No-throw guarantee.
 
+        @par Cancellation
+        If the environment's stop token has been requested, the write
+        completes immediately with `error::canceled` and transfers no
+        data. An empty buffer sequence is a no-op that completes
+        successfully regardless of the stop token.
+
         @param buffers The const buffer sequence containing data to write.
 
         @return An awaitable that await-returns `(error_code,std::size_t)`.
@@ -156,24 +163,23 @@ public:
         {
             write_stream* self_;
             CB buffers_;
+            bool canceled_ = false;
 
-            bool await_ready() const noexcept { return true; }
+            bool await_ready() const noexcept { return false; }
 
-            // This method is required to satisfy Capy's IoAwaitable concept,
-            // but is never called because await_ready() returns true.
-            //
-            // Capy uses a two-layer awaitable system: the promise's
-            // await_transform wraps awaitables in a transform_awaiter whose
-            // standard await_suspend(coroutine_handle) calls this custom
-            // 2-argument overload, passing the io_env from the coroutine's
-            // context. For synchronous test awaitables like this one, the
-            // coroutine never suspends, so this is not invoked. The signature
-            // exists to allow the same awaitable type to work with both
-            // synchronous (test) and asynchronous (real I/O) code.
-            void await_suspend(
+            // The operation completes synchronously, but await_suspend is
+            // the only place io_env is delivered (the promise's
+            // transform_awaiter forwards it here). Returning false means
+            // the coroutine does not actually suspend; it resumes
+            // immediately, having observed the stop token. See io_env,
+            // IoAwaitable.
+            bool
+            await_suspend(
                 std::coroutine_handle<>,
-                io_env const*) const noexcept
+                io_env const* env) noexcept
             {
+                canceled_ = env->stop_token.stop_requested();
+                return false;
             }
 
             io_result<std::size_t>
@@ -181,6 +187,9 @@ public:
             {
                 if(buffer_empty(buffers_))
                     return {{}, 0};
+
+                if(canceled_)
+                    return {error::canceled, 0};
 
                 auto ec = self_->f_.maybe_fail();
                 if(ec)

--- a/test/unit/io/any_read_source.cpp
+++ b/test/unit/io/any_read_source.cpp
@@ -25,7 +25,6 @@
 
 #include <array>
 #include <coroutine>
-#include <stop_token>
 #include <string_view>
 
 namespace boost {

--- a/test/unit/io/any_write_sink.cpp
+++ b/test/unit/io/any_write_sink.cpp
@@ -24,7 +24,6 @@
 
 #include <array>
 #include <coroutine>
-#include <stop_token>
 #include <string_view>
 #include <vector>
 

--- a/test/unit/io/any_write_stream.cpp
+++ b/test/unit/io/any_write_stream.cpp
@@ -25,7 +25,6 @@
 #include <array>
 #include <coroutine>
 #include <span>
-#include <stop_token>
 #include <string_view>
 #include <vector>
 

--- a/test/unit/test/buffer_sink.cpp
+++ b/test/unit/test/buffer_sink.cpp
@@ -12,12 +12,14 @@
 
 #include <boost/capy/buffers/make_buffer.hpp>
 #include <boost/capy/concept/buffer_sink.hpp>
+#include <boost/capy/cond.hpp>
 #include <boost/capy/task.hpp>
 
 #include "test/unit/test_helpers.hpp"
 
 #include <cstring>
 #include <span>
+#include <stop_token>
 #include <string_view>
 
 namespace boost {
@@ -281,6 +283,53 @@ public:
     }
 
     void
+    testCommitCanceled()
+    {
+        // commit awaited with an already-requested stop token returns
+        // error::canceled and commits nothing.
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                buffer_sink bs;
+                mutable_buffer arr[4];
+                auto bufs = bs.prepare(arr);
+                std::memcpy(bufs[0].data(), "hello", 5);
+
+                auto [ec] = co_await bs.commit(5);
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST_EQ(bs.size(), 0u);
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
+    testCommitEofCanceled()
+    {
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                buffer_sink bs;
+                mutable_buffer arr[4];
+                auto bufs = bs.prepare(arr);
+                std::memcpy(bufs[0].data(), "hello", 5);
+
+                auto [ec] = co_await bs.commit_eof(5);
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST_EQ(bs.size(), 0u);
+                BOOST_TEST(! bs.eof_called());
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
     run()
     {
         testConstruct();
@@ -294,6 +343,8 @@ public:
         testClear();
         testFuseErrorInjectionCommit();
         testFuseErrorInjectionCommitEof();
+        testCommitCanceled();
+        testCommitEofCanceled();
     }
 };
 

--- a/test/unit/test/buffer_source.cpp
+++ b/test/unit/test/buffer_source.cpp
@@ -19,6 +19,7 @@
 #include "test/unit/test_helpers.hpp"
 
 #include <span>
+#include <stop_token>
 #include <string_view>
 
 namespace boost {
@@ -296,6 +297,29 @@ public:
     }
 
     void
+    testPullCanceled()
+    {
+        // pull awaited with an already-requested stop token returns
+        // error::canceled and an empty buffer span.
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                buffer_source bs;
+                bs.provide("hello world");
+
+                const_buffer arr[4];
+                auto [ec, bufs] = co_await bs.pull(arr);
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST(bufs.empty());
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
     run()
     {
         testConstruct();
@@ -310,6 +334,7 @@ public:
         testMaxPullSizeMultiple();
         testFuseErrorInjection();
         testClearAndReuse();
+        testPullCanceled();
     }
 };
 

--- a/test/unit/test/read_source.cpp
+++ b/test/unit/test/read_source.cpp
@@ -18,6 +18,7 @@
 #include "test/unit/test_helpers.hpp"
 
 #include <array>
+#include <stop_token>
 #include <string_view>
 
 namespace boost {
@@ -497,6 +498,50 @@ public:
     }
 
     void
+    testReadCanceled()
+    {
+        // read awaited with an already-requested stop token returns
+        // error::canceled instead of data.
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                read_source rs;
+                rs.provide("hello world");
+
+                char buf[32] = {};
+                auto [ec, n] = co_await rs.read(make_buffer(buf));
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST_EQ(n, 0u);
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
+    testReadSomeCanceled()
+    {
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                read_source rs;
+                rs.provide("hello world");
+
+                char buf[32] = {};
+                auto [ec, n] = co_await rs.read_some(make_buffer(buf));
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST_EQ(n, 0u);
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
     run()
     {
         testConstruct();
@@ -523,6 +568,9 @@ public:
         testReadSomeMaxReadSize();
         testReadSomeBufferSequence();
         testReadSomeFuseErrorInjection();
+
+        testReadCanceled();
+        testReadSomeCanceled();
     }
 };
 

--- a/test/unit/test/read_stream.cpp
+++ b/test/unit/test/read_stream.cpp
@@ -19,6 +19,7 @@
 #include "test/unit/test_helpers.hpp"
 
 #include <array>
+#include <stop_token>
 #include <string_view>
 
 namespace boost {
@@ -347,6 +348,29 @@ public:
     }
 
     void
+    testReadSomeCanceled()
+    {
+        // A read_some awaited with a stop token that is already
+        // requested returns error::canceled instead of data.
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                read_stream rs;
+                rs.provide("hello world");
+
+                char buf[32] = {};
+                auto [ec, n] = co_await rs.read_some(make_buffer(buf));
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST_EQ(n, 0u);
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
     run()
     {
         testConstruct();
@@ -364,6 +388,7 @@ public:
         testClearAndReuse();
         testMaxReadSize();
         testMaxReadSizeMultiple();
+        testReadSomeCanceled();
     }
 };
 

--- a/test/unit/test/stream.cpp
+++ b/test/unit/test/stream.cpp
@@ -15,6 +15,11 @@
 #include <boost/capy/concept/stream.hpp>
 #include <boost/capy/concept/write_stream.hpp>
 #include <boost/capy/cond.hpp>
+#include <boost/capy/error.hpp>
+#include <boost/capy/ex/executor_ref.hpp>
+#include <boost/capy/ex/io_env.hpp>
+#include <boost/capy/ex/run_async.hpp>
+#include <boost/capy/ex/thread_pool.hpp>
 #include <boost/capy/io_task.hpp>
 #include <boost/capy/task.hpp>
 #include <boost/capy/test/run_blocking.hpp>
@@ -23,7 +28,11 @@
 #include "test/unit/test_helpers.hpp"
 
 #include <array>
+#include <latch>
+#include <queue>
+#include <stop_token>
 #include <string_view>
+#include <thread>
 
 namespace boost {
 namespace capy {
@@ -658,6 +667,205 @@ public:
         BOOST_TEST(write_success_count > 0);
     }
 
+    //--------------------------------------------
+    //
+    // Cancellation
+    //
+    //--------------------------------------------
+
+    void
+    testReadSomeCancellationWhileSuspended()
+    {
+        // A read that suspends waiting for the peer is resumed with
+        // error::canceled when the environment's stop token fires.
+        // Driven manually on a queuing executor for deterministic,
+        // non-blocking control (mirrors async_mutex's cancellation test).
+        auto [a, b] = make_stream_pair();
+        std::queue<std::coroutine_handle<>> q;
+        queuing_executor ex(q);
+        std::stop_source ss;
+
+        std::error_code reader_ec;
+        bool reader_done = false;
+
+        auto reader = [](stream& s,
+            std::error_code& out_ec, bool& done) -> task<>
+        {
+            char buf[32] = {};
+            auto [ec, n] = co_await s.read_some(make_buffer(buf));
+            out_ec = ec;
+            (void)n;
+            done = true;
+        }(b, reader_ec, reader_done);
+
+        auto h = reader.handle();
+        reader.release();
+        io_env env;
+        env.executor = executor_ref(ex);
+        env.stop_token = ss.get_token();
+        h.promise().set_environment(&env);
+
+        // No data available: the read suspends.
+        h.resume();
+        BOOST_TEST(! reader_done);
+
+        // Requesting stop posts the continuation through the executor.
+        ss.request_stop();
+        BOOST_TEST(! q.empty());
+
+        q.front().resume();
+        q.pop();
+
+        BOOST_TEST(reader_done);
+        BOOST_TEST(reader_ec == make_error_code(error::canceled));
+
+        h.destroy();
+    }
+
+    void
+    testReadSomeStopRequestedBeforeSuspend()
+    {
+        // A read that would block (no data) but whose stop token is
+        // already requested resolves to error::canceled without parking.
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                auto [a, b] = make_stream_pair();
+                // No data provided: the read would otherwise suspend.
+                char buf[32] = {};
+                auto [ec, n] = co_await b.read_some(make_buffer(buf));
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST_EQ(n, 0u);
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
+    testReadSomeDestroyWhileSuspended()
+    {
+        // Destroying a coroutine while its read is parked must tear down
+        // the stop callback and unlink the pending slot, so a later peer
+        // operation does not touch a freed claim flag.
+        auto [a, b] = make_stream_pair();
+        std::queue<std::coroutine_handle<>> q;
+        queuing_executor ex(q);
+        std::stop_source ss;
+
+        auto reader = [](stream& s) -> task<>
+        {
+            char buf[32] = {};
+            auto [ec, n] = co_await s.read_some(make_buffer(buf));
+            (void)ec;
+            (void)n;
+        }(b);
+
+        auto h = reader.handle();
+        reader.release();
+        io_env env;
+        env.executor = executor_ref(ex);
+        env.stop_token = ss.get_token();
+        h.promise().set_environment(&env);
+
+        h.resume();
+        BOOST_TEST(q.empty());
+
+        // Destroy the suspended reader; the awaitable destructor runs.
+        h.destroy();
+
+        // The pending slot is unlinked: a subsequent peer write finds no
+        // parked reader and does not dereference the freed claim flag.
+        a.provide("late");
+        BOOST_TEST(true);
+    }
+
+    void
+    testReadSomeCancellationCrossThread()
+    {
+        // A read suspended on one thread is cancelled by a stop request
+        // issued from another, exercising the stop-callback path under
+        // real concurrency (validated by TSan). Only the stop callback
+        // crosses threads; the stream itself is touched solely by the
+        // pool thread, honoring its single-threaded contract.
+        thread_pool pool(1);
+        std::latch done(1);
+        std::latch suspended(1);
+        std::stop_source ss;
+
+        auto [a, b] = make_stream_pair();
+        std::error_code reader_ec;
+
+        auto reader = [&]() -> task<>
+        {
+            char buf[32] = {};
+            suspended.count_down();
+            auto [ec, n] = co_await b.read_some(make_buffer(buf));
+            reader_ec = ec;
+            (void)n;
+        };
+
+        run_async(pool.get_executor(), ss.get_token(),
+            [&]() { done.count_down(); },
+            [&](std::exception_ptr) { done.count_down(); })(reader());
+
+        suspended.wait();
+        // Give await_suspend time to register the stop callback.
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        ss.request_stop();
+
+        done.wait();
+        BOOST_TEST(reader_ec == make_error_code(error::canceled));
+    }
+
+    void
+    testReadSomeStopWithDataAvailable()
+    {
+        // When data is already buffered, a read completes normally even
+        // if the stop token is set: cancellation only applies to a read
+        // that would otherwise block.
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                auto [a, b] = make_stream_pair();
+                a.provide("hello");
+
+                char buf[32] = {};
+                auto [ec, n] = co_await b.read_some(make_buffer(buf));
+                ran = true;
+                BOOST_TEST(! ec);
+                BOOST_TEST_EQ(n, 5u);
+                BOOST_TEST_EQ(std::string_view(buf, n), "hello");
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
+    testWriteSomeCancellation()
+    {
+        // write_some never blocks, so it honors the stop token up front:
+        // an already-requested stop yields error::canceled.
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                auto [a, b] = make_stream_pair();
+                auto [ec, n] = co_await a.write_some(
+                    const_buffer("hi", 2));
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST_EQ(n, 0u);
+            }());
+        BOOST_TEST(ran);
+    }
+
     void
     run()
     {
@@ -689,6 +897,14 @@ public:
         testLoopback();
         testFuseReadErrorInjection();
         testFuseWriteErrorInjection();
+
+        // Cancellation
+        testReadSomeCancellationWhileSuspended();
+        testReadSomeStopRequestedBeforeSuspend();
+        testReadSomeDestroyWhileSuspended();
+        testReadSomeCancellationCrossThread();
+        testReadSomeStopWithDataAvailable();
+        testWriteSomeCancellation();
     }
 };
 

--- a/test/unit/test/write_sink.cpp
+++ b/test/unit/test/write_sink.cpp
@@ -12,11 +12,13 @@
 
 #include <boost/capy/buffers/make_buffer.hpp>
 #include <boost/capy/concept/write_sink.hpp>
+#include <boost/capy/cond.hpp>
 #include <boost/capy/task.hpp>
 
 #include "test/unit/test_helpers.hpp"
 
 #include <array>
+#include <stop_token>
 #include <string_view>
 
 namespace boost {
@@ -521,6 +523,87 @@ public:
     }
 
     void
+    testWriteCanceled()
+    {
+        // Each write op awaited with an already-requested stop token
+        // returns error::canceled and has no effect.
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                write_sink ws;
+                auto [ec, n] = co_await ws.write(
+                    const_buffer("hello", 5));
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST_EQ(n, 0u);
+                BOOST_TEST_EQ(ws.size(), 0u);
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
+    testWriteSomeCanceled()
+    {
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                write_sink ws;
+                auto [ec, n] = co_await ws.write_some(
+                    const_buffer("hello", 5));
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST_EQ(n, 0u);
+                BOOST_TEST_EQ(ws.size(), 0u);
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
+    testWriteEofWithBuffersCanceled()
+    {
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                write_sink ws;
+                auto [ec, n] = co_await ws.write_eof(
+                    const_buffer("hello", 5));
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST_EQ(n, 0u);
+                BOOST_TEST_EQ(ws.size(), 0u);
+                BOOST_TEST(! ws.eof_called());
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
+    testWriteEofCanceled()
+    {
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                write_sink ws;
+                auto [ec] = co_await ws.write_eof();
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST(! ws.eof_called());
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
     run()
     {
         testConstruct();
@@ -549,6 +632,11 @@ public:
         testWriteSomeBufferSequence();
         testWriteSomeMaxWriteSize();
         testWriteSomeFuseErrorInjection();
+
+        testWriteCanceled();
+        testWriteSomeCanceled();
+        testWriteEofWithBuffersCanceled();
+        testWriteEofCanceled();
     }
 };
 

--- a/test/unit/test/write_stream.cpp
+++ b/test/unit/test/write_stream.cpp
@@ -13,11 +13,13 @@
 #include <boost/capy/buffers/make_buffer.hpp>
 #include <boost/capy/concept/write_sink.hpp>
 #include <boost/capy/concept/write_stream.hpp>
+#include <boost/capy/cond.hpp>
 #include <boost/capy/task.hpp>
 
 #include "test/unit/test_helpers.hpp"
 
 #include <array>
+#include <stop_token>
 #include <string_view>
 
 namespace boost {
@@ -321,6 +323,28 @@ public:
     }
 
     void
+    testWriteSomeCanceled()
+    {
+        // write_some awaited with an already-requested stop token
+        // returns error::canceled and writes nothing.
+        std::stop_source ss;
+        ss.request_stop();
+        bool ran = false;
+        run_blocking(ss.get_token())(
+            [&]() -> task<>
+            {
+                write_stream ws;
+                auto [ec, n] = co_await ws.write_some(
+                    const_buffer("hello", 5));
+                ran = true;
+                BOOST_TEST(ec == cond::canceled);
+                BOOST_TEST_EQ(n, 0u);
+                BOOST_TEST_EQ(ws.size(), 0u);
+            }());
+        BOOST_TEST(ran);
+    }
+
+    void
     run()
     {
         testConstruct();
@@ -337,6 +361,7 @@ public:
         testExpectExcessData();
         testMaxWriteSize();
         testMaxWriteSizeMultiple();
+        testWriteSomeCanceled();
     }
 };
 


### PR DESCRIPTION
All capy::test mock awaitables now resolve to error::canceled when the environment's stop token is requested, so code under test can exercise its cancellation paths against the mocks. The synchronous mocks check the token up front; stream::read_some wakes a blocked read via a stop callback while preserving its synchronous fast path when data is already buffered.

io_env reaches an awaitable only through await_suspend, so the synchronous mocks must suspend once to observe it. They return false from await_suspend (conditional no-suspend) rather than self-transferring via the returned handle: the return-h form leaks the awaiting coroutine frame under run_async.

Also removes now-unused <stop_token> includes from the any_* tests.

Closes #317