### PR TITLE
fix(run_async): keep allocator arguments out of handler deduction

### DIFF
--- a/include/boost/capy/ex/run_async.hpp
+++ b/include/boost/capy/ex/run_async.hpp
@@ -34,6 +34,19 @@ namespace boost {
 namespace capy {
 namespace detail {
 
+/** Match types usable as `run_async` completion handlers.
+
+    Excludes the types meaningful to the other `run_async` parameters,
+    so a stop token, memory resource pointer, or allocator argument
+    selects its dedicated overload by conversion instead of deducing
+    as an exact-match handler.
+*/
+template<class H>
+concept RunAsyncHandler =
+    !std::is_convertible_v<H, std::pmr::memory_resource*> &&
+    !std::is_convertible_v<H, std::stop_token> &&
+    !Allocator<H>;
+
 /// Function pointer type for type-erased frame deallocation.
 using dealloc_fn = void(*)(void*, std::size_t);
 
@@ -517,6 +530,7 @@ run_async(Ex ex)
     @see executor
 */
 template<Executor Ex, class H1>
+    requires detail::RunAsyncHandler<H1>
 [[nodiscard]] auto
 run_async(Ex ex, H1 h1)
 {
@@ -560,6 +574,7 @@ run_async(Ex ex, H1 h1)
     @see executor
 */
 template<Executor Ex, class H1, class H2>
+    requires (detail::RunAsyncHandler<H1> && detail::RunAsyncHandler<H2>)
 [[nodiscard]] auto
 run_async(Ex ex, H1 h1, H2 h2)
 {
@@ -626,6 +641,7 @@ run_async(Ex ex, std::stop_token st)
     @see executor
 */
 template<Executor Ex, class H1>
+    requires detail::RunAsyncHandler<H1>
 [[nodiscard]] auto
 run_async(Ex ex, std::stop_token st, H1 h1)
 {
@@ -653,6 +669,7 @@ run_async(Ex ex, std::stop_token st, H1 h1)
     @see executor
 */
 template<Executor Ex, class H1, class H2>
+    requires (detail::RunAsyncHandler<H1> && detail::RunAsyncHandler<H2>)
 [[nodiscard]] auto
 run_async(Ex ex, std::stop_token st, H1 h1, H2 h2)
 {

--- a/test/unit/ex/run_async.cpp
+++ b/test/unit/ex/run_async.cpp
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdio>
+#include <memory_resource>
 #include <memory>
 #include <queue>
 #include <stdexcept>
@@ -507,6 +508,33 @@ struct run_async_test
         BOOST_TEST(result);
     }
 
+    static task<void>
+    set_flag(bool& flag)
+    {
+        flag = true;
+        co_return;
+    }
+
+    void
+    testDerivedResourcePointer()
+    {
+        int dispatch_count = 0;
+        sync_executor d(dispatch_count);
+        std::pmr::monotonic_buffer_resource arena;
+        bool ran = false;
+
+        run_async(d, &arena)(set_flag(ran));
+        BOOST_TEST(ran);
+
+        ran = false;
+        run_async(d, std::stop_token{}, &arena)(set_flag(ran));
+        BOOST_TEST(ran);
+
+        ran = false;
+        run_async(d, &arena, [&] { ran = true; })(returns_void());
+        BOOST_TEST(ran);
+    }
+
     //----------------------------------------------------------
     // Sync Dispatcher
     //----------------------------------------------------------
@@ -775,6 +803,7 @@ struct run_async_test
 
         // Allocator Propagation
         testAllocatorPropagation();
+        testDerivedResourcePointer();
 
         // Sync Dispatcher
         testSyncDispatcherBasic();


### PR DESCRIPTION
A pointer to a derived memory resource deduced as an exact-match completion handler, beating the memory_resource* overloads that need a derived-to-base conversion, then failing to instantiate when the pointer was invoked. The same hijack applied to the second handler position and, once constrained naively, made allocator values ambiguous against the value-allocator overloads.

Constrain every deduced handler position with a RunAsyncHandler concept that excludes the types meaningful to the other parameters: memory resource pointers, stop tokens, and allocators.