### PR TITLE
ci: build the clang-cl leg in post-C++20 mode as well

### DIFF
--- a/.github/compilers.json
+++ b/.github/compilers.json
@@ -115,7 +115,7 @@
   "clang-cl": [
     {
       "version": "*",
-      "cxxstd": "20",
+      "cxxstd": "20,latest",
       "latest_cxxstd": "20",
       "runs_on": "windows-2022",
       "cxx": "clang++-cl",


### PR DESCRIPTION
No Windows leg exercised anything newer than C++20; newest-standard coverage existed only on the POSIX legs.

Use cxxstd=latest rather than 23: the msvc toolset (whose flags clang-win inherits) has no /std: mapping for 23, so cxxstd=23 emits no standard flag, the configure checks fail at the C++14 default, and b2 silently skips every target in that variant. latest maps to /std:c++latest, which enables the C++23-and-later library (_HAS_CXX23) on clang-cl.