### PR TITLE
fix(thread_pool): notify under the mutex in post

### DIFF
--- a/src/ex/thread_pool.cpp
+++ b/src/ex/thread_pool.cpp
@@ -149,8 +149,10 @@ public:
         {
             std::lock_guard<std::mutex> lock(mutex_);
             push(&c);
+            // Under the lock so the pool cannot drain, join, and
+            // destroy the condition variable mid-signal.
+            work_cv_.notify_one();
         }
-        work_cv_.notify_one();
     }
 
     void

--- a/test/unit/ex/thread_pool.cpp
+++ b/test/unit/ex/thread_pool.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/capy/concept/execution_context.hpp>
 #include <boost/capy/concept/executor.hpp>
+#include <boost/capy/ex/run.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/ex/work_guard.hpp>
 
@@ -697,6 +698,36 @@ struct thread_pool_test
         BOOST_TEST_EQ(result.load(), 42);
     }
 
+    static task<void>
+    hop_and_count(
+        thread_pool::executor_type worker_ex, std::atomic<int>& count)
+    {
+        count += co_await boost::capy::run(worker_ex)(returns_int(1));
+    }
+
+    void
+    testForeignPostAfterJoin()
+    {
+        // The worker pool's thread posts the continuation back into a
+        // pool that joins and dies immediately after the work drains,
+        // exercising the window where the poster is still inside
+        // post() during destruction.
+        thread_pool worker(1);
+        auto worker_ex = worker.get_executor();
+        std::atomic<int> count{0};
+
+        for(int i = 0; i < 50; ++i)
+        {
+            thread_pool pool(1);
+            run_async(pool.get_executor())(
+                hop_and_count(worker_ex, count));
+            pool.join();
+        }
+
+        BOOST_TEST_EQ(count.load(), 50);
+        worker.join();
+    }
+
     void
     run()
     {
@@ -726,6 +757,7 @@ struct thread_pool_test
         testStopCallbackRepeated();
         testWorkGuardKeepsPoolAlive();
         testJoinWithRunAsync();
+        testForeignPostAfterJoin();
     }
 };
 


### PR DESCRIPTION
join() guarantees the work has drained, not that foreign posting threads have left post(). A cross-executor completion could enqueue its item, have it consumed, and see the pool join and destruct while the poster was still inside the condition variable signal (pthread_cond_signal racing pthread_cond_destroy, TSan-confirmed).

Notifying while holding the mutex orders the destroy after the poster's last touch of the condition variable: the consumer cannot pop until the poster releases the lock. Wait morphing keeps the held-lock notify cheap on Linux.

The regression test hops a task through a long-lived worker pool back into a short-lived pool that joins and dies immediately; under TSan the race reproduced on every run before the fix.