### PR TITLE
test(buffers): zero-initialize the array in buffer_slice testConstInput

### DIFF
--- a/test/unit/buffers/buffer_slice.cpp
+++ b/test/unit/buffers/buffer_slice.cpp
@@ -62,7 +62,7 @@ struct buffer_slice_test
     void
     testConstInput()
     {
-        char a[10];
+        char a[10] = {};
         std::array<const_buffer, 1> cb = { const_buffer(a, sizeof(a)) };
         auto s = buffer_slice(cb);
         static_assert(ConstBufferSequence<decltype(s)>,


### PR DESCRIPTION
The uninitialized array is passed by pointer to const_buffer, which trips -Werror=maybe-uninitialized in the coverage build. The bytes are never read — the test only checks concept modeling — so zero-init is inert.