### PR TITLE
fix(any_write_sink): accept mutable buffer sequences in write

### DIFF
--- a/include/boost/capy/io/any_write_sink.hpp
+++ b/include/boost/capy/io/any_write_sink.hpp
@@ -854,7 +854,7 @@ template<ConstBufferSequence CB>
 io_task<std::size_t>
 any_write_sink::write(CB buffers)
 {
-    buffer_param<CB> bp(buffers);
+    const_buffer_param<CB> bp(buffers);
     std::size_t total = 0;
 
     for(;;)

--- a/test/unit/io/any_write_sink.cpp
+++ b/test/unit/io/any_write_sink.cpp
@@ -303,6 +303,27 @@ public:
     }
 
     void
+    testWriteMutableSequence()
+    {
+        test::fuse f;
+        auto r = f.armed([&](test::fuse&) -> task<> {
+            test::write_sink ws(f);
+
+            any_write_sink aws(&ws);
+
+            std::string body = "hello world";
+            auto [ec, n] = co_await aws.write(make_buffer(body));
+            if(ec)
+                co_return;
+
+            BOOST_TEST_EQ(n, 11u);
+            BOOST_TEST_EQ(ws.data(), "hello world");
+            BOOST_TEST(!ws.eof_called());
+        });
+        BOOST_TEST(r.success);
+    }
+
+    void
     testWriteMultiple()
     {
         test::fuse f;
@@ -775,6 +796,7 @@ public:
         testWriteSomeEmptyBuffer();
         testWriteEmptyBuffer();
         testWrite();
+        testWriteMutableSequence();
         testWriteMultiple();
         testWriteBufferSequence();
         testWriteSingleBuffer();


### PR DESCRIPTION
ConstBufferSequence admits mutable sequences, but write windowed them through buffer_param, whose span<mutable_buffer> cannot convert to the type-erased write_(span<const_buffer const>), so calls such as write(make_buffer(some_string)) failed to instantiate. Use const_buffer_param, as write_eof already does.