### PR TITLE
Remove unconditional IPO disable on boost_capy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,13 +126,7 @@ add_library(boost_capy include/boost/capy.hpp build/Jamfile ${BOOST_CAPY_HEADERS
 add_library(Boost::capy ALIAS boost_capy)
 boost_capy_setup_properties(boost_capy)
 
-# Disable IPO/LTCG - causes LNK2016 errors with MSVC
-set_target_properties(boost_capy PROPERTIES
-    EXPORT_NAME capy
-    INTERPROCEDURAL_OPTIMIZATION OFF
-    INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF
-    INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO OFF
-    INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL OFF)
+set_target_properties(boost_capy PROPERTIES EXPORT_NAME capy)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
The block forced INTERPROCEDURAL_OPTIMIZATION off on every platform to work around an MSVC LNK2016, but CMake never enables IPO by default, so it only fired when a consumer opted into LTO -- and then it opted capy out on GCC/Clang too, where the linker bug does not exist. Remove it and let CI show whether current MSVC still fails with IPO enabled.

See #361.