### PR TITLE
docs: give doc code one shared header and one namespace style

### DIFF
--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -84,6 +84,16 @@ The Antora pipeline provides two mechanisms; use them instead of hand-authoring:
   maintainer ruled that B4 binds them anyway: describing what a class *is* is not a licensed
   house style, it is the defect B4 exists to catch. Treat both audits' B4 dispositions on class
   briefs as superseded; this is what authorizes re-opening that finding set.)*
+- **B5. Doc code uses the namespace alias, never a using-directive.** Every file under
+  `test/doc/`, and every code block authored inline in a `.adoc` page, spells library names
+  against `namespace capy = boost::capy;` — `capy::task`, `capy::test::fuse`,
+  `capy::this_coro::executor` — even on a page that never declares the alias itself. A reader
+  should be able to tell which names in an example come from Capy without knowing the library.
+  The exception: a block that verbatim-quotes library-internal source keeps that source's own
+  unqualified spelling. `using namespace boost::capy;` is not used in doc code. Warning
+  suppressions live in `test/doc/doc_warnings.hpp`, included once per file outside every tag; a
+  warning that fires in one fragment stays in that fragment with a comment saying why. B5 is
+  enforced by review only — no script checks it.
 
 ## Part C — Wording (pragmatic Simplified Technical English)
 
@@ -228,7 +238,7 @@ Not every rule is machine-checkable. Each rule sits in one of three tiers:
 |---|---|
 | **Gate** | A1, A6, A7, B2, B3, C2, C4, C9, C10, D2 |
 | **Warning** | A2, B1, C1, C3, C5, C6, D4, D5, E1 |
-| **Review** | A3, A4, A5, B4, C7, C8, C11, D1, D3, E2, E3, E4 |
+| **Review** | A3, A4, A5, B4, B5, C7, C8, C11, D1, D3, E2, E3, E4 |
 
 The accuracy gates (B2, B3, D2 correctness) are enforced by the snippet-compile job, not by
 Vale — that job is what makes examples unable to drift.
@@ -294,7 +304,8 @@ max: 25
 - **F2.** The snippet-compile job is the accuracy gate; keep every example sourced from a
   compiled file (Part B2).
 - **F3.** Doc PR checklist: mode declared (A1)? no hand-typed signatures (B1)? example
-  compiled (B2)? terminology clean (`vale`)? rationale present (D3)?
+  compiled (B2)? namespace alias, not a using-directive (B5)? terminology clean (`vale`)?
+  rationale present (D3)?
 
 ### F4 — A check is not adopted until a planted violation has failed it
 

--- a/doc/modules/ROOT/pages/4.coroutines/4b.launching.adoc
+++ b/doc/modules/ROOT/pages/4.coroutines/4b.launching.adoc
@@ -44,7 +44,7 @@ rvalue-qualified:
 .Does not compile
 [source,cpp,role=pseudocode]
 ----
-auto wrapper = run_async(pool.get_executor());  // Don't do this
+auto wrapper = capy::run_async(pool.get_executor());  // Don't do this
 wrapper(compute());  // Error: operator() requires an rvalue
 ----
 

--- a/doc/modules/ROOT/pages/5.buffers/5a.buffers.adoc
+++ b/doc/modules/ROOT/pages/5.buffers/5a.buffers.adoc
@@ -281,7 +281,7 @@ Conversion always happens on the stack; the implementation never allocates. A fi
 .Pseudocode - internal implementation
 [source,cpp,role=pseudocode]
 ----
-template<ConstBufferSequence Buffers>
+template<capy::ConstBufferSequence Buffers>
 auto platform_write(Buffers const& buffers)
 {
     iovec iovecs[16];  // fixed on-frame window, never heap-allocated

--- a/doc/modules/ROOT/pages/7.testing/7a.drivers.adoc
+++ b/doc/modules/ROOT/pages/7.testing/7a.drivers.adoc
@@ -213,18 +213,18 @@ task on a context it owns. `run_one` returns any exception the task raised as a
 .Excerpt - not compiled here
 [source,cpp,role=pseudocode]
 ----
-fuse f;
-auto io_runner = [](task<void> t) -> std::exception_ptr {
+capy::test::fuse f;
+auto io_runner = [](capy::task<void> t) -> std::exception_ptr {
     corosio::io_context ioc;
     std::exception_ptr ep;
-    run_async(ioc.get_executor(),
+    capy::run_async(ioc.get_executor(),
         [](auto&&...){}, [&ep](std::exception_ptr e){ ep = e; })(std::move(t));
     ioc.run();
     return ep;
 };
 auto r = f.armed(
     io_runner,
-    [&](fuse&) -> task<void> {
+    [&](capy::test::fuse&) -> capy::task<void> {
         co_await corosio::timeout(some_op(), 5s);
     });
 BOOST_TEST(r.success);

--- a/test/doc/CMakeLists.txt
+++ b/test/doc/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2026 Steve Gerbino
+# Copyright (c) 2026 Michael Vandeberg
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -76,7 +77,7 @@ else()
         "[reference-examples] not compiled: they are never executed, and under "
         "coverage they only add never-entered template instantiations")
 endif()
-set(PFILES ${SNIPPETS} ${REFERENCE_SNIPPETS} CMakeLists.txt Jamfile)
+set(PFILES ${SNIPPETS} ${REFERENCE_SNIPPETS} doc_warnings.hpp CMakeLists.txt Jamfile)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES ${PFILES})
 
 add_executable(boost_capy_doc_tests ${PFILES})

--- a/test/doc/doc_warnings.hpp
+++ b/test/doc/doc_warnings.hpp
@@ -1,0 +1,57 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+#ifndef BOOST_CAPY_TEST_DOC_WARNINGS_HPP
+#define BOOST_CAPY_TEST_DOC_WARNINGS_HPP
+
+/* Warning suppressions shared by every compiled documentation fragment.
+
+   Fragments and reference examples deliberately leave results and bindings
+   unused. The pages and the reference explain those values in prose instead,
+   and adding a use would put code on the page that teaches nothing. test/doc
+   builds with -Wall -Wextra -Werror (test/doc/CMakeLists.txt and
+   test/doc/Jamfile), so an unused result would otherwise fail the build.
+
+   Include this first in a fragment, and always outside every tag:: region --
+   the site renders those regions, and scaffolding must not appear on a page.
+
+   The pragmas have no push/pop, so they apply to the rest of the translation
+   unit. That is the intent: a fragment is scaffolding plus tagged regions, and
+   both need them.
+
+   Keep this list minimal. A warning that fires in one fragment belongs in that
+   fragment, under a comment saying why, not here.
+*/
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-value"
+#pragma GCC diagnostic ignored "-Wunused-result"
+#pragma GCC diagnostic ignored "-Wunused-function"
+// gcc 15 with sanitizers misattributes coroutine frame delete paths
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wunused-lambda-capture"
+#pragma clang diagnostic ignored "-Wunused-private-field"
+#endif
+#if defined(_MSC_VER)
+#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
+#pragma warning(disable: 4189) // local variable initialized but not referenced
+#pragma warning(disable: 4100) // unreferenced formal parameter
+#pragma warning(disable: 4101) // unreferenced local variable
+#pragma warning(disable: 4456) // declaration hides previous local declaration
+#pragma warning(disable: 4457) // declaration hides function parameter
+#pragma warning(disable: 4458) // declaration hides class member
+#pragma warning(disable: 4459) // declaration hides global declaration
+#endif
+
+#endif

--- a/test/doc/programs/4b_launching_run_async.cpp
+++ b/test/doc/programs/4b_launching_run_async.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -11,17 +12,17 @@
 
 // tag::full[]
 #include <boost/capy.hpp>
-using namespace boost::capy;
+namespace capy = boost::capy;
 
-task<int> compute()
+capy::task<int> compute()
 {
     co_return 42;
 }
 
 int main()
 {
-    thread_pool pool;
-    run_async(pool.get_executor())(compute());
+    capy::thread_pool pool;
+    capy::run_async(pool.get_executor())(compute());
     // Task is now running on the thread pool
 
     pool.join();  // wait for outstanding work to complete

--- a/test/doc/programs/4c_executors_executor_ref.cpp
+++ b/test/doc/programs/4c_executors_executor_ref.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -19,11 +20,11 @@
 #include <coroutine>
 #include <semaphore>
 
-using namespace boost::capy;
+namespace capy = boost::capy;
 
 namespace {
 
-continuation parked;
+capy::continuation parked;
 std::binary_semaphore parked_ready{0};
 
 // Suspends its coroutine and publishes the continuation so another
@@ -33,7 +34,7 @@ struct park
     bool await_ready() const noexcept { return false; }
 
     std::coroutine_handle<> await_suspend(
-        std::coroutine_handle<> h, io_env const*)
+        std::coroutine_handle<> h, capy::io_env const*)
     {
         parked.h = h;
         parked_ready.release();
@@ -43,16 +44,16 @@ struct park
     void await_resume() {}
 };
 
-task<void> parked_task()
+capy::task<void> parked_task()
 {
     co_await park{};
 }
 
 // Launch a coroutine on the pool and block until it has parked,
 // leaving its continuation ready to be scheduled.
-continuation& make_suspended_work(thread_pool& pool)
+capy::continuation& make_suspended_work(capy::thread_pool& pool)
 {
-    run_async(pool.get_executor())(parked_task());
+    capy::run_async(pool.get_executor())(parked_task());
     parked_ready.acquire();
     return parked;
 }
@@ -60,18 +61,18 @@ continuation& make_suspended_work(thread_pool& pool)
 } // namespace
 
 // tag::full[]
-void schedule_work(executor_ref ex, continuation& c)
+void schedule_work(capy::executor_ref ex, capy::continuation& c)
 {
     ex.post(c);  // Works with any executor
 }
 
 int main()
 {
-    thread_pool pool;
+    capy::thread_pool pool;
     auto pool_ex = pool.get_executor();
-    executor_ref ex = pool_ex;  // Type erasure; pool_ex must outlive ex
+    capy::executor_ref ex = pool_ex;  // Type erasure; pool_ex must outlive ex
 
-    continuation& c = make_suspended_work(pool);  // a coroutine parked on the pool
+    capy::continuation& c = make_suspended_work(pool);  // a coroutine parked on the pool
     schedule_work(ex, c);
     pool.join();
 }

--- a/test/doc/programs/4c_executors_thread_pool.cpp
+++ b/test/doc/programs/4c_executors_thread_pool.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -16,9 +17,9 @@
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
 
-using namespace boost::capy;
+namespace capy = boost::capy;
 
-task<void> my_task()
+capy::task<void> my_task()
 {
     co_return;
 }
@@ -27,13 +28,13 @@ task<void> my_task()
 int main()
 {
     // Create pool with 4 threads
-    thread_pool pool(4);
+    capy::thread_pool pool(4);
 
     // Get an executor for this pool
     auto ex = pool.get_executor();
 
     // Start work on the pool
-    run_async(ex)(my_task());
+    capy::run_async(ex)(my_task());
 
     pool.join();  // wait for outstanding work to complete
 }

--- a/test/doc/programs/index_page_echo.cpp
+++ b/test/doc/programs/index_page_echo.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -12,16 +13,16 @@
 // tag::full[]
 #include <boost/capy.hpp>
 
-using namespace boost::capy;
+namespace capy = boost::capy;
 
-task<> echo(any_stream& stream)
+capy::task<> echo(capy::any_stream& stream)
 {
     char buf[1024];
     for(;;)
     {
-        auto [ec, n] = co_await stream.read_some(make_buffer(buf));
+        auto [ec, n] = co_await stream.read_some(capy::make_buffer(buf));
 
-        auto [wec, wn] = co_await write(stream, const_buffer(buf, n));
+        auto [wec, wn] = co_await capy::write(stream, capy::const_buffer(buf, n));
 
         if(ec)
             co_return;
@@ -38,7 +39,7 @@ int main()
     //
     //   corosio::io_context ioc;
     //   corosio::tcp_socket stream = /* from an acceptor or connect */;
-    //   run_async(ioc.get_executor())(echo(stream));
+    //   capy::run_async(ioc.get_executor())(echo(stream));
     //   ioc.run();
 }
 // end::full[]

--- a/test/doc/reference/ExecutionContext.concept.cpp
+++ b/test/doc/reference/ExecutionContext.concept.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,30 +27,29 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example_1[]
-class X : public execution_context
+class X : public capy::execution_context
 {
 public:
-    using executor_type = executor_ref;  // any type satisfying Executor
+    using executor_type = capy::executor_ref;  // any type satisfying Executor
     executor_type get_executor() noexcept;
 };
 
-static_assert( ExecutionContext<X> );
+static_assert( capy::ExecutionContext<X> );
 // end::example_1[]
 } // namespace ex_1
 
 namespace ex_2 {
 // tag::example_2[]
-template<ExecutionContext Ctx>
-void spawn_work( Ctx& ctx, task<> work )
+template<capy::ExecutionContext Ctx>
+void spawn_work( Ctx& ctx, capy::task<> work )
 {
     auto ex = ctx.get_executor();
-    run_async(ex)(std::move(work)); // schedules work; runs on ctx
+    capy::run_async(ex)(std::move(work)); // schedules work; runs on ctx
 }
 // end::example_2[]
 } // namespace ex_2

--- a/test/doc/reference/Executor.concept.cpp
+++ b/test/doc/reference/Executor.concept.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -59,13 +34,13 @@ namespace ex_1 {
 // tag::example_1[]
 class E
 {
-    execution_context& ctx_;
+    capy::execution_context& ctx_;
     std::thread::id home_ = std::this_thread::get_id();
 
 public:
-    explicit E(execution_context& ctx) noexcept : ctx_(ctx) {}
+    explicit E(capy::execution_context& ctx) noexcept : ctx_(ctx) {}
 
-    execution_context& context() const noexcept { return ctx_; }
+    capy::execution_context& context() const noexcept { return ctx_; }
     void on_work_started() const noexcept {}
     void on_work_finished() const noexcept {}
 
@@ -75,7 +50,7 @@ public:
     }
 
     std::coroutine_handle<> dispatch(
-        continuation& c ) const
+        capy::continuation& c ) const
     {
         if( std::this_thread::get_id() == home_ )
             return c.h;            // symmetric transfer
@@ -83,13 +58,13 @@ public:
         return std::noop_coroutine();
     }
 
-    void post( continuation& ) const
+    void post( capy::continuation& ) const
     {
         // enqueue for later execution on this executor's context
     }
 };
 
-static_assert( Executor<E> );
+static_assert( capy::Executor<E> );
 // end::example_1[]
 } // namespace ex_1
 
@@ -98,14 +73,14 @@ namespace ex_2 {
 class E
 {
 public:
-    execution_context& context() const noexcept;
+    capy::execution_context& context() const noexcept;
 
     void on_work_started() const noexcept;
     void on_work_finished() const noexcept;
 
     std::coroutine_handle<> dispatch(
-        continuation& c ) const;
-    void post( continuation& c ) const;
+        capy::continuation& c ) const;
+    void post( capy::continuation& c ) const;
 
     bool operator==( E const& ) const noexcept;
 };

--- a/test/doc/reference/IoAwaitable.concept.cpp
+++ b/test/doc/reference/IoAwaitable.concept.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -52,7 +28,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -95,7 +70,7 @@ public:
 };
 // end::example[]
 
-static_assert( IoAwaitable<my_awaitable> );
+static_assert( capy::IoAwaitable<my_awaitable> );
 } // namespace ex_1
 
 } // namespace

--- a/test/doc/reference/IoRunnable.concept.cpp
+++ b/test/doc/reference/IoRunnable.concept.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -65,7 +40,7 @@ public:
         std::exception_ptr exception() noexcept;
         int result();  // non-void tasks only
         void set_continuation(std::coroutine_handle<>) noexcept;
-        void set_environment(io_env const*) noexcept;
+        void set_environment(capy::io_env const*) noexcept;
     };
 
     std::coroutine_handle<promise_type> handle() const noexcept;

--- a/test/doc/reference/ReadStream.concept.cpp
+++ b/test/doc/reference/ReadStream.concept.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,27 +27,26 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example_1[]
-template< MutableBufferSequence MB >
-IoAwaitable auto read_some( MB buffers );
+template< capy::MutableBufferSequence MB >
+capy::IoAwaitable auto read_some( MB buffers );
 // end::example_1[]
 } // namespace ex_1
 
 namespace ex_2 {
 // tag::example_2[]
-template< ReadStream Stream >
-task<> read_all( Stream& s, char* buf, std::size_t size )
+template< capy::ReadStream Stream >
+capy::task<> read_all( Stream& s, char* buf, std::size_t size )
 {
     std::size_t total = 0;
     while( total < size )
     {
         auto [ec, n] = co_await s.read_some(
-            mutable_buffer( buf + total, size - total ) );
+            capy::mutable_buffer( buf + total, size - total ) );
         total += n;
         if( ec )
             co_return;

--- a/test/doc/reference/Stream.concept.cpp
+++ b/test/doc/reference/Stream.concept.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,17 +27,16 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-template<Stream S>
-task<> echo(S& stream)
+template<capy::Stream S>
+capy::task<> echo(S& stream)
 {
     char buf[1024];
-    auto [ec, n] = co_await stream.read_some(make_buffer(buf));
+    auto [ec, n] = co_await stream.read_some(capy::make_buffer(buf));
     if(ec)
         co_return;
 
@@ -72,7 +47,7 @@ task<> echo(S& stream)
     while(total < n)
     {
         auto [ec2, n2] = co_await stream.write_some(
-            const_buffer(buf + total, n - total));
+            capy::const_buffer(buf + total, n - total));
         total += n2;
         if(ec2)
             co_return;

--- a/test/doc/reference/WriteStream.concept.cpp
+++ b/test/doc/reference/WriteStream.concept.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,27 +27,26 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example_1[]
-template< ConstBufferSequence Buffers >
-IoAwaitable auto write_some( Buffers buffers );
+template< capy::ConstBufferSequence Buffers >
+capy::IoAwaitable auto write_some( Buffers buffers );
 // end::example_1[]
 } // namespace ex_1
 
 namespace ex_2 {
 // tag::example_2[]
-template< WriteStream Stream >
-task<> write_all( Stream& s, char const* buf, std::size_t size )
+template< capy::WriteStream Stream >
+capy::task<> write_all( Stream& s, char const* buf, std::size_t size )
 {
     std::size_t total = 0;
     while( total < size )
     {
         auto [ec, n] = co_await s.write_some(
-            const_buffer( buf + total, size - total ) );
+            capy::const_buffer( buf + total, size - total ) );
         total += n;
         if( ec )
             co_return;

--- a/test/doc/reference/any_executor.record.cpp
+++ b/test/doc/reference/any_executor.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -60,9 +35,9 @@ namespace ex_1 {
 // c must stay at a stable address until the executor dequeues it, so
 // the caller owns it -- typically as part of the awaitable or
 // operation state that posts it, never as a callee-local temporary.
-void dispatch_via_context(thread_pool& ctx, continuation& c)
+void dispatch_via_context(capy::thread_pool& ctx, capy::continuation& c)
 {
-    any_executor exec = ctx.get_executor();
+    capy::any_executor exec = ctx.get_executor();
     if(exec)
     {
         auto& context = exec.context();

--- a/test/doc/reference/any_read_stream.record.cpp
+++ b/test/doc/reference/any_read_stream.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -61,24 +36,24 @@ namespace ex_1 {
 // the whole buffer sequence as read.
 struct instant_stream
 {
-    template<MutableBufferSequence MB>
+    template<capy::MutableBufferSequence MB>
     auto read_some(MB buffers)
     {
-        return ready(buffer_size(buffers));
+        return capy::ready(capy::buffer_size(buffers));
     }
 };
 
-task<> use_any_read_stream()
+capy::task<> use_any_read_stream()
 {
     // Owning - takes ownership of the stream
-    any_read_stream owning_stream(instant_stream{});
+    capy::any_read_stream owning_stream(instant_stream{});
 
     // Reference - wraps without ownership
     instant_stream instant;
-    any_read_stream ref_stream(&instant);
+    capy::any_read_stream ref_stream(&instant);
 
     char data[1024];
-    mutable_buffer buf(data, sizeof(data));
+    capy::mutable_buffer buf(data, sizeof(data));
     auto [ec, n] = co_await owning_stream.read_some(buf);
 }
 // end::example[]

--- a/test/doc/reference/any_stream.record.cpp
+++ b/test/doc/reference/any_stream.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -61,39 +36,39 @@ namespace ex_1 {
 // immediately, reporting the whole buffer sequence transferred.
 struct instant_stream
 {
-    template<MutableBufferSequence MB>
+    template<capy::MutableBufferSequence MB>
     auto read_some(MB buffers)
     {
-        return ready(buffer_size(buffers));
+        return capy::ready(capy::buffer_size(buffers));
     }
 
-    template<ConstBufferSequence CB>
+    template<capy::ConstBufferSequence CB>
     auto write_some(CB buffers)
     {
-        return ready(buffer_size(buffers));
+        return capy::ready(capy::buffer_size(buffers));
     }
 };
 
-void reader(any_read_stream&) {}
-void writer(any_write_stream&) {}
+void reader(capy::any_read_stream&) {}
+void writer(capy::any_write_stream&) {}
 
-task<> use_any_stream()
+capy::task<> use_any_stream()
 {
     // Owning - takes ownership of the stream
-    any_stream owning_stream(instant_stream{});
+    capy::any_stream owning_stream(instant_stream{});
 
     // Reference - wraps without ownership
     instant_stream instant;
-    any_stream ref_stream(&instant);
+    capy::any_stream ref_stream(&instant);
 
     // Use read_some from the any_read_stream base
     char rdata[1024];
-    mutable_buffer rbuf(rdata, sizeof(rdata));
+    capy::mutable_buffer rbuf(rdata, sizeof(rdata));
     auto [ec1, n1] = co_await owning_stream.read_some(std::span(&rbuf, 1));
 
     // Use write_some from the any_write_stream base
     char wdata[] = "hello";
-    const_buffer wbuf(wdata, sizeof(wdata));
+    capy::const_buffer wbuf(wdata, sizeof(wdata));
     auto [ec2, n2] = co_await owning_stream.write_some(std::span(&wbuf, 1));
 
     // Pass to functions expecting one capability

--- a/test/doc/reference/any_write_stream.record.cpp
+++ b/test/doc/reference/any_write_stream.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -61,24 +36,24 @@ namespace ex_1 {
 // the whole buffer sequence as written.
 struct instant_stream
 {
-    template<ConstBufferSequence CB>
+    template<capy::ConstBufferSequence CB>
     auto write_some(CB buffers)
     {
-        return ready(buffer_size(buffers));
+        return capy::ready(capy::buffer_size(buffers));
     }
 };
 
-task<> use_any_write_stream()
+capy::task<> use_any_write_stream()
 {
     // Owning - takes ownership of the stream
-    any_write_stream owning_stream(instant_stream{});
+    capy::any_write_stream owning_stream(instant_stream{});
 
     // Reference - wraps without ownership
     instant_stream instant;
-    any_write_stream ref_stream(&instant);
+    capy::any_write_stream ref_stream(&instant);
 
     char data[] = "hello";
-    const_buffer buf(data, sizeof(data));
+    capy::const_buffer buf(data, sizeof(data));
     auto [ec, n] = co_await owning_stream.write_some(std::span(&buf, 1));
 }
 // end::example[]

--- a/test/doc/reference/async_event.record.cpp
+++ b/test/doc/reference/async_event.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,22 +27,21 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-async_event event;
+capy::async_event event;
 
-task<> waiter() {
+capy::task<> waiter() {
     auto [ec] = co_await event.wait();
     if(ec)
         co_return;
     // ... event was set ...
 }
 
-task<> notifier() {
+capy::task<> notifier() {
     // ... do some work ...
     event.set();  // Wake all waiters
     co_return;

--- a/test/doc/reference/async_mutex.record.cpp
+++ b/test/doc/reference/async_mutex.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,15 +27,14 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-async_mutex cm;
+capy::async_mutex cm;
 
-task<> protected_operation() {
+capy::task<> protected_operation() {
     auto [ec] = co_await cm.lock();
     if(ec)
         co_return;
@@ -68,7 +43,7 @@ task<> protected_operation() {
 }
 
 // Or with RAII:
-task<> protected_operation_raii() {
+capy::task<> protected_operation_raii() {
     auto [ec, guard] = co_await cm.scoped_lock();
     if(ec)
         co_return;

--- a/test/doc/reference/async_waker.record.cpp
+++ b/test/doc/reference/async_waker.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -59,7 +34,7 @@ namespace ex_1 {
 // tag::example[]
 void waker_example()
 {
-    async_waker waker;
+    capy::async_waker waker;
 
     // user-provided timing thread
     std::thread th([&waker] {
@@ -67,7 +42,7 @@ void waker_example()
         waker.wake();
     });
 
-    auto waiter = [&waker]() -> task<> {
+    auto waiter = [&waker]() -> capy::task<> {
         auto [ec] = co_await waker.wait();
         // resumed on the executor after ~100ms
     };

--- a/test/doc/reference/awaitable_decomposes_to.concept.cpp
+++ b/test/doc/reference/awaitable_decomposes_to.concept.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -60,8 +35,8 @@ namespace ex_1 {
 // Constrain a function to accept only awaitables that return
 // a decomposable result of (error_code, size_t)
 template<typename A>
-    requires awaitable_decomposes_to<A, std::error_code, std::size_t>
-task<void> process(A&& op)
+    requires capy::awaitable_decomposes_to<A, std::error_code, std::size_t>
+capy::task<void> process(A&& op)
 {
     auto [ec, n] = co_await std::forward<A>(op);
     if (ec)

--- a/test/doc/reference/buffer_param.record.cpp
+++ b/test/doc/reference/buffer_param.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,20 +27,19 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 namespace ex_1 {
 // tag::example_1[]
-task<> write(ConstBufferSequence auto buffers);   // CORRECT
-task<> write(ConstBufferSequence auto& buffers);  // WRONG - dangling reference
+capy::task<> write(capy::ConstBufferSequence auto buffers);   // CORRECT
+capy::task<> write(capy::ConstBufferSequence auto& buffers);  // WRONG - dangling reference
 // end::example_1[]
 } // namespace ex_1
 namespace ex_2 {
 // tag::example_2[]
-task<> send(ConstBufferSequence auto buffers)
+capy::task<> send(capy::ConstBufferSequence auto buffers)
 {
-    buffer_param bp(buffers);
+    capy::buffer_param bp(buffers);
     while(true)
     {
         auto bufs = bp.data();
@@ -81,10 +56,10 @@ namespace ex_3 {
 class base
 {
 public:
-    template<ConstBufferSequence BS>
-    task<> write(BS buffers)
+    template<capy::ConstBufferSequence BS>
+    capy::task<> write(BS buffers)
     {
-        const_buffer_param<BS> bp(buffers);
+        capy::const_buffer_param<BS> bp(buffers);
         while(true)
         {
             auto bufs = bp.data();
@@ -97,8 +72,8 @@ public:
     }
 
 protected:
-    virtual task<> write_impl(
-        std::span<const_buffer> buffers,
+    virtual capy::task<> write_impl(
+        std::span<capy::const_buffer> buffers,
         std::size_t& bytes_written) = 0;
 };
 // end::example_3[]

--- a/test/doc/reference/buffer_size.function.cpp
+++ b/test/doc/reference/buffer_size.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -59,10 +34,10 @@ namespace ex_1 {
 // tag::example[]
 unsigned char header[16];
 unsigned char payload[512];
-std::array<mutable_buffer, 2> bufs = {
-    mutable_buffer( header, sizeof(header) ),
-    mutable_buffer( payload, sizeof(payload) ) };
-std::size_t total = buffer_size( bufs );  // 16 + 512
+std::array<capy::mutable_buffer, 2> bufs = {
+    capy::mutable_buffer( header, sizeof(header) ),
+    capy::mutable_buffer( payload, sizeof(payload) ) };
+std::size_t total = capy::buffer_size( bufs );  // 16 + 512
 // end::example[]
 } // namespace ex_1
 

--- a/test/doc/reference/buffer_slice.function.cpp
+++ b/test/doc/reference/buffer_slice.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,17 +27,16 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-task<> send_in_two_parts( any_write_stream& sock, const_buffer bufs )
+capy::task<> send_in_two_parts( capy::any_write_stream& sock, capy::const_buffer bufs )
 {
-    co_await write(sock, buffer_slice(bufs, 0, 16384));  // first 16 KB
-    auto rest = buffer_slice(bufs, 16384);               // drop first 16 KB
-    co_await write(sock, rest);
+    co_await capy::write(sock, capy::buffer_slice(bufs, 0, 16384));  // first 16 KB
+    auto rest = capy::buffer_slice(bufs, 16384);               // drop first 16 KB
+    co_await capy::write(sock, rest);
 }
 // end::example[]
 } // namespace ex_1

--- a/test/doc/reference/cond.enum.cpp
+++ b/test/doc/reference/cond.enum.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,20 +27,19 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-task<> classify_read_error( any_read_stream& stream, mutable_buffer bufs )
+capy::task<> classify_read_error( capy::any_read_stream& stream, capy::mutable_buffer bufs )
 {
     auto [ec, n] = co_await stream.read_some( bufs );
-    if( ec == cond::canceled )
+    if( ec == capy::cond::canceled )
     {
         // handle cancellation
     }
-    else if( ec == cond::eof )
+    else if( ec == capy::cond::eof )
     {
         // handle end of stream
     }

--- a/test/doc/reference/const_buffer_archetype_.record.cpp
+++ b/test/doc/reference/const_buffer_archetype_.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -59,7 +34,7 @@ namespace ex_1 {
 // tag::example[]
 template<typename T>
 concept MyWritable =
-    requires(T& stream, const_buffer_archetype buffers)
+    requires(T& stream, capy::const_buffer_archetype buffers)
     {
         stream.write(buffers);
     };

--- a/test/doc/reference/consuming_buffers.record.cpp
+++ b/test/doc/reference/consuming_buffers.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,16 +27,15 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 namespace ex_1 {
 // tag::example[]
-template<MutableBufferSequence Buffers>
-io_task<std::size_t> read_until_full( any_read_stream& stream, Buffers buffers )
+template<capy::MutableBufferSequence Buffers>
+capy::io_task<std::size_t> read_until_full( capy::any_read_stream& stream, Buffers buffers )
 {
-    consuming_buffers consuming(buffers);
-    std::size_t total = 0, want = buffer_size(buffers);
+    capy::consuming_buffers consuming(buffers);
+    std::size_t total = 0, want = capy::buffer_size(buffers);
     while (total < want)
     {
         auto [ec, n] = co_await stream.read_some(consuming.data());

--- a/test/doc/reference/decomposes_to.concept.cpp
+++ b/test/doc/reference/decomposes_to.concept.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -59,8 +34,8 @@ namespace ex_1 {
 // tag::example[]
 struct result { int a; double b; };
 
-static_assert(decomposes_to<result, int, double>);
-static_assert(decomposes_to<std::tuple<int, double>, int, double>);
+static_assert(capy::decomposes_to<result, int, double>);
+static_assert(capy::decomposes_to<std::tuple<int, double>, int, double>);
 // end::example[]
 } // namespace ex_1
 

--- a/test/doc/reference/execution_context.record.cpp
+++ b/test/doc/reference/execution_context.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,13 +27,12 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-struct file_service : execution_context::service
+struct file_service : capy::execution_context::service
 {
 protected:
     void shutdown() override {}
@@ -67,10 +42,10 @@ struct posix_file_service : file_service
 {
     using key_type = file_service;
 
-    explicit posix_file_service(execution_context&) {}
+    explicit posix_file_service(capy::execution_context&) {}
 };
 
-class io_context : public execution_context
+class io_context : public capy::execution_context
 {
 public:
     ~io_context()

--- a/test/doc/reference/execution_context__service.record.cpp
+++ b/test/doc/reference/execution_context__service.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,15 +27,14 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-struct my_service : execution_context::service
+struct my_service : capy::execution_context::service
 {
-    explicit my_service(execution_context&) {}
+    explicit my_service(capy::execution_context&) {}
 
 protected:
     void shutdown() override

--- a/test/doc/reference/executor_ref.record.cpp
+++ b/test/doc/reference/executor_ref.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -59,13 +34,13 @@ namespace ex_1 {
 // tag::example[]
 // my_continuation must stay at a stable address until the executor
 // dequeues it, so it is owned by the caller, not by store_executor().
-void store_executor(executor_ref ex, continuation& my_continuation)
+void store_executor(capy::executor_ref ex, capy::continuation& my_continuation)
 {
     if(ex)
         ex.post(my_continuation);
 }
 
-void use_thread_pool(thread_pool& ctx, continuation& my_continuation)
+void use_thread_pool(capy::thread_pool& ctx, capy::continuation& my_continuation)
 {
     store_executor(ctx.get_executor(), my_continuation);
 }

--- a/test/doc/reference/frame_alloc_mixin.record.cpp
+++ b/test/doc/reference/frame_alloc_mixin.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -59,7 +34,7 @@ namespace ex_1 {
 // tag::example[]
 struct my_internal_coroutine
 {
-    struct promise_type : frame_alloc_mixin
+    struct promise_type : capy::frame_alloc_mixin
     {
         my_internal_coroutine get_return_object();
         std::suspend_always initial_suspend() noexcept;

--- a/test/doc/reference/immediate.record.cpp
+++ b/test/doc/reference/immediate.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,19 +27,18 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example_1[]
 // Wrap a sync operation as an awaitable
-immediate<int> get_value()
+capy::immediate<int> get_value()
 {
     return {42};
 }
 
-task<void> example()
+capy::task<void> example()
 {
     int x = co_await get_value();  // No suspension, returns 42
 }
@@ -74,15 +49,15 @@ namespace ex_2 {
 // tag::example_2[]
 struct my_sync_sink
 {
-    template<ConstBufferSequence CB>
-    immediate<io_result<std::size_t>>
+    template<capy::ConstBufferSequence CB>
+    capy::immediate<capy::io_result<std::size_t>>
     write(CB buffers)
     {
         auto n = process_sync(buffers);
         return {{std::error_code(), n}};
     }
 
-    immediate<io_result<>>
+    capy::immediate<capy::io_result<>>
     write_eof()
     {
         return {{}};

--- a/test/doc/reference/io_awaitable_promise_base.record.cpp
+++ b/test/doc/reference/io_awaitable_promise_base.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -62,7 +37,7 @@ namespace ex_1 {
 // variations on promise plumbing.
 struct my_task
 {
-    struct promise_type : io_awaitable_promise_base<promise_type>
+    struct promise_type : capy::io_awaitable_promise_base<promise_type>
     {
         my_task get_return_object()
         {
@@ -103,20 +78,20 @@ struct my_task
 
 my_task example()
 {
-    auto env = co_await this_coro::environment;
+    auto env = co_await capy::this_coro::environment;
     // Access env->executor, env->stop_token, env->frame_allocator
 
     // Or use fine-grained accessors:
-    auto ex = co_await this_coro::executor;
-    auto token = co_await this_coro::stop_token;
-    auto* alloc = co_await this_coro::frame_allocator;
+    auto ex = co_await capy::this_coro::executor;
+    auto token = co_await capy::this_coro::stop_token;
+    auto* alloc = co_await capy::this_coro::frame_allocator;
 }
 // end::example_1[]
 } // namespace ex_1
 
 namespace ex_2 {
 // tag::example_2[]
-struct promise_type : io_awaitable_promise_base<promise_type>
+struct promise_type : capy::io_awaitable_promise_base<promise_type>
 {
     template<typename A>
     auto transform_awaitable(A&& a)
@@ -134,7 +109,7 @@ namespace ex_3 {
 // section's point is the await_suspend overload below, not the promise.
 struct my_task
 {
-    struct promise_type : io_awaitable_promise_base<promise_type>
+    struct promise_type : capy::io_awaitable_promise_base<promise_type>
     {
         my_task get_return_object()
         {
@@ -174,7 +149,7 @@ struct my_task
 
     // IoAwaitable await_suspend receives and stores the environment,
     // then resumes into the coroutine body via symmetric transfer
-    std::coroutine_handle<> await_suspend(std::coroutine_handle<> cont, io_env const* env)
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<> cont, capy::io_env const* env)
     {
         h_.promise().set_continuation(cont);
         h_.promise().set_environment(env);

--- a/test/doc/reference/io_result.typedef.cpp
+++ b/test/doc/reference/io_result.typedef.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,13 +27,12 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example_1[]
-task<> discard_first_chunk( any_read_stream& s, mutable_buffer buf )
+capy::task<> discard_first_chunk( capy::any_read_stream& s, capy::mutable_buffer buf )
 {
     auto [ec, n] = co_await s.read_some(buf);
     if (ec)
@@ -68,7 +43,7 @@ task<> discard_first_chunk( any_read_stream& s, mutable_buffer buf )
 
 namespace ex_2 {
 // tag::example_2[]
-task<> read_into_locals( any_read_stream& s, mutable_buffer buf )
+capy::task<> read_into_locals( capy::any_read_stream& s, capy::mutable_buffer buf )
 {
     std::error_code ec;
     std::size_t n = 0;

--- a/test/doc/reference/io_task.typedef.cpp
+++ b/test/doc/reference/io_task.typedef.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,21 +27,20 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-io_task<std::size_t> read_one( any_read_stream& s, mutable_buffer buf )
+capy::io_task<std::size_t> read_one( capy::any_read_stream& s, capy::mutable_buffer buf )
 {
     co_return co_await s.read_some(buf);  // returns io_result<std::size_t>
 }
 
-io_task<> require_ready(bool ready)
+capy::io_task<> require_ready(bool ready)
 {
     if(!ready)
-        co_return make_error_code(error::eof);  // error_code converts to io_result<>
+        co_return capy::make_error_code(capy::error::eof);  // error_code converts to io_result<>
     co_return {};
 }
 // end::example[]

--- a/test/doc/reference/mutable_buffer_archetype_.record.cpp
+++ b/test/doc/reference/mutable_buffer_archetype_.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -59,7 +34,7 @@ namespace ex_1 {
 // tag::example[]
 template<typename T>
 concept MyReadable =
-    requires(T& stream, mutable_buffer_archetype buffers)
+    requires(T& stream, capy::mutable_buffer_archetype buffers)
     {
         stream.read(buffers);
     };

--- a/test/doc/reference/operator_.function.cpp
+++ b/test/doc/reference/operator_.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -59,10 +34,10 @@ namespace ex_1 {
 // tag::example[]
 unsigned char header[16];
 unsigned char payload[512];
-std::array<mutable_buffer, 2> bufs = {
-    mutable_buffer( header, sizeof(header) ),
-    mutable_buffer( payload, sizeof(payload) ) };
-std::size_t total = buffer_size( bufs );  // 16 + 512
+std::array<capy::mutable_buffer, 2> bufs = {
+    capy::mutable_buffer( header, sizeof(header) ),
+    capy::mutable_buffer( payload, sizeof(payload) ) };
+std::size_t total = capy::buffer_size( bufs );  // 16 + 512
 // end::example[]
 } // namespace ex_1
 

--- a/test/doc/reference/read.function.cpp
+++ b/test/doc/reference/read.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 

--- a/test/doc/reference/read_at_least.function.cpp
+++ b/test/doc/reference/read_at_least.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 

--- a/test/doc/reference/ready.function.cpp
+++ b/test/doc/reference/ready.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,14 +27,13 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 namespace ex_1 {
 // tag::example_1[]
-std::size_t write_all_sync(const_buffer buf)
+std::size_t write_all_sync(capy::const_buffer buf)
 {
-    return buffer_size(buf);
+    return capy::buffer_size(buf);
 }
 
 std::error_code connect_sync()
@@ -66,37 +41,37 @@ std::error_code connect_sync()
     return {};
 }
 
-immediate<io_result<std::size_t>>
-write(const_buffer buf)
+capy::immediate<capy::io_result<std::size_t>>
+write(capy::const_buffer buf)
 {
     auto n = write_all_sync(buf);
-    return ready(n);  // success with n bytes
+    return capy::ready(n);  // success with n bytes
 }
 
-immediate<io_result<>>
+capy::immediate<capy::io_result<>>
 connect()
 {
     connect_sync();
-    return ready();  // void success
+    return capy::ready();  // void success
 }
 // end::example_1[]
 } // namespace ex_1
 namespace ex_2 {
 // tag::example_2[]
-std::error_code write_checked_sync(const_buffer buf)
+std::error_code write_checked_sync(capy::const_buffer buf)
 {
-    if(buffer_size(buf) == 0)
+    if(capy::buffer_size(buf) == 0)
         return std::make_error_code(std::errc::invalid_argument);
     return {};
 }
 
-immediate<io_result<std::size_t>>
-write(const_buffer buf)
+capy::immediate<capy::io_result<std::size_t>>
+write(capy::const_buffer buf)
 {
     auto ec = write_checked_sync(buf);
     if(ec)
-        return ready(ec, std::size_t{0});
-    return ready(buffer_size(buf));
+        return capy::ready(ec, std::size_t{0});
+    return capy::ready(capy::buffer_size(buf));
 }
 // end::example_2[]
 } // namespace ex_2

--- a/test/doc/reference/recycling_memory_resource.record.cpp
+++ b/test/doc/reference/recycling_memory_resource.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,18 +27,17 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-task<void> my_task() { co_return; }
+capy::task<void> my_task() { co_return; }
 
-void run_with_recycling( any_executor ex )
+void run_with_recycling( capy::any_executor ex )
 {
-    auto* mr = get_recycling_memory_resource();
-    run_async(ex, mr)(my_task());
+    auto* mr = capy::get_recycling_memory_resource();
+    capy::run_async(ex, mr)(my_task());
 }
 // end::example[]
 } // namespace ex_1

--- a/test/doc/reference/run.function.cpp
+++ b/test/doc/reference/run.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,28 +27,27 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 namespace ex_1 {
 // tag::example_1[]
-task<void> cancellable_task() { co_return; }
+capy::task<void> cancellable_task() { co_return; }
 
-task<void> override_stop_token()
+capy::task<void> override_stop_token()
 {
     std::stop_source source;
-    co_await run(source.get_token())(cancellable_task());
+    co_await capy::run(source.get_token())(cancellable_task());
 }
 // end::example_1[]
 } // namespace ex_1
 
 namespace ex_2 {
 // tag::example_2[]
-task<void> my_task() { co_return; }
+capy::task<void> my_task() { co_return; }
 
-task<void> switch_executor( any_executor other_executor )
+capy::task<void> switch_executor( capy::any_executor other_executor )
 {
-    co_await run(other_executor)(my_task());
+    co_await capy::run(other_executor)(my_task());
 }
 // end::example_2[]
 } // namespace ex_2

--- a/test/doc/reference/run_async.function.cpp
+++ b/test/doc/reference/run_async.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,22 +27,21 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 namespace ex_1 {
 // tag::example_1[]
-task<void> my_task() { co_return; }
+capy::task<void> my_task() { co_return; }
 
-void start_task( any_executor ex )
+void start_task( capy::any_executor ex )
 {
-    run_async(ex)(my_task());
+    capy::run_async(ex)(my_task());
 }
 // end::example_1[]
 } // namespace ex_1
 namespace ex_2 {
 // tag::example_2[]
-task<int> compute_value() { co_return 42; }
+capy::task<int> compute_value() { co_return 42; }
 
 template<class... Fs>
 struct overloaded : Fs... { using Fs::operator()...; };
@@ -80,9 +55,9 @@ int last_result = 0;
 int last_result2 = 0;
 bool last_failed = false;
 
-void run_with_result_handler_demo( any_executor ex )
+void run_with_result_handler_demo( capy::any_executor ex )
 {
-    run_async(ex, [](int result) {
+    capy::run_async(ex, [](int result) {
         last_result = result;   // the successful value arrives here
     })(compute_value());
 
@@ -91,13 +66,13 @@ void run_with_result_handler_demo( any_executor ex )
         [](int result) { last_result2 = result; },      // the successful value arrives here
         [](std::exception_ptr) { last_failed = true; }  // the failure arrives here
     };
-    run_async(ex, handle_result_or_exception)(compute_value());
+    capy::run_async(ex, handle_result_or_exception)(compute_value());
 }
 // end::example_2[]
 } // namespace ex_2
 namespace ex_3 {
 // tag::example_3[]
-task<int> compute_value() { co_return 42; }
+capy::task<int> compute_value() { co_return 42; }
 
 // The handlers may run after this function returns, on whichever thread
 // the executor schedules them, so the state they write must outlive
@@ -105,9 +80,9 @@ task<int> compute_value() { co_return 42; }
 int separate_handlers_result = 0;
 std::string separate_handlers_error;
 
-void run_with_separate_handlers_demo( any_executor ex )
+void run_with_separate_handlers_demo( capy::any_executor ex )
 {
-    run_async(ex,
+    capy::run_async(ex,
         [](int result) {
             separate_handlers_result = result;   // the successful value arrives here
         },
@@ -123,12 +98,12 @@ void run_with_separate_handlers_demo( any_executor ex )
 } // namespace ex_3
 namespace ex_4 {
 // tag::example_4[]
-task<void> cancellable_task() { co_return; }
+capy::task<void> cancellable_task() { co_return; }
 
-void run_with_cancellation( any_executor ex )
+void run_with_cancellation( capy::any_executor ex )
 {
     std::stop_source source;
-    run_async(ex, source.get_token())(cancellable_task());
+    capy::run_async(ex, source.get_token())(cancellable_task());
     // Later: source.request_stop();
 }
 // end::example_4[]

--- a/test/doc/reference/run_async_wrapper.record.cpp
+++ b/test/doc/reference/run_async_wrapper.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,39 +27,38 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-task<void> my_task() { co_return; }
+capy::task<void> my_task() { co_return; }
 
-void correct_usage( any_executor ex )
+void correct_usage( capy::any_executor ex )
 {
     // Correct usage - wrapper is temporary, task is the direct argument
-    run_async(ex)(my_task());
+    capy::run_async(ex)(my_task());
 }
 
-void rvalue_only_call( any_executor ex )
+void rvalue_only_call( capy::any_executor ex )
 {
     // Compiles - copy elision constructs w directly from the prvalue
-    auto w = run_async(ex);
+    auto w = capy::run_async(ex);
 
     // Calling on the rvalue is the supported form; calling through
     // the stored lvalue is rejected by the rvalue ref-qualifier.
     using wrapper = decltype(w);
-    static_assert(   std::is_invocable_v< wrapper,  task<void> > );
-    static_assert( ! std::is_invocable_v< wrapper&, task<void> > );
+    static_assert(   std::is_invocable_v< wrapper,  capy::task<void> > );
+    static_assert( ! std::is_invocable_v< wrapper&, capy::task<void> > );
 
     std::move(w)(my_task());  // Compiles: w is now an rvalue
 }
 
-void silent_misuse( any_executor ex )
+void silent_misuse( capy::any_executor ex )
 {
     // Compiles, but WRONG - task frame allocated before run_async runs
     auto t = my_task();
-    run_async(ex)(std::move(t));
+    capy::run_async(ex)(std::move(t));
 }
 // end::example[]
 } // namespace ex_1

--- a/test/doc/reference/strand.record.cpp
+++ b/test/doc/reference/strand.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
@@ -61,10 +36,10 @@ namespace ex_1 {
 // each must outlive its time there. The caller owns c1/c2/c3 --
 // typically as members of the awaitable or operation state that
 // posts them, never as locals that go out of scope while enqueued.
-void post_three(thread_pool& pool,
-    continuation& c1, continuation& c2, continuation& c3)
+void post_three(capy::thread_pool& pool,
+    capy::continuation& c1, capy::continuation& c2, capy::continuation& c3)
 {
-    strand sd(pool.get_executor());  // CTAD deduces the executor type
+    capy::strand sd(pool.get_executor());  // CTAD deduces the executor type
 
     sd.post(c1);
     sd.post(c2);

--- a/test/doc/reference/task.record.cpp
+++ b/test/doc/reference/task.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,13 +27,12 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-task<int> compute_value( any_read_stream& stream, mutable_buffer buf )
+capy::task<int> compute_value( capy::any_read_stream& stream, capy::mutable_buffer buf )
 {
     auto [ec, n] = co_await stream.read_some( buf );
     if( ec )
@@ -65,7 +40,7 @@ task<int> compute_value( any_read_stream& stream, mutable_buffer buf )
     co_return static_cast<int>( n );
 }
 
-task<> run_session( any_read_stream& stream, mutable_buffer buf )
+capy::task<> run_session( capy::any_read_stream& stream, capy::mutable_buffer buf )
 {
     int result = co_await compute_value( stream, buf );
 }

--- a/test/doc/reference/test__buffer_to_string.function.cpp
+++ b/test/doc/reference/test__buffer_to_string.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,31 +30,29 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-task<>
+capy::task<>
 buffer_to_string_examples()
 {
     // Single buffer sequence
-    const_buffer cb( "hello", 5 );
-    BOOST_TEST_EQ( buffer_to_string( cb ), "hello" );
+    capy::const_buffer cb( "hello", 5 );
+    BOOST_TEST_EQ( capy::test::buffer_to_string( cb ), "hello" );
 
     // Multiple buffer sequences (concatenation)
-    const_buffer b1( "hello", 5 );
-    const_buffer b2( " world", 6 );
-    BOOST_TEST_EQ( buffer_to_string( b1, b2 ), "hello world" );
+    capy::const_buffer b1( "hello", 5 );
+    capy::const_buffer b2( " world", 6 );
+    BOOST_TEST_EQ( capy::test::buffer_to_string( b1, b2 ), "hello world" );
 
     // With bufgrind splits: each half is itself a buffer sequence,
     // so pass it directly -- there is no .data() to unwrap.
-    bufgrind bg( cb );
+    capy::test::bufgrind bg( cb );
     while( bg ) {
         auto [h1, h2] = co_await bg.next();
-        BOOST_TEST_EQ( buffer_to_string( h1, h2 ), "hello" );
+        BOOST_TEST_EQ( capy::test::buffer_to_string( h1, h2 ), "hello" );
     }
 }
 // end::example[]

--- a/test/doc/reference/test__bufgrind.record.cpp
+++ b/test/doc/reference/test__bufgrind.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,8 +30,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 
@@ -66,17 +40,17 @@ bufgrind_walk_splits_demo()
 {
     // Test all split points of a buffer
     std::string data = "hello world";
-    auto cb = make_buffer( data );
+    auto cb = capy::make_buffer( data );
 
-    fuse f;
-    auto r = f.inert( [&]( fuse& ) -> task<> {
-        bufgrind bg( cb );
+    capy::test::fuse f;
+    auto r = f.inert( [&]( capy::test::fuse& ) -> capy::task<> {
+        capy::test::bufgrind bg( cb );
         while( bg ) {
             auto [b1, b2] = co_await bg.next();
             // b1 contains first N bytes (as a buffer sequence)
             // b2 contains remaining bytes (as a buffer sequence)
             // concatenating b1 + b2 equals original
-            BOOST_TEST( buffer_to_string( b1, b2 ) == data );
+            BOOST_TEST( capy::test::buffer_to_string( b1, b2 ) == data );
         }
     } );
 }
@@ -87,17 +61,17 @@ namespace ex_2 {
 // tag::example_2[]
 // Mutable buffers preserve mutability
 char data[100];
-mutable_buffer buf( data, sizeof( data ) );
+capy::mutable_buffer buf( data, sizeof( data ) );
 
-task<>
+capy::task<>
 bufgrind_walk_mutable()
 {
-    bufgrind bg( buf );
+    capy::test::bufgrind bg( buf );
     while( bg ) {
         auto [b1, b2] = co_await bg.next();
         // b1, b2 yield mutable_buffer when iterated
-        static_assert( MutableBufferSequence<decltype(b1)> );
-        static_assert( MutableBufferSequence<decltype(b2)> );
+        static_assert( capy::MutableBufferSequence<decltype(b1)> );
+        static_assert( capy::MutableBufferSequence<decltype(b2)> );
     }
 }
 // end::example_2[]
@@ -106,12 +80,12 @@ bufgrind_walk_mutable()
 namespace ex_3 {
 // tag::example_3[]
 // Skip by 10 bytes for faster iteration
-const_buffer bufgrind_step_data( "0123456789ABCDE", 15 );
+capy::const_buffer bufgrind_step_data( "0123456789ABCDE", 15 );
 
-task<>
+capy::task<>
 bufgrind_walk_by_step()
 {
-    bufgrind bg( bufgrind_step_data, 10 );
+    capy::test::bufgrind bg( bufgrind_step_data, 10 );
     while( bg ) {
         auto [b1, b2] = co_await bg.next();
         // Visits positions 0, 10, 20, ..., and always size

--- a/test/doc/reference/test__fuse.record.cpp
+++ b/test/doc/reference/test__fuse.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,8 +30,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 
@@ -63,7 +37,7 @@ namespace ex_1 {
 // tag::example_1[]
 void basic_inline_usage()
 {
-    fuse()([](fuse& f) {
+    capy::test::fuse()([](capy::test::fuse& f) {
         auto ec = f.maybe_fail();
         if(ec)
             return;
@@ -82,8 +56,8 @@ void named_fuse_with_armed()
 {
     struct MyObject
     {
-        fuse& f;
-        explicit MyObject(fuse& f) : f(f) {}
+        capy::test::fuse& f;
+        explicit MyObject(capy::test::fuse& f) : f(f) {}
 
         void do_something()
         {
@@ -93,9 +67,9 @@ void named_fuse_with_armed()
         }
     };
 
-    fuse f;
+    capy::test::fuse f;
     MyObject obj(f);
-    auto r = f.armed([&](fuse&) {
+    auto r = f.armed([&](capy::test::fuse&) {
         obj.do_something();
     });
 }
@@ -106,8 +80,8 @@ namespace ex_3 {
 // tag::example_3[]
 void inert_single_run_test(bool some_condition)
 {
-    fuse f;
-    auto r = f.inert([&](fuse& f) {
+    capy::test::fuse f;
+    auto r = f.inert([&](capy::test::fuse& f) {
         auto ec = f.maybe_fail();  // Always succeeds
         if(some_condition)
             f.fail();  // Only way to signal failure
@@ -122,9 +96,9 @@ void dependency_injection_standalone_usage()
 {
     class MyService
     {
-        fuse& f_;
+        capy::test::fuse& f_;
     public:
-        explicit MyService(fuse& f) : f_(f) {}
+        explicit MyService(capy::test::fuse& f) : f_(f) {}
 
         std::error_code do_work()
         {
@@ -137,12 +111,12 @@ void dependency_injection_standalone_usage()
     };
 
     // Production usage - fuse is no-op
-    fuse f;
+    capy::test::fuse f;
     MyService svc(f);
     svc.do_work();  // maybe_fail() returns {} always
 
     // Test usage - failures are injected
-    auto r = f.armed([&](fuse&) {
+    auto r = f.armed([&](capy::test::fuse&) {
         svc.do_work();  // maybe_fail() triggers failures
     });
 }
@@ -151,10 +125,10 @@ void dependency_injection_standalone_usage()
 
 namespace ex_5 {
 // tag::example_5[]
-auto custom_ec = make_error_code(
+auto custom_ec = std::make_error_code(
     std::errc::operation_canceled);
-fuse f(custom_ec);
-auto r = f.armed([](fuse& f) {
+capy::test::fuse f(custom_ec);
+auto r = f.armed([](capy::test::fuse& f) {
     auto ec = f.maybe_fail();
     if(ec)
         return;
@@ -166,8 +140,8 @@ namespace ex_6 {
 // tag::example_6[]
 void checking_the_result()
 {
-    fuse f;
-    auto r = f([](fuse& f) {
+    capy::test::fuse f;
+    auto r = f([](capy::test::fuse& f) {
         auto ec = f.maybe_fail();
         if(ec)
             return;
@@ -186,8 +160,8 @@ namespace ex_7 {
 // tag::example_7[]
 void test_framework_integration()
 {
-    fuse f;
-    auto r = f([](fuse& f) {
+    capy::test::fuse f;
+    auto r = f([](capy::test::fuse& f) {
         auto ec = f.maybe_fail();
         if(ec)
             return;

--- a/test/doc/reference/test__fuse__armed.function.cpp
+++ b/test/doc/reference/test__fuse__armed.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,8 +30,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 namespace ex_1 {
@@ -67,11 +41,11 @@ namespace ex_1 {
 // particular kind of executor. join() blocks until the posted
 // task and its handlers have finished, so ep is safe to read
 // once it returns.
-std::exception_ptr run_one_iteration(task<> t)
+std::exception_ptr run_one_iteration(capy::task<> t)
 {
-    thread_pool pool(1);
+    capy::thread_pool pool(1);
     std::exception_ptr ep;
-    run_async(pool.get_executor(),
+    capy::run_async(pool.get_executor(),
         [](auto&&...) {},
         [&](std::exception_ptr e) { ep = e; }
     )(std::move(t));
@@ -81,9 +55,9 @@ std::exception_ptr run_one_iteration(task<> t)
 
 void armed_with_custom_runner()
 {
-    fuse f;
+    capy::test::fuse f;
     auto r = f.armed(run_one_iteration,
-        [](fuse& f) -> task<>
+        [](capy::test::fuse& f) -> capy::task<>
         {
             auto ec = f.maybe_fail();
             if(ec)
@@ -97,8 +71,8 @@ namespace ex_2 {
 // tag::example_2[]
 void armed_basic_two_points()
 {
-    fuse f;
-    auto r = f.armed([](fuse& f) {
+    capy::test::fuse f;
+    auto r = f.armed([](capy::test::fuse& f) {
         auto ec = f.maybe_fail();
         if(ec)
             return;
@@ -121,8 +95,8 @@ namespace ex_3 {
 // tag::example_3[]
 void armed_coroutine_two_points()
 {
-    fuse f;
-    auto r = f.armed([&](fuse&) -> task<void> {
+    capy::test::fuse f;
+    auto r = f.armed([&](capy::test::fuse&) -> capy::task<void> {
         auto ec = f.maybe_fail();
         if(ec)
             co_return;

--- a/test/doc/reference/test__fuse__fail.function.cpp
+++ b/test/doc/reference/test__fuse__fail.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,16 +30,14 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 namespace ex_1 {
 // tag::example_1[]
 void fail_on_unmet_condition(int some_value, int expected)
 {
-    fuse f;
-    auto r = f([&](fuse& f) {
+    capy::test::fuse f;
+    auto r = f([&](capy::test::fuse& f) {
         auto ec = f.maybe_fail();
         if(ec)
             return;
@@ -88,8 +62,8 @@ namespace ex_2 {
 // tag::example_2[]
 void fail_captures_exception(void (*do_something)())
 {
-    fuse f;
-    auto r = f([&](fuse& f) {
+    capy::test::fuse f;
+    auto r = f([&](capy::test::fuse& f) {
         try
         {
             do_something();

--- a/test/doc/reference/test__fuse__fuse.function.cpp
+++ b/test/doc/reference/test__fuse__fuse.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,20 +30,18 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 namespace ex_1 {
 // tag::example_1[]
 void custom_error_code()
 {
-    auto custom_ec = make_error_code(
+    auto custom_ec = std::make_error_code(
         std::errc::operation_canceled);
-    fuse f(custom_ec);
+    capy::test::fuse f(custom_ec);
 
     std::error_code captured_ec;
-    auto r = f([&](fuse& f) {
+    auto r = f([&](capy::test::fuse& f) {
         auto ec = f.maybe_fail();
         if(ec)
         {
@@ -86,10 +60,10 @@ namespace ex_2 {
 // tag::example_2[]
 void default_error_code()
 {
-    fuse f;
+    capy::test::fuse f;
     std::error_code captured_ec;
 
-    auto r = f([&](fuse& f) {
+    auto r = f([&](capy::test::fuse& f) {
         auto ec = f.maybe_fail();
         if(ec)
         {
@@ -99,7 +73,7 @@ void default_error_code()
     });
 
     // A default-constructed fuse delivers error::test_failure.
-    BOOST_TEST( captured_ec == error::test_failure );
+    BOOST_TEST( captured_ec == capy::error::test_failure );
 }
 // end::example_2[]
 } // namespace ex_2

--- a/test/doc/reference/test__fuse__inert.function.cpp
+++ b/test/doc/reference/test__fuse__inert.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,16 +30,14 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 namespace ex_1 {
 // tag::example_1[]
 void inert_run_once(bool some_condition)
 {
-    fuse f;
-    auto r = f.inert([&](fuse& f) {
+    capy::test::fuse f;
+    auto r = f.inert([&](capy::test::fuse& f) {
         auto ec = f.maybe_fail();  // Always succeeds
 
         assert(!ec);  // inert() never injects
@@ -88,8 +62,8 @@ namespace ex_2 {
 // tag::example_2[]
 void inert_coroutine_run_once(bool some_condition)
 {
-    fuse f;
-    auto r = f.inert([&](fuse& f) -> task<void> {
+    capy::test::fuse f;
+    auto r = f.inert([&](capy::test::fuse& f) -> capy::task<void> {
         auto ec = f.maybe_fail();  // Always succeeds
 
         assert(!ec);  // inert() never injects

--- a/test/doc/reference/test__fuse__maybe_fail.function.cpp
+++ b/test/doc/reference/test__fuse__maybe_fail.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,15 +30,13 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 
 namespace ex_1 {
 // tag::example_1[]
-fuse f;
-auto r = f([](fuse& f) {
+capy::test::fuse f;
+auto r = f([](capy::test::fuse& f) {
     // Error code mode: returns the error
     auto ec = f.maybe_fail();
     if(ec)
@@ -78,7 +52,7 @@ auto r = f([](fuse& f) {
 
 namespace ex_2 {
 // tag::example_2[]
-fuse f;
+capy::test::fuse f;
 auto ec = f.maybe_fail();  // Always returns {} (no-op)
 // end::example_2[]
 } // namespace ex_2

--- a/test/doc/reference/test__fuse__operator_.function.cpp
+++ b/test/doc/reference/test__fuse__operator_.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,8 +30,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 
@@ -64,20 +38,20 @@ namespace ex_1 {
 void call_operator_is_armed_alias()
 {
     // These are equivalent:
-    fuse f;
-    auto r1 = f.armed([](fuse& f) {
+    capy::test::fuse f;
+    auto r1 = f.armed([](capy::test::fuse& f) {
         auto ec = f.maybe_fail();
         if(ec)
             return;
     });
-    auto r2 = f([](fuse& f) {
+    auto r2 = f([](capy::test::fuse& f) {
         auto ec = f.maybe_fail();
         if(ec)
             return;
     });
 
     // Inline usage:
-    auto r3 = fuse()([](fuse& f) {
+    auto r3 = capy::test::fuse()([](capy::test::fuse& f) {
         auto ec = f.maybe_fail();
         if(ec)
             return;

--- a/test/doc/reference/test__fuse__result.record.cpp
+++ b/test/doc/reference/test__fuse__result.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,8 +30,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 
@@ -63,8 +37,8 @@ namespace ex_1 {
 // tag::example[]
 void inspecting_the_captured_exception()
 {
-    fuse f;
-    auto r = f([](fuse& f) {
+    capy::test::fuse f;
+    auto r = f([](capy::test::fuse& f) {
         try
         {
             throw std::exception();

--- a/test/doc/reference/test__read_stream.record.cpp
+++ b/test/doc/reference/test__read_stream.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,8 +30,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 
@@ -64,20 +38,20 @@ namespace ex_1 {
 void
 read_stream_armed_demo()
 {
-    fuse f;
+    capy::test::fuse f;
 
-    auto r = f.armed( [&]( fuse& ) -> task<void> {
+    auto r = f.armed( [&]( capy::test::fuse& ) -> capy::task<void> {
         // Constructed inside the lambda: armed() re-invokes this
         // function once per injected failure point, and a
         // read_stream constructed outside would carry a stale
         // read position across those rounds.
-        read_stream rs( f );
+        capy::test::read_stream rs( f );
         rs.provide( "Hello, " );
         rs.provide( "World!" );
 
         char buf[32];
         auto [ec, n] = co_await rs.read_some(
-            mutable_buffer( buf, sizeof( buf ) ) );
+            capy::mutable_buffer( buf, sizeof( buf ) ) );
         if( ec )
             co_return;
         // buf contains "Hello, World!"

--- a/test/doc/reference/test__run_blocking.function.cpp
+++ b/test/doc/reference/test__run_blocking.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,13 +30,11 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 namespace ex_1 {
 // tag::example_1[]
-task<int>
+capy::task<int>
 compute_example_2()
 {
     co_return 7;
@@ -70,7 +44,7 @@ void
 run_blocking_two_handler_demo()
 {
     int result = 0;
-    run_blocking(
+    capy::test::run_blocking(
         [&](int v) { result = v; },
         [](std::exception_ptr ep) { std::rethrow_exception( ep ); }
     )( compute_example_2() );
@@ -80,7 +54,7 @@ run_blocking_two_handler_demo()
 
 namespace ex_2 {
 // tag::example_2[]
-task<>
+capy::task<>
 run_blocking_void_example()
 {
     co_return;
@@ -89,14 +63,14 @@ run_blocking_void_example()
 void
 run_blocking_no_handler_demo()
 {
-    run_blocking()( run_blocking_void_example() );
+    capy::test::run_blocking()( run_blocking_void_example() );
 }
 // end::example_2[]
 } // namespace ex_2
 
 namespace ex_3 {
 // tag::example_3[]
-task<int>
+capy::task<int>
 compute_example()
 {
     co_return 42;
@@ -106,7 +80,7 @@ void
 run_blocking_h1_demo()
 {
     int result = 0;
-    run_blocking( [&](int v) { result = v; } )(
+    capy::test::run_blocking( [&](int v) { result = v; } )(
         compute_example() );
     BOOST_TEST_EQ( result, 42 );
 }

--- a/test/doc/reference/test__stream.record.cpp
+++ b/test/doc/reference/test__stream.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,8 +30,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 
@@ -64,23 +38,23 @@ namespace ex_1 {
 void
 stream_pair_armed_demo()
 {
-    fuse f;
+    capy::test::fuse f;
 
-    auto r = f.armed( [&]( fuse& ) -> task<> {
+    auto r = f.armed( [&]( capy::test::fuse& ) -> capy::task<> {
         // Constructed inside the lambda: armed() re-invokes this
         // function once per injected failure point, and a stream
         // pair constructed outside would carry buffered state
         // across those rounds.
-        auto [a, b] = make_stream_pair( f );
+        auto [a, b] = capy::test::make_stream_pair( f );
 
         auto [ec, n] = co_await a.write_some(
-            const_buffer( "hello", 5 ) );
+            capy::const_buffer( "hello", 5 ) );
         if( ec )
             co_return;
 
         char buf[32];
         auto [ec2, n2] = co_await b.read_some(
-            mutable_buffer( buf, sizeof( buf ) ) );
+            capy::mutable_buffer( buf, sizeof( buf ) ) );
         if( ec2 )
             co_return;
         // buf contains "hello"

--- a/test/doc/reference/test__write_stream.record.cpp
+++ b/test/doc/reference/test__write_stream.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 #include <boost/capy/test.hpp>
@@ -54,8 +30,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
-using namespace boost::capy::test;
 
 namespace {
 
@@ -64,17 +38,17 @@ namespace ex_1 {
 void
 write_stream_armed_demo()
 {
-    fuse f;
+    capy::test::fuse f;
 
-    auto r = f.armed( [&]( fuse& ) -> task<void> {
+    auto r = f.armed( [&]( capy::test::fuse& ) -> capy::task<void> {
         // Constructed inside the lambda: armed() re-invokes this
         // function once per injected failure point, and a
         // write_stream constructed outside would carry
         // accumulated data across those rounds.
-        write_stream ws( f );
+        capy::test::write_stream ws( f );
 
         auto [ec, n] = co_await ws.write_some(
-            const_buffer( "Hello", 5 ) );
+            capy::const_buffer( "Hello", 5 ) );
         if( ec )
             co_return;
         // ws.data() returns "Hello"

--- a/test/doc/reference/this_coro.namespace.cpp
+++ b/test/doc/reference/this_coro.namespace.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,18 +27,17 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-task<void> example()
+capy::task<void> example()
 {
-    auto* env = co_await this_coro::environment;
-    auto ex = co_await this_coro::executor;
-    auto token = co_await this_coro::stop_token;
-    auto* alloc = co_await this_coro::frame_allocator;
+    auto* env = co_await capy::this_coro::environment;
+    auto ex = co_await capy::this_coro::executor;
+    auto token = co_await capy::this_coro::stop_token;
+    auto* alloc = co_await capy::this_coro::frame_allocator;
 }
 // end::example[]
 } // namespace ex_1

--- a/test/doc/reference/this_coro__environment.variable.cpp
+++ b/test/doc/reference/this_coro__environment.variable.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,15 +27,14 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-task<void> example()
+capy::task<void> example()
 {
-    auto* env = co_await this_coro::environment;
+    auto* env = co_await capy::this_coro::environment;
     // env->executor - the executor this coroutine is bound to
     // env->stop_token - the stop token for cancellation
     // env->frame_allocator - the frame allocator

--- a/test/doc/reference/this_coro__executor.variable.cpp
+++ b/test/doc/reference/this_coro__executor.variable.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,15 +27,14 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-task<void> example()
+capy::task<void> example()
 {
-    executor_ref ex = co_await this_coro::executor;
+    capy::executor_ref ex = co_await capy::this_coro::executor;
 }
 // end::example[]
 } // namespace ex_1

--- a/test/doc/reference/this_coro__frame_allocator.variable.cpp
+++ b/test/doc/reference/this_coro__frame_allocator.variable.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,15 +27,14 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-task<void> example()
+capy::task<void> example()
 {
-    auto* alloc = co_await this_coro::frame_allocator;
+    auto* alloc = co_await capy::this_coro::frame_allocator;
     // alloc is nullptr when using the default allocator
 }
 // end::example[]

--- a/test/doc/reference/this_coro__stop_token.variable.cpp
+++ b/test/doc/reference/this_coro__stop_token.variable.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,15 +27,14 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-task<void> cancellable_work()
+capy::task<void> cancellable_work()
 {
-    auto token = co_await this_coro::stop_token;
+    auto token = co_await capy::this_coro::stop_token;
     if (token.stop_requested())
         co_return;
 }

--- a/test/doc/reference/thread_pool.record.cpp
+++ b/test/doc/reference/thread_pool.record.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,19 +27,18 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 
 namespace ex_1 {
 // tag::example[]
-task<void> some_task() { co_return; }
+capy::task<void> some_task() { co_return; }
 
 void run_on_pool()
 {
-    thread_pool pool(4);  // 4 worker threads
+    capy::thread_pool pool(4);  // 4 worker threads
     auto ex = pool.get_executor();
-    run_async(ex)(some_task());  // start work; tracked so join() waits for it
+    capy::run_async(ex)(some_task());  // start work; tracked so join() waits for it
     pool.join();  // wait for outstanding work to complete
     // pool destructor stops the pool, discarding any pending work
 }

--- a/test/doc/reference/when_all.function.cpp
+++ b/test/doc/reference/when_all.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,26 +27,25 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 namespace ex_1 {
 // tag::example_1[]
-io_task<std::size_t> read_one( any_read_stream& stream, mutable_buffer buf )
+capy::io_task<std::size_t> read_one( capy::any_read_stream& stream, capy::mutable_buffer buf )
 {
     co_return co_await stream.read_some(buf);
 }
 
-task<void> read_all_connections(
-    std::vector<any_read_stream>& streams, std::vector<mutable_buffer>& buffers )
+capy::task<void> read_all_connections(
+    std::vector<capy::any_read_stream>& streams, std::vector<capy::mutable_buffer>& buffers )
 {
     // One awaitable per stream: each stream is touched by exactly one
     // child, so running them concurrently is safe.
-    std::vector<io_task<std::size_t>> reads;
+    std::vector<capy::io_task<std::size_t>> reads;
     for (std::size_t i = 0; i < streams.size(); ++i)
         reads.push_back(read_one(streams[i], buffers[i]));
 
-    auto [ec, counts] = co_await when_all(std::move(reads));
+    auto [ec, counts] = co_await capy::when_all(std::move(reads));
     if (ec)
     {
         // handle error
@@ -81,13 +56,13 @@ task<void> read_all_connections(
 namespace ex_2 {
 // tag::example_2[]
 template< class MakeJob >
-task<void> run_n_jobs( MakeJob make_job, int n )
+capy::task<void> run_n_jobs( MakeJob make_job, int n )
 {
-    std::vector<io_task<>> jobs;
+    std::vector<capy::io_task<>> jobs;
     for (int i = 0; i < n; ++i)
         jobs.push_back(make_job(i));  // io_task<> per index
 
-    auto [ec] = co_await when_all(std::move(jobs));
+    auto [ec] = co_await capy::when_all(std::move(jobs));
 }
 // end::example_2[]
 } // namespace ex_2

--- a/test/doc/reference/when_any.function.cpp
+++ b/test/doc/reference/when_any.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,26 +27,25 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 namespace ex_1 {
 // tag::example_1[]
-io_task<std::size_t> read_from( any_read_stream& stream, mutable_buffer buf )
+capy::io_task<std::size_t> read_from( capy::any_read_stream& stream, capy::mutable_buffer buf )
 {
     co_return co_await stream.read_some(buf);
 }
 
-task<void> read_first_ready(
-    std::vector<any_read_stream>& streams, std::vector<mutable_buffer>& buffers )
+capy::task<void> read_first_ready(
+    std::vector<capy::any_read_stream>& streams, std::vector<capy::mutable_buffer>& buffers )
 {
     // One awaitable per stream: each stream is touched by exactly one
     // child, so racing them concurrently is safe.
-    std::vector<io_task<std::size_t>> reads;
+    std::vector<capy::io_task<std::size_t>> reads;
     for (std::size_t i = 0; i < streams.size(); ++i)
         reads.push_back(read_from(streams[i], buffers[i]));
 
-    auto result = co_await when_any(std::move(reads));
+    auto result = co_await capy::when_any(std::move(reads));
     if (result.index() == 1)
     {
         auto [idx, n] = std::get<1>(result);  // winning stream's slot and byte count
@@ -80,23 +55,23 @@ task<void> read_first_ready(
 } // namespace ex_1
 namespace ex_2 {
 // tag::example_2[]
-io_task<> background_work_a()
+capy::io_task<> background_work_a()
 {
     co_return {};
 }
 
-io_task<> background_work_b()
+capy::io_task<> background_work_b()
 {
     co_return {};
 }
 
-task<void> example()
+capy::task<void> example()
 {
-    std::vector<io_task<>> jobs;
+    std::vector<capy::io_task<>> jobs;
     jobs.push_back(background_work_a());
     jobs.push_back(background_work_b());
 
-    auto result = co_await when_any(std::move(jobs));
+    auto result = co_await capy::when_any(std::move(jobs));
     if (result.index() == 1)
     {
         auto winner = std::get<1>(result);  // index of the job that succeeded first

--- a/test/doc/reference/work_guard.record.cpp
+++ b/test/doc/reference/work_guard.record.cpp
@@ -11,16 +11,10 @@
 // documentation by doc/addons/extensions/reference-snippets.lua. The tagged
 // region is what the reference renders; scaffolding stays outside the tags.
 
-// Examples deliberately leave results unused; the reference explains the
-// values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-function"
-#endif
+#include "../doc_warnings.hpp"
+
+// This example defines a helper that nothing calls; MSVC reports the removal.
 #if defined(_MSC_VER)
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4101) // unreferenced local variable
 #pragma warning(disable: 4505) // unreferenced local function removed
 #endif
 
@@ -31,17 +25,16 @@ namespace capy = boost::capy;
 
 namespace {
 
-using namespace boost::capy;
 
 // tag::work_guard[]
 void keep_alive_while_setting_up()
 {
-    thread_pool pool(1);
+    capy::thread_pool pool(1);
 
     // Keep the pool from completing while we set things up. Note
     // make_work_guard() takes the Executor from get_executor(), not
     // the thread_pool context itself.
-    auto guard = make_work_guard(pool.get_executor());
+    auto guard = capy::make_work_guard(pool.get_executor());
 
     // ... post work to pool ...
 

--- a/test/doc/reference/write.function.cpp
+++ b/test/doc/reference/write.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 

--- a/test/doc/reference/write_at_least.function.cpp
+++ b/test/doc/reference/write_at_least.function.cpp
@@ -15,31 +15,7 @@
 // suppressions and namespaces around them are scaffolding. Each region gets
 // its own namespace so that examples which reuse a name still compile.
 
-// Examples leave results unused; the reference explains them in prose.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy.hpp>
 
@@ -51,7 +27,6 @@
 #include <vector>
 
 namespace capy = boost::capy;
-using namespace boost::capy;
 
 namespace {
 

--- a/test/doc/snippets/2a_foundations.cpp
+++ b/test/doc/snippets/2a_foundations.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,32 +11,7 @@
 // Compiled fragments shown in pages/2.cpp20-coroutines/2a.foundations.adoc.
 // Pages include the tagged regions; scaffolding stays outside the tags.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/task.hpp>
 #include <boost/capy/ex/run_async.hpp>
@@ -165,10 +141,8 @@ database_t database;
 parsed_request parse_request(std::string const&) { return {1}; }
 std::string compute_response(std::string const&) { return "response"; }
 
-using capy::task;
-
 // tag::coroutine_request[]
-task<void> handle_request(connection& conn)
+capy::task<void> handle_request(connection& conn)
 {
     std::string request = co_await conn.async_read();
     auto parsed = parse_request(request);

--- a/test/doc/snippets/2b_syntax.cpp
+++ b/test/doc/snippets/2b_syntax.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,32 +11,7 @@
 // Compiled fragments shown in pages/2.cpp20-coroutines/2b.syntax.adoc.
 // Pages include the tagged regions; scaffolding stays outside the tags.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/task.hpp>
 #include <boost/capy/ex/run_async.hpp>
@@ -56,20 +32,18 @@ namespace capy = boost::capy;
 
 namespace {
 
-using capy::task;
-
 struct http_response
 {
     std::string body;
 };
 
-task<http_response> http_get(std::string)
+capy::task<http_response> http_get(std::string)
 {
     co_return http_response{"<html></html>"};
 }
 
 // tag::co_await_example[]
-task<std::string> fetch_page(std::string url)
+capy::task<std::string> fetch_page(std::string url)
 {
     auto response = co_await http_get(url);  // suspends until HTTP completes
     co_return response.body;                 // continues after resumption
@@ -127,7 +101,7 @@ generator<int> count_to(int n)
 // end::co_yield_example[]
 
 // tag::co_return_example[]
-task<int> compute()
+capy::task<int> compute()
 {
     int result = 42;
     co_return result;  // completes the coroutine with value 42

--- a/test/doc/snippets/2c_machinery.cpp
+++ b/test/doc/snippets/2c_machinery.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,32 +11,7 @@
 // Compiled fragments shown in pages/2.cpp20-coroutines/2c.machinery.adoc.
 // Declaration-only scaffolding; compiling is the test.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <coroutine>
 

--- a/test/doc/snippets/2d_advanced.cpp
+++ b/test/doc/snippets/2d_advanced.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,32 +11,7 @@
 // Compiled fragments shown in pages/2.cpp20-coroutines/2d.advanced.adoc.
 // Pages include the tagged regions; scaffolding stays outside the tags.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/task.hpp>
 #include <boost/capy/ex/run_async.hpp>
@@ -171,15 +147,13 @@ namespace capy = boost::capy;
 
 namespace {
 
-using capy::task;
-
-task<> b();
-task<> c();
+capy::task<> b();
+capy::task<> c();
 
 // tag::task_chain[]
-task<> a() { co_await b(); }
-task<> b() { co_await c(); }
-task<> c() { co_return; }
+capy::task<> a() { co_await b(); }
+capy::task<> b() { co_await c(); }
+capy::task<> c() { co_return; }
 // end::task_chain[]
 
 // Awaiter scaffolding for the symmetric-transfer fragment
@@ -235,14 +209,14 @@ struct promise_type
 
 } // namespace symmetric_generator
 
-task<void> compute_something()
+capy::task<void> compute_something()
 {
     co_return;
 }
 
-void store_for_later(task<void>) {}
+void store_for_later(capy::task<void>) {}
 
-[[maybe_unused]] task<void> halo_demo()
+[[maybe_unused]] capy::task<void> halo_demo()
 {
     // tag::halo[]
     // HALO might apply here because the task is awaited immediately

--- a/test/doc/snippets/3a_foundations.cpp
+++ b/test/doc/snippets/3a_foundations.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/3.concurrency/3a.foundations.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <atomic>
 #include <thread>

--- a/test/doc/snippets/3b_synchronization.cpp
+++ b/test/doc/snippets/3b_synchronization.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/3.concurrency/3b.synchronization.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <iostream>
 #include <mutex>

--- a/test/doc/snippets/3c_advanced.cpp
+++ b/test/doc/snippets/3c_advanced.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/3.concurrency/3c.advanced.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 // tag::shared_mutex[]
 #include <iostream>

--- a/test/doc/snippets/3d_patterns.cpp
+++ b/test/doc/snippets/3d_patterns.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/3.concurrency/3d.patterns.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 // tag::thread_safe_queue[]
 #include <iostream>

--- a/test/doc/snippets/4a_tasks.cpp
+++ b/test/doc/snippets/4a_tasks.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,35 +11,7 @@
 // Compiled fragments shown in pages/4.coroutines/4a.tasks.adoc. Pages
 // include the tagged regions; scaffolding stays outside the tags.
 
-// Fragments deliberately leave named results unused; page comments
-// explain the values instead.
-
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 // tag::include_task[]
 #include <boost/capy/task.hpp>
@@ -56,12 +29,12 @@
 #include "test_suite.hpp"
 
 // The page's first fragment introduces the umbrella include and the
-// using-directive that later fragments rely on for unqualified names.
+// namespace alias that later fragments rely on for capy:: qualification.
 // tag::declaring[]
 // tag::include_umbrella[]
 #include <boost/capy.hpp>
 // end::include_umbrella[]
-using namespace boost::capy;
+namespace capy = boost::capy;
 // end::declaring[]
 
 namespace {
@@ -70,17 +43,17 @@ namespace declaring {
 
 // tag::declaring[]
 
-task<int> compute_value()
+capy::task<int> compute_value()
 {
     co_return 42;
 }
 
-task<std::string> fetch_greeting()
+capy::task<std::string> fetch_greeting()
 {
     co_return "Hello, Capy!";
 }
 
-task<> do_nothing()  // task<void>
+capy::task<> do_nothing()  // task<void>
 {
     co_return;
 }
@@ -91,13 +64,13 @@ task<> do_nothing()  // task<void>
 namespace returning {
 
 // tag::returning[]
-task<int> add(int a, int b)
+capy::task<int> add(int a, int b)
 {
     int result = a + b;
     co_return result;  // Completes with value
 }
 
-task<> log_message(std::string msg)
+capy::task<> log_message(std::string msg)
 {
     std::cout << msg << "\n";
     co_return;  // Completes without value
@@ -112,22 +85,22 @@ namespace io_results {
 // io_result<Ts...> holds an error code `ec` plus zero or more payload
 // values. io_task<Ts...> is just an alias for task<io_result<Ts...>>.
 
-io_task<> ensure_ready(bool ready)
+capy::io_task<> ensure_ready(bool ready)
 {
     if(! ready)
-        co_return make_error_code(std::errc::not_connected);  // ec converts
+        co_return std::make_error_code(std::errc::not_connected);  // ec converts
     co_return {};                                             // success
 }
 
-io_task<std::size_t> count_ready(bool ready)
+capy::io_task<std::size_t> count_ready(bool ready)
 {
-    using result = io_result<std::size_t>;
+    using result = capy::io_result<std::size_t>;
     if(! ready)
-        co_return result{make_error_code(std::errc::not_connected), 0};
+        co_return result{std::make_error_code(std::errc::not_connected), 0};
     co_return result{std::error_code(), 42};  // success, carrying a value
 }
 
-task<> use_them()
+capy::task<> use_them()
 {
     // io_result models the tuple protocol: ec first, then the payloads.
     auto [ec, n] = co_await count_ready(true);
@@ -142,17 +115,17 @@ task<> use_them()
 namespace awaiting {
 
 // tag::awaiting[]
-task<int> step_one()
+capy::task<int> step_one()
 {
     co_return 10;
 }
 
-task<int> step_two(int x)
+capy::task<int> step_two(int x)
 {
     co_return x * 2;
 }
 
-task<int> full_operation()
+capy::task<int> full_operation()
 {
     int a = co_await step_one();  // Suspends until step_one completes
     int b = co_await step_two(a); // Suspends until step_two completes
@@ -165,13 +138,13 @@ task<int> full_operation()
 namespace lazy {
 
 // tag::lazy[]
-task<int> compute()
+capy::task<int> compute()
 {
     std::cout << "Computing...\n";  // Not printed until awaited
     co_return 42;
 }
 
-task<> example()
+capy::task<> example()
 {
     auto t = compute();   // Task created, but "Computing..." NOT printed yet
     std::cout << "Task created\n";
@@ -185,13 +158,13 @@ task<> example()
 
 namespace symmetric {
 
-task<> b();
-task<> c();
+capy::task<> b();
+capy::task<> c();
 
 // tag::chain[]
-task<> a() { co_await b(); }
-task<> b() { co_await c(); }
-task<> c() { co_return; }
+capy::task<> a() { co_await b(); }
+capy::task<> b() { co_await c(); }
+capy::task<> c() { co_return; }
 // end::chain[]
 
 } // namespace symmetric
@@ -213,9 +186,9 @@ struct final_suspend_sketch
 namespace moving {
 
 // tag::move_only[]
-task<int> compute();
+capy::task<int> compute();
 
-task<> example()
+capy::task<> example()
 {
     auto t1 = compute();
     auto t2 = std::move(t1);  // OK: ownership transferred, t1 is now empty
@@ -226,7 +199,7 @@ task<> example()
 }
 // end::move_only[]
 
-task<int> compute()
+capy::task<int> compute()
 {
     co_return 42;
 }
@@ -236,14 +209,14 @@ task<int> compute()
 namespace exceptions {
 
 // tag::exceptions[]
-task<int> might_fail(bool should_fail)
+capy::task<int> might_fail(bool should_fail)
 {
     if (should_fail)
         throw std::runtime_error("Operation failed");
     co_return 42;
 }
 
-task<> example()
+capy::task<> example()
 {
     try
     {
@@ -263,14 +236,15 @@ struct tasks_test
     void
     testDeclaring()
     {
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         int value = 0;
         std::string greeting;
-        run_async(pool.get_executor(), [&](int v) { value = v; })(
+        capy::run_async(pool.get_executor(), [&](int v) { value = v; })(
             declaring::compute_value());
-        run_async(pool.get_executor(), [&](std::string s) { greeting = s; })(
+        capy::run_async(
+            pool.get_executor(), [&](std::string s) { greeting = s; })(
             declaring::fetch_greeting());
-        run_async(pool.get_executor())(declaring::do_nothing());
+        capy::run_async(pool.get_executor())(declaring::do_nothing());
         pool.join();
         BOOST_TEST(value == 42);
         BOOST_TEST(greeting == "Hello, Capy!");
@@ -279,11 +253,12 @@ struct tasks_test
     void
     testReturning()
     {
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         int sum = 0;
-        run_async(pool.get_executor(), [&](int r) { sum = r; })(
+        capy::run_async(pool.get_executor(), [&](int r) { sum = r; })(
             returning::add(2, 3));
-        run_async(pool.get_executor())(returning::log_message("logged"));
+        capy::run_async(pool.get_executor())(
+            returning::log_message("logged"));
         pool.join();
         BOOST_TEST(sum == 5);
     }
@@ -294,11 +269,11 @@ struct tasks_test
         using returning::add;
         // tag::run[]
         // You have a task; run it on an executor and observe its result.
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         auto ex = pool.get_executor();
 
         int total = 0;
-        run_async(ex, [&](int result) {
+        capy::run_async(ex, [&](int result) {
             std::cout << "Result: " << result << "\n";  // prints 5
             total = result;
         })(add(2, 3));
@@ -311,9 +286,9 @@ struct tasks_test
     void
     testAwaiting()
     {
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         int result = 0;
-        run_async(pool.get_executor(), [&](int r) { result = r; })(
+        capy::run_async(pool.get_executor(), [&](int r) { result = r; })(
             awaiting::full_operation());
         pool.join();
         BOOST_TEST(result == 25);
@@ -322,32 +297,32 @@ struct tasks_test
     void
     testLazy()
     {
-        thread_pool pool(1);
-        run_async(pool.get_executor())(lazy::example());
+        capy::thread_pool pool(1);
+        capy::run_async(pool.get_executor())(lazy::example());
         pool.join();
     }
 
     void
     testChain()
     {
-        thread_pool pool(1);
-        run_async(pool.get_executor())(symmetric::a());
+        capy::thread_pool pool(1);
+        capy::run_async(pool.get_executor())(symmetric::a());
         pool.join();
     }
 
     void
     testMoveOnly()
     {
-        thread_pool pool(1);
-        run_async(pool.get_executor())(moving::example());
+        capy::thread_pool pool(1);
+        capy::run_async(pool.get_executor())(moving::example());
         pool.join();
     }
 
     void
     testExceptions()
     {
-        thread_pool pool(1);
-        run_async(pool.get_executor())(exceptions::example());
+        capy::thread_pool pool(1);
+        capy::run_async(pool.get_executor())(exceptions::example());
         pool.join();
     }
 

--- a/test/doc/snippets/4b_launching.cpp
+++ b/test/doc/snippets/4b_launching.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,32 +11,7 @@
 // Compiled fragments shown in pages/4.coroutines/4b.launching.adoc. Pages
 // include the tagged regions; scaffolding stays outside the tags.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/task.hpp>
 #include <boost/capy/ex/run.hpp>
@@ -51,29 +27,28 @@
 
 #include "test_suite.hpp"
 
+namespace capy = boost::capy;
+
 namespace {
 
-// The page teaches with unqualified names after its opening program
-// shows `using namespace boost::capy;`.
-using namespace boost::capy;
-
-task<int> compute()
+capy::task<int> compute()
 {
     co_return 42;
 }
 
-task<int> expensive_computation()
+capy::task<int> expensive_computation()
 {
     co_return 6 * 7;
 }
 
 // tag::run_hop[]
-task<int> compute_on_pool(thread_pool& pool)
+capy::task<int> compute_on_pool(capy::thread_pool& pool)
 {
     // This task runs on whatever executor we're already on
 
     // But this child task runs on the pool's executor:
-    int result = co_await run(pool.get_executor())(expensive_computation());
+    int result = co_await capy::run(pool.get_executor())(
+        expensive_computation());
 
     // After co_await, we're back on our original executor
     co_return result;
@@ -82,9 +57,9 @@ task<int> compute_on_pool(thread_pool& pool)
 
 std::atomic<bool> cancellable_saw_token{false};
 
-task<void> cancellable_task()
+capy::task<void> cancellable_task()
 {
-    auto token = co_await this_coro::stop_token;
+    auto token = co_await capy::this_coro::stop_token;
     cancellable_saw_token = token.stop_possible();
 }
 
@@ -101,41 +76,42 @@ void update_shared_state(int value)
 // in scope, and the child records what its stop token observed.
 struct inherit_fixture
 {
-    thread_pool pool{1};
+    capy::thread_pool pool{1};
     bool child_saw_stop = false;
 
-    task<void> child_task()
+    capy::task<void> child_task()
     {
-        auto token = co_await this_coro::stop_token;
+        auto token = co_await capy::this_coro::stop_token;
         child_saw_stop = token.stop_requested();
     }
 
     // tag::inherit_token[]
-    task<void> parent()
+    capy::task<void> parent()
     {
         // Child automatically receives our stop token
-        co_await run(pool.get_executor())(child_task());
+        co_await capy::run(pool.get_executor())(child_task());
     }
     // end::inherit_token[]
 };
 
 struct override_fixture
 {
-    thread_pool pool{1};
+    capy::thread_pool pool{1};
     bool child_saw_stop = true;
 
-    task<void> child_task()
+    capy::task<void> child_task()
     {
-        auto token = co_await this_coro::stop_token;
+        auto token = co_await capy::this_coro::stop_token;
         child_saw_stop = token.stop_requested();
     }
 
     // tag::override_token[]
-    task<void> parent()
+    capy::task<void> parent()
     {
         std::stop_source local;
         // Child gets local's token, not our caller's
-        co_await run(pool.get_executor(), local.get_token())(child_task());
+        co_await capy::run(
+            pool.get_executor(), local.get_token())(child_task());
     }
     // end::override_token[]
 };
@@ -145,16 +121,16 @@ struct launching_test
     void
     testHandlerOverloads()
     {
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         auto ex = pool.get_executor();
         // tag::handlers[]
         // Result handler only (an unhandled exception calls std::terminate)
-        run_async(ex, [](int result) {
+        capy::run_async(ex, [](int result) {
             std::cout << "Got: " << result << "\n";
         })(compute());
 
         // Separate handlers for result and exception
-        run_async(ex,
+        capy::run_async(ex,
             [](int result) { std::cout << "Result: " << result << "\n"; },
             [](std::exception_ptr ep) {
                 try { std::rethrow_exception(ep); }
@@ -170,10 +146,11 @@ struct launching_test
     void
     testRunHop()
     {
-        thread_pool launch_pool(1);
-        thread_pool work_pool(1);
+        capy::thread_pool launch_pool(1);
+        capy::thread_pool work_pool(1);
         int result = 0;
-        run_async(launch_pool.get_executor(), [&](int r) { result = r; })(
+        capy::run_async(
+            launch_pool.get_executor(), [&](int r) { result = r; })(
             compute_on_pool(work_pool));
         launch_pool.join();
         BOOST_TEST(result == 42);
@@ -183,11 +160,11 @@ struct launching_test
     void
     testInjectToken()
     {
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         auto ex = pool.get_executor();
         // tag::inject_token[]
         std::stop_source source;
-        run_async(ex, source.get_token())(cancellable_task());
+        capy::run_async(ex, source.get_token())(cancellable_task());
 
         // Later, to request cancellation:
         source.request_stop();
@@ -199,12 +176,12 @@ struct launching_test
     void
     testInheritToken()
     {
-        thread_pool launch_pool(1);
+        capy::thread_pool launch_pool(1);
         inherit_fixture fx;
         // A pre-stopped source makes inheritance observable in the child
         std::stop_source source;
         source.request_stop();
-        run_async(launch_pool.get_executor(), source.get_token())(
+        capy::run_async(launch_pool.get_executor(), source.get_token())(
             fx.parent());
         launch_pool.join();
         BOOST_TEST(fx.child_saw_stop);
@@ -214,13 +191,13 @@ struct launching_test
     void
     testOverrideToken()
     {
-        thread_pool launch_pool(1);
+        capy::thread_pool launch_pool(1);
         override_fixture fx;
         // The caller's token is stopped, but the child sees the fresh
         // local token instead
         std::stop_source source;
         source.request_stop();
-        run_async(launch_pool.get_executor(), source.get_token())(
+        capy::run_async(launch_pool.get_executor(), source.get_token())(
             fx.parent());
         launch_pool.join();
         BOOST_TEST(!fx.child_saw_stop);
@@ -230,10 +207,10 @@ struct launching_test
     void
     testHandlerThreading()
     {
-        thread_pool pool(4);
+        capy::thread_pool pool(4);
         // tag::handler_thread[]
         // If pool has 4 threads, the handler runs on one of those threads
-        run_async(pool.get_executor(), [](int result) {
+        capy::run_async(pool.get_executor(), [](int result) {
             // This runs on a pool thread, NOT the main thread
             update_shared_state(result);
         })(compute());

--- a/test/doc/snippets/4c_executors.cpp
+++ b/test/doc/snippets/4c_executors.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/4.coroutines/4c.executors.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/continuation.hpp>
 #include <boost/capy/ex/execution_context.hpp>
@@ -51,9 +27,10 @@
 
 #include "test_suite.hpp"
 
+namespace capy = boost::capy;
+
 namespace {
 
-using namespace boost::capy;
 
 struct request {};
 struct response {};
@@ -64,12 +41,12 @@ struct connection
 {
     struct { int requests = 0; } stats;
 
-    task<request> read() { co_return request{}; }
-    task<void> write(response) { co_return; }
+    capy::task<request> read() { co_return request{}; }
+    capy::task<void> write(response) { co_return; }
 };
 
 // tag::handle_client[]
-task<void> handle_client(connection& conn)
+capy::task<void> handle_client(connection& conn)
 {
     auto req = co_await conn.read();
     auto resp = process(req);
@@ -81,7 +58,7 @@ task<void> handle_client(connection& conn)
 struct my_executor;
 
 // tag::my_context[]
-class my_context : public execution_context
+class my_context : public capy::execution_context
 {
 public:
     // ... custom implementation
@@ -93,23 +70,23 @@ public:
 // tag::shared_resource[]
 class shared_resource
 {
-    strand<thread_pool::executor_type> strand_;
+    capy::strand<capy::thread_pool::executor_type> strand_;
     int counter_ = 0;
 
 public:
-    explicit shared_resource(thread_pool& pool)
+    explicit shared_resource(capy::thread_pool& pool)
         : strand_(pool.get_executor())
     {
     }
 
-    task<int> increment()
+    capy::task<int> increment()
     {
         // All increments are serialized through the strand
-        co_return co_await run(strand_)(do_increment());
+        co_return co_await capy::run(strand_)(do_increment());
     }
 
 private:
-    task<int> do_increment()
+    capy::task<int> do_increment()
     {
         // No mutex needed—strand ensures exclusive access
         ++counter_;
@@ -118,7 +95,7 @@ private:
 };
 // end::shared_resource[]
 
-task<int> independent_task(int i)
+capy::task<int> independent_task(int i)
 {
     co_return i;
 }
@@ -127,19 +104,19 @@ struct executors_test
 {
     void testHandleClient()
     {
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         connection conn;
-        run_async(pool.get_executor())(handle_client(conn));
+        capy::run_async(pool.get_executor())(handle_client(conn));
         pool.join();
         BOOST_TEST(conn.stats.requests == 1);
     }
 
     void testSharedResource()
     {
-        thread_pool pool(2);
+        capy::thread_pool pool(2);
         shared_resource sr(pool);
         int result = 0;
-        run_async(pool.get_executor(), [&result](int v) {
+        capy::run_async(pool.get_executor(), [&result](int v) {
             result = v;
         })(sr.increment());
         pool.join();
@@ -149,7 +126,7 @@ struct executors_test
     void testSingleThread()
     {
         // tag::single_thread[]
-        thread_pool single_thread(1);
+        capy::thread_pool single_thread(1);
         auto ex = single_thread.get_executor();
         // All work runs on the single thread
         // end::single_thread[]
@@ -159,8 +136,9 @@ struct executors_test
     void testDataStrand()
     {
         // tag::data_strand[]
-        thread_pool pool(4);
-        strand<thread_pool::executor_type> data_strand(pool.get_executor());
+        capy::thread_pool pool(4);
+        capy::strand<capy::thread_pool::executor_type> data_strand(
+            pool.get_executor());
 
         // Use data_strand for all access to shared data
         // Use pool.get_executor() for independent work
@@ -171,13 +149,13 @@ struct executors_test
     void testIndependentWork()
     {
         // tag::independent_tasks[]
-        thread_pool pool(4);
+        capy::thread_pool pool(4);
         auto ex = pool.get_executor();
 
         // Start independent tasks directly on the pool
-        std::vector<task<int>> tasks;
+        std::vector<capy::task<int>> tasks;
         for (int i = 0; i < 100; ++i)
-            run_async(ex)(independent_task(i));
+            capy::run_async(ex)(independent_task(i));
         // end::independent_tasks[]
         pool.join();
     }

--- a/test/doc/snippets/4d_io_awaitable.cpp
+++ b/test/doc/snippets/4d_io_awaitable.cpp
@@ -10,32 +10,7 @@
 
 // Compiled fragments shown in pages/4.coroutines/4d.io-awaitable.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/concept/io_awaitable.hpp>
 #include <boost/capy/continuation.hpp>
@@ -57,7 +32,6 @@ namespace capy = boost::capy;
 
 namespace {
 
-using namespace boost::capy;
 
 // The page shows the three standard await_suspend forms side by
 // side; a single type cannot declare all three, so each lives in
@@ -88,18 +62,18 @@ struct std_awaiter_handle
 struct io_awaiter_signature
 {
     // tag::two_arg_await_suspend[]
-    auto await_suspend(std::coroutine_handle<> h, io_env const* env);
+    auto await_suspend(std::coroutine_handle<> h, capy::io_env const* env);
     // end::two_arg_await_suspend[]
 };
 
-static_assert(capy::IoAwaitable<task<int>>);
+static_assert(capy::IoAwaitable<capy::task<int>>);
 static_assert(!capy::IoAwaitable<std_awaiter_void>);
 
 struct caller_promise
 {
-    io_env const* env_ = nullptr;
+    capy::io_env const* env_ = nullptr;
 
-    io_env const* environment() const noexcept { return env_; }
+    capy::io_env const* environment() const noexcept { return env_; }
 };
 
 template<class Awaitable>
@@ -121,7 +95,7 @@ struct transform_awaiter_sketch
 struct context_flow_child
 {
     std::coroutine_handle<> await_suspend(
-        std::coroutine_handle<>, io_env const*)
+        std::coroutine_handle<>, capy::io_env const*)
     {
         return std::noop_coroutine();
     }
@@ -145,8 +119,8 @@ void store_result() {}
 // tag::my_awaitable[]
 struct my_awaitable
 {
-    io_env const* env_ = nullptr;
-    continuation cont_;
+    capy::io_env const* env_ = nullptr;
+    capy::continuation cont_;
     result_type result_;
 
     bool await_ready() const noexcept
@@ -154,7 +128,8 @@ struct my_awaitable
         return false;  // Or true if result is immediately available
     }
 
-    std::coroutine_handle<> await_suspend(std::coroutine_handle<> h, io_env const* env)
+    std::coroutine_handle<> await_suspend(
+        std::coroutine_handle<> h, capy::io_env const* env)
     {
         // Store pointer to environment, never copy
         env_ = env;
@@ -194,14 +169,15 @@ struct add_awaitable
 {
     int a_;
     int b_;
-    io_env const* env_ = nullptr;
+    capy::io_env const* env_ = nullptr;
     // Defaulted, so the call site supplies only a_ and b_.
-    continuation cont_{};
+    capy::continuation cont_{};
     result_type result_{};
 
     bool await_ready() const noexcept { return false; }
 
-    std::coroutine_handle<> await_suspend(std::coroutine_handle<> h, io_env const* env)
+    std::coroutine_handle<> await_suspend(
+        std::coroutine_handle<> h, capy::io_env const* env)
     {
         env_ = env;
         cont_.h = h;
@@ -214,7 +190,7 @@ struct add_awaitable
 };
 
 // A task awaits the custom IoAwaitable and returns what it delivered.
-task<int> add_via_awaitable()
+capy::task<int> add_via_awaitable()
 {
     co_return co_await add_awaitable{2, 3};
 }
@@ -223,13 +199,13 @@ task<int> add_via_awaitable()
 // tag::stoppable_awaitable[]
 struct stoppable_awaitable
 {
-    mutable continuation cont_;
+    mutable capy::continuation cont_;
     std::optional<std::stop_callback<std::function<void()>>> stop_cb_;
 
     bool await_ready() { return false; }
 
     std::coroutine_handle<> await_suspend(
-        std::coroutine_handle<> h, io_env const* env)
+        std::coroutine_handle<> h, capy::io_env const* env)
     {
         if (env->stop_token.stop_requested())
             return h;  // Already cancelled, resume immediately
@@ -254,7 +230,7 @@ struct wrong_stop_callback_demo
 {
     std::optional<std::stop_callback<std::function<void()>>> stop_cb_;
 
-    void emplace_wrong(std::coroutine_handle<> h, io_env const* env)
+    void emplace_wrong(std::coroutine_handle<> h, capy::io_env const* env)
     {
         // tag::wrong_stop_callback[]
         // WRONG: resumes coroutine on the calling thread
@@ -280,7 +256,7 @@ void await_transform_sketch()
     }
 }
 
-template void await_transform_sketch<task<int>>();
+template void await_transform_sketch<capy::task<int>>();
 
 // The "foreign runtime" is played by a plain thread that invokes the
 // completion callback, exactly like a callback-based C library would.
@@ -295,14 +271,14 @@ void start_foreign_op(std::function<void()> on_complete)
 // Bridge a foreign async operation into a Capy coroutine.
 struct foreign_bridge
 {
-    io_env const* env_ = nullptr;
-    continuation cont_;
+    capy::io_env const* env_ = nullptr;
+    capy::continuation cont_;
     result_type result_;
 
     bool await_ready() const noexcept { return false; }
 
     std::coroutine_handle<> await_suspend(
-        std::coroutine_handle<> h, io_env const* env)
+        std::coroutine_handle<> h, capy::io_env const* env)
     {
         env_ = env;
         cont_.h = h;   // stable address; the executor links continuations intrusively
@@ -323,7 +299,7 @@ struct foreign_bridge
 };
 // end::foreign_bridge[]
 
-task<int> use_bridge()
+capy::task<int> use_bridge()
 {
     co_return co_await foreign_bridge{};
 }
@@ -332,9 +308,9 @@ struct io_awaitable_test
 {
     void testForeignBridge()
     {
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         bool done = false;
-        run_async(pool.get_executor(), [&done](int) {
+        capy::run_async(pool.get_executor(), [&done](int) {
             done = true;
         })(use_bridge());
         pool.join();
@@ -348,9 +324,9 @@ struct io_awaitable_test
         // tag::run_awaitable[]
         // Run the task on a thread pool and observe the value the
         // custom IoAwaitable delivered to the completion handler.
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         int result = 0;
-        run_async(pool.get_executor(), [&result](int value) {
+        capy::run_async(pool.get_executor(), [&result](int value) {
             result = value;   // the awaitable delivered 5
         })(add_via_awaitable());
         pool.join();

--- a/test/doc/snippets/4e_cancellation.cpp
+++ b/test/doc/snippets/4e_cancellation.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/4.coroutines/4e.cancellation.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/cond.hpp>
 #include <boost/capy/continuation.hpp>
@@ -69,7 +45,6 @@ namespace capy = boost::capy;
 
 namespace {
 
-using namespace boost::capy;
 
 void do_work() {}
 
@@ -109,28 +84,28 @@ void example()
 }
 // end::observer_pattern[]
 
-task<> child();
+capy::task<> child();
 
 // tag::token_propagation[]
-task<> parent()
+capy::task<> parent()
 {
     // Our stop token is automatically passed to child
     co_await child();
 }
 
-task<> child()
+capy::task<> child()
 {
     // Receives parent's stop token via IoAwaitable protocol
-    auto token = co_await this_coro::stop_token;  // Access current token
+    auto token = co_await capy::this_coro::stop_token;  // Access current token
 }
 // end::token_propagation[]
 
-task<> do_chunk_of_work() { co_return; }
+capy::task<> do_chunk_of_work() { co_return; }
 
 // tag::access_stop_token[]
-task<> cancellable_work()
+capy::task<> cancellable_work()
 {
-    auto token = co_await this_coro::stop_token;
+    auto token = co_await capy::this_coro::stop_token;
 
     while (!token.stop_requested())
     {
@@ -141,12 +116,12 @@ task<> cancellable_work()
 
 struct Item {};
 
-task<> process(Item const&) { co_return; }
+capy::task<> process(Item const&) { co_return; }
 
 // tag::check_token[]
-task<> process_items(std::vector<Item> const& items)
+capy::task<> process_items(std::vector<Item> const& items)
 {
-    auto token = co_await this_coro::stop_token;
+    auto token = co_await capy::this_coro::stop_token;
 
     for (auto const& item : items)
     {
@@ -162,13 +137,13 @@ struct resource_handle {};
 
 resource_handle acquire_resource() { return {}; }
 
-task<> use_resource(resource_handle&) { co_return; }
+capy::task<> use_resource(resource_handle&) { co_return; }
 
 // tag::raii_cleanup[]
-task<> with_resource()
+capy::task<> with_resource()
 {
     auto resource = acquire_resource();  // RAII wrapper
-    auto token = co_await this_coro::stop_token;
+    auto token = co_await capy::this_coro::stop_token;
 
     while (!token.stop_requested())
     {
@@ -178,17 +153,17 @@ task<> with_resource()
 }
 // end::raii_cleanup[]
 
-task<std::string> do_fetch() { co_return "payload"; }
+capy::task<std::string> do_fetch() { co_return "payload"; }
 
 // tag::canceled_convention[]
-task<std::string> fetch_with_cancel()
+capy::task<std::string> fetch_with_cancel()
 {
-    auto token = co_await this_coro::stop_token;
+    auto token = co_await capy::this_coro::stop_token;
 
     if (token.stop_requested())
     {
         throw std::system_error(
-            make_error_code(error::canceled));
+            capy::make_error_code(capy::error::canceled));
     }
 
     co_return co_await do_fetch();
@@ -200,7 +175,7 @@ task<std::string> fetch_with_cancel()
 std::optional<std::stop_callback<std::coroutine_handle<>>> stop_cb;
 
 std::coroutine_handle<> await_suspend(
-    std::coroutine_handle<> h, io_env const* env)
+    std::coroutine_handle<> h, capy::io_env const* env)
 {
     stop_cb.emplace(env->stop_token, h);  // Resumes inline!
     return std::noop_coroutine();
@@ -210,23 +185,23 @@ std::coroutine_handle<> await_suspend(
 // Compile-only bug demo: firing the callback would resume the
 // coroutine on the stopping thread, so nothing ever calls it.
 [[maybe_unused]] std::coroutine_handle<> (* const wrong_pattern)(
-    std::coroutine_handle<>, io_env const*) = &await_suspend;
+    std::coroutine_handle<>, capy::io_env const*) = &await_suspend;
 
-void start_async_operation(std::coroutine_handle<>, io_env const*) {}
+void start_async_operation(std::coroutine_handle<>, capy::io_env const*) {}
 
 // tag::stoppable_awaitable[]
 struct my_stoppable_awaitable
 {
     using stop_cb_t = std::stop_callback<std::function<void()>>;
 
-    mutable continuation cont_;
+    mutable capy::continuation cont_;
     std::unique_ptr<stop_cb_t> stop_cb_;
     // ... other members for the async operation ...
 
     bool await_ready() { return false; }
 
     std::coroutine_handle<> await_suspend(
-        std::coroutine_handle<> h, io_env const* env)
+        std::coroutine_handle<> h, capy::io_env const* env)
     {
         if (env->stop_token.stop_requested())
             return h;  // Already cancelled
@@ -244,7 +219,7 @@ struct my_stoppable_awaitable
 };
 // end::stoppable_awaitable[]
 
-task<> use_stoppable()
+capy::task<> use_stoppable()
 {
     co_await my_stoppable_awaitable{};
 }
@@ -280,27 +255,28 @@ capy::io_task<> deadline(capy::async_waker& waker)
 }
 // end::racing_deadline[]
 
-task<> race(fetch_channel& ch, capy::async_waker& waker, std::size_t& winner)
+capy::task<> race(
+    fetch_channel& ch, capy::async_waker& waker, std::size_t& winner)
 {
-    auto result = co_await when_any(await_fetch(ch), deadline(waker));
+    auto result = co_await capy::when_any(await_fetch(ch), deadline(waker));
     winner = result.index();
 }
 
-task<> fetch_next_chunk(std::string const&) { co_return; }
+capy::task<> fetch_next_chunk(std::string const&) { co_return; }
 
-task<void> download(std::string url);
+capy::task<void> download(std::string url);
 
 // tag::user_cancellation[]
 class download_manager
 {
-    executor_ref executor_;
+    capy::executor_ref executor_;
     std::stop_source stop_source_;
 
 public:
     void start_download(std::string url)
     {
         // Token propagated via io_env, not as a function argument
-        run_async(executor_, stop_source_.get_token())(download(url));
+        capy::run_async(executor_, stop_source_.get_token())(download(url));
     }
 
     void cancel()
@@ -309,9 +285,10 @@ public:
     }
 };
 
-task<void> download(std::string url)
+capy::task<void> download(std::string url)
 {
-    auto token = co_await this_coro::stop_token;  // From run_async's io_env
+    // From run_async's io_env
+    auto token = co_await capy::this_coro::stop_token;
     while (!token.stop_requested())
     {
         co_await fetch_next_chunk(url);
@@ -321,13 +298,14 @@ task<void> download(std::string url)
 
 // download_manager needs a live execution context to launch; the
 // class itself is the demonstration, so nothing instantiates it.
-[[maybe_unused]] task<void> (* const download_demo)(std::string) = &download;
+[[maybe_unused]] capy::task<void> (* const download_demo)(std::string)
+    = &download;
 
 struct connection {};
 
-task<> process_request(connection&) { co_return; }
+capy::task<> process_request(connection&) { co_return; }
 
-task<> send_goodbye(connection&) { co_return; }
+capy::task<> send_goodbye(connection&) { co_return; }
 
 // tag::graceful_shutdown[]
 class server
@@ -341,7 +319,7 @@ public:
         // All pending operations receive stop request
     }
 
-    task<> handle_connection(connection conn)
+    capy::task<> handle_connection(connection conn)
     {
         auto token = shutdown_source_.get_token();
 

--- a/test/doc/snippets/4f_composition.cpp
+++ b/test/doc/snippets/4f_composition.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/4.coroutines/4f.composition.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 // tag::when_all_basic[]
 #include <boost/capy/when_all.hpp>
@@ -68,20 +44,20 @@
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
-namespace {
+namespace capy = boost::capy;
 
-using namespace boost::capy;
+namespace {
 
 namespace overview {
 
 std::atomic<int> runs{0};
 
-io_task<> task_a() { ++runs; co_return io_result<>{}; }
-io_task<> task_b() { ++runs; co_return io_result<>{}; }
-io_task<> task_c() { ++runs; co_return io_result<>{}; }
+capy::io_task<> task_a() { ++runs; co_return capy::io_result<>{}; }
+capy::io_task<> task_b() { ++runs; co_return capy::io_result<>{}; }
+capy::io_task<> task_c() { ++runs; co_return capy::io_result<>{}; }
 
 // tag::sequential[]
-task<> sequential()
+capy::task<> sequential()
 {
     co_await task_a();  // Wait for A
     co_await task_b();  // Then wait for B
@@ -90,10 +66,10 @@ task<> sequential()
 // end::sequential[]
 
 // tag::concurrent[]
-task<> concurrent()
+capy::task<> concurrent()
 {
     // Run A, B, C simultaneously
-    co_await when_all(task_a(), task_b(), task_c());
+    co_await capy::when_all(task_a(), task_b(), task_c());
 }
 // end::concurrent[]
 
@@ -103,13 +79,25 @@ namespace when_all_basics {
 
 // tag::when_all_basic[]
 
-io_task<int> fetch_a() { co_return io_result<int>{std::error_code(), 1}; }
-io_task<int> fetch_b() { co_return io_result<int>{std::error_code(), 2}; }
-io_task<std::string> fetch_c() { co_return io_result<std::string>{std::error_code(), "hello"}; }
-
-task<> example()
+capy::io_task<int> fetch_a()
 {
-    auto [ec, a, b, c] = co_await when_all(fetch_a(), fetch_b(), fetch_c());
+    co_return capy::io_result<int>{std::error_code(), 1};
+}
+
+capy::io_task<int> fetch_b()
+{
+    co_return capy::io_result<int>{std::error_code(), 2};
+}
+
+capy::io_task<std::string> fetch_c()
+{
+    co_return capy::io_result<std::string>{std::error_code(), "hello"};
+}
+
+capy::task<> example()
+{
+    auto [ec, a, b, c] = co_await capy::when_all(
+        fetch_a(), fetch_b(), fetch_c());
 
     // ec == std::error_code{} (success)
     // a == 1
@@ -123,12 +111,17 @@ task<> example()
 namespace void_mix {
 
 // tag::when_all_void_mix[]
-io_task<> void_task() { co_return io_result<>{}; }
-io_task<int> int_task() { co_return io_result<int>{std::error_code(), 42}; }
+capy::io_task<> void_task() { co_return capy::io_result<>{}; }
 
-task<> example()
+capy::io_task<int> int_task()
 {
-    auto [ec, a, b, c] = co_await when_all(int_task(), void_task(), int_task());
+    co_return capy::io_result<int>{std::error_code(), 42};
+}
+
+capy::task<> example()
+{
+    auto [ec, a, b, c] = co_await capy::when_all(
+        int_task(), void_task(), int_task());
     // a == 42       (int)
     // b == tuple<>  (from void io_task)
     // c == 42       (int)
@@ -139,13 +132,13 @@ task<> example()
 
 namespace all_void {
 
-io_task<> void_task_a() { co_return io_result<>{}; }
-io_task<> void_task_b() { co_return io_result<>{}; }
+capy::io_task<> void_task_a() { co_return capy::io_result<>{}; }
+capy::io_task<> void_task_b() { co_return capy::io_result<>{}; }
 
 // tag::when_all_all_void[]
-task<> example()
+capy::task<> example()
 {
-    auto r = co_await when_all(void_task_a(), void_task_b());
+    auto r = co_await capy::when_all(void_task_a(), void_task_b());
     if (std::get<0>(r))
     {
         // handle error
@@ -157,13 +150,20 @@ task<> example()
 
 namespace error_handling {
 
-io_task<int> task_a() { co_return io_result<int>{std::error_code(), 1}; }
-io_task<int> task_b() { co_return io_result<int>{error::timeout, 0}; }
+capy::io_task<int> task_a()
+{
+    co_return capy::io_result<int>{std::error_code(), 1};
+}
+
+capy::io_task<int> task_b()
+{
+    co_return capy::io_result<int>{capy::error::timeout, 0};
+}
 
 // tag::when_all_error[]
-task<> example()
+capy::task<> example()
 {
-    auto [ec, a, b] = co_await when_all(task_a(), task_b());
+    auto [ec, a, b] = co_await capy::when_all(task_a(), task_b());
     if (ec)
         std::cerr << "Error: " << ec.message() << "\n";
 }
@@ -174,18 +174,18 @@ task<> example()
 namespace exceptions {
 
 // tag::when_all_exception[]
-io_task<int> might_throw(bool fail)
+capy::io_task<int> might_throw(bool fail)
 {
     if (fail)
         throw std::runtime_error("failed");
-    co_return io_result<int>{std::error_code(), 42};
+    co_return capy::io_result<int>{std::error_code(), 42};
 }
 
-task<> example()
+capy::task<> example()
 {
     try
     {
-        co_await when_all(might_throw(true), might_throw(false));
+        co_await capy::when_all(might_throw(true), might_throw(false));
     }
     catch (std::runtime_error const& e)
     {
@@ -200,27 +200,30 @@ namespace stop_prop {
 
 std::atomic<int> iterations{0};
 
-io_task<> do_iteration()
+capy::io_task<> do_iteration()
 {
     ++iterations;
-    co_return io_result<>{};
+    co_return capy::io_result<>{};
 }
 
-io_task<> fail_fast() { co_return io_result<>{error::timeout}; }
+capy::io_task<> fail_fast()
+{
+    co_return capy::io_result<>{capy::error::timeout};
+}
 
 // tag::stop_propagation[]
-io_task<> long_running()
+capy::io_task<> long_running()
 {
-    auto token = co_await this_coro::stop_token;
+    auto token = co_await capy::this_coro::stop_token;
 
     for (int i = 0; i < 1000; ++i)
     {
         if (token.stop_requested())
-            co_return io_result<>{};  // Exit early when sibling fails
+            co_return capy::io_result<>{};  // Exit early when sibling fails
 
         co_await do_iteration();
     }
-    co_return io_result<>{};
+    co_return capy::io_result<>{};
 }
 // end::stop_propagation[]
 
@@ -228,14 +231,21 @@ io_task<> long_running()
 
 namespace any_basic {
 
-io_task<int> fetch_int() { co_return io_result<int>{std::error_code(), 7}; }
-io_task<std::string> fetch_string() { co_return io_result<std::string>{std::error_code(), "s"}; }
+capy::io_task<int> fetch_int()
+{
+    co_return capy::io_result<int>{std::error_code(), 7};
+}
+
+capy::io_task<std::string> fetch_string()
+{
+    co_return capy::io_result<std::string>{std::error_code(), "s"};
+}
 
 // tag::when_any_basic[]
 
-task<> example()
+capy::task<> example()
 {
-    auto result = co_await when_any(
+    auto result = co_await capy::when_any(
         fetch_int(),     // io_task<int>
         fetch_string()   // io_task<std::string>
     );
@@ -250,16 +260,16 @@ task<> example()
 
 namespace wrap_translate {
 
-io_task<> inner() { co_return io_result<>{error::canceled}; }
+capy::io_task<> inner() { co_return capy::io_result<>{capy::error::canceled}; }
 
 // tag::wrap_translate_error[]
 // canceled is benign here: translate it to success so when_any picks this child.
-io_task<> wrapped()
+capy::io_task<> wrapped()
 {
     auto [ec] = co_await inner();
-    if (ec == cond::canceled)
-        co_return io_result<>{};   // success: when_any sees a winner
-    co_return io_result<>{ec};     // propagate other errors unchanged
+    if (ec == capy::cond::canceled)
+        co_return capy::io_result<>{};   // success: when_any sees a winner
+    co_return capy::io_result<>{ec};     // propagate other errors unchanged
 }
 // end::wrap_translate_error[]
 
@@ -267,14 +277,14 @@ io_task<> wrapped()
 
 namespace wrap_lift {
 
-io_task<> inner() { co_return io_result<>{error::timeout}; }
+capy::io_task<> inner() { co_return capy::io_result<>{capy::error::timeout}; }
 
 // tag::wrap_lift_error[]
 // Always succeeds; the winner's payload carries the original ec.
-io_task<std::error_code> wrapped()
+capy::io_task<std::error_code> wrapped()
 {
     auto [ec] = co_await inner();
-    co_return io_result<std::error_code>{std::error_code(), ec};
+    co_return capy::io_result<std::error_code>{std::error_code(), ec};
 }
 
 // when_any(wrapped(), ...) -> variant<error_code, std::error_code, ...>
@@ -293,33 +303,34 @@ struct page_data
     std::string sidebar;
 };
 
-io_task<std::string> fetch_header(std::string url)
+capy::io_task<std::string> fetch_header(std::string url)
 {
-    co_return io_result<std::string>{std::error_code(), url + ":header"};
+    co_return capy::io_result<std::string>{std::error_code(), url + ":header"};
 }
 
-io_task<std::string> fetch_body(std::string url)
+capy::io_task<std::string> fetch_body(std::string url)
 {
-    co_return io_result<std::string>{std::error_code(), url + ":body"};
+    co_return capy::io_result<std::string>{std::error_code(), url + ":body"};
 }
 
-io_task<std::string> fetch_sidebar(std::string url)
+capy::io_task<std::string> fetch_sidebar(std::string url)
 {
-    co_return io_result<std::string>{std::error_code(), url + ":sidebar"};
+    co_return capy::io_result<std::string>{
+        std::error_code(), url + ":sidebar"};
 }
 
 // tag::parallel_fetch[]
-io_task<page_data> fetch_page_data(std::string url)
+capy::io_task<page_data> fetch_page_data(std::string url)
 {
-    auto [ec, header, body, sidebar] = co_await when_all(
+    auto [ec, header, body, sidebar] = co_await capy::when_all(
         fetch_header(url),
         fetch_body(url),
         fetch_sidebar(url)
     );
     if (ec)
-        co_return io_result<page_data>{ec, {}};
+        co_return capy::io_result<page_data>{ec, {}};
 
-    co_return io_result<page_data>{std::error_code(), {
+    co_return capy::io_result<page_data>{std::error_code(), {
         std::move(header),
         std::move(body),
         std::move(sidebar)
@@ -337,15 +348,15 @@ struct item
 };
 
 // tag::fan_out[]
-io_task<int> process_item(item i);
+capy::io_task<int> process_item(item i);
 
-task<int> process_all(std::vector<item> const& items)
+capy::task<int> process_all(std::vector<item> const& items)
 {
-    std::vector<io_task<int>> tasks;
+    std::vector<capy::io_task<int>> tasks;
     for (auto const& item : items)
         tasks.push_back(process_item(item));
 
-    auto [ec, results] = co_await when_all(std::move(tasks));
+    auto [ec, results] = co_await capy::when_all(std::move(tasks));
     if (ec)
         co_return 0;
 
@@ -356,9 +367,9 @@ task<int> process_all(std::vector<item> const& items)
 }
 // end::fan_out[]
 
-io_task<int> process_item(item i)
+capy::io_task<int> process_item(item i)
 {
-    co_return io_result<int>{std::error_code(), i.value};
+    co_return capy::io_result<int>{std::error_code(), i.value};
 }
 
 } // namespace fanout
@@ -368,20 +379,20 @@ struct composition_test
     void testOverview()
     {
         overview::runs = 0;
-        test::run_blocking()(overview::sequential());
+        capy::test::run_blocking()(overview::sequential());
         BOOST_TEST_EQ(overview::runs.load(), 3);
-        test::run_blocking()(overview::concurrent());
+        capy::test::run_blocking()(overview::concurrent());
         BOOST_TEST_EQ(overview::runs.load(), 6);
     }
 
     void testWhenAllBasic()
     {
-        test::run_blocking()(when_all_basics::example());
+        capy::test::run_blocking()(when_all_basics::example());
 
         bool checked = false;
-        auto check = [&]() -> task<>
+        auto check = [&]() -> capy::task<>
         {
-            auto [ec, a, b, c] = co_await when_all(
+            auto [ec, a, b, c] = co_await capy::when_all(
                 when_all_basics::fetch_a(),
                 when_all_basics::fetch_b(),
                 when_all_basics::fetch_c());
@@ -391,18 +402,18 @@ struct composition_test
             BOOST_TEST(c == "hello");
             checked = true;
         };
-        test::run_blocking()(check());
+        capy::test::run_blocking()(check());
         BOOST_TEST(checked);
     }
 
     void testVoidMix()
     {
-        test::run_blocking()(void_mix::example());
+        capy::test::run_blocking()(void_mix::example());
 
         bool checked = false;
-        auto check = [&]() -> task<>
+        auto check = [&]() -> capy::task<>
         {
-            auto [ec, a, b, c] = co_await when_all(
+            auto [ec, a, b, c] = co_await capy::when_all(
                 void_mix::int_task(),
                 void_mix::void_task(),
                 void_mix::int_task());
@@ -412,55 +423,55 @@ struct composition_test
             BOOST_TEST_EQ(c, 42);
             checked = true;
         };
-        test::run_blocking()(check());
+        capy::test::run_blocking()(check());
         BOOST_TEST(checked);
     }
 
     void testAllVoid()
     {
-        test::run_blocking()(all_void::example());
+        capy::test::run_blocking()(all_void::example());
 
         bool checked = false;
-        auto check = [&]() -> task<>
+        auto check = [&]() -> capy::task<>
         {
-            auto r = co_await when_all(
+            auto r = co_await capy::when_all(
                 all_void::void_task_a(),
                 all_void::void_task_b());
             BOOST_TEST(!std::get<0>(r));
             checked = true;
         };
-        test::run_blocking()(check());
+        capy::test::run_blocking()(check());
         BOOST_TEST(checked);
     }
 
     void testErrorHandling()
     {
-        test::run_blocking()(error_handling::example());
+        capy::test::run_blocking()(error_handling::example());
 
         bool checked = false;
-        auto check = [&]() -> task<>
+        auto check = [&]() -> capy::task<>
         {
-            auto [ec, a, b] = co_await when_all(
+            auto [ec, a, b] = co_await capy::when_all(
                 error_handling::task_a(),
                 error_handling::task_b());
-            BOOST_TEST(ec == cond::timeout);
+            BOOST_TEST(ec == capy::cond::timeout);
             checked = true;
         };
-        test::run_blocking()(check());
+        capy::test::run_blocking()(check());
         BOOST_TEST(checked);
     }
 
     void testException()
     {
-        test::run_blocking()(exceptions::example());
+        capy::test::run_blocking()(exceptions::example());
 
         bool checked = false;
-        auto check = [&]() -> task<>
+        auto check = [&]() -> capy::task<>
         {
             bool caught = false;
             try
             {
-                co_await when_all(
+                co_await capy::when_all(
                     exceptions::might_throw(true),
                     exceptions::might_throw(false));
             }
@@ -470,7 +481,7 @@ struct composition_test
             }
             BOOST_TEST(caught);
 
-            auto [ec, x, y] = co_await when_all(
+            auto [ec, x, y] = co_await capy::when_all(
                 exceptions::might_throw(false),
                 exceptions::might_throw(false));
             BOOST_TEST(!ec);
@@ -478,7 +489,7 @@ struct composition_test
             BOOST_TEST_EQ(y, 42);
             checked = true;
         };
-        test::run_blocking()(check());
+        capy::test::run_blocking()(check());
         BOOST_TEST(checked);
     }
 
@@ -487,30 +498,30 @@ struct composition_test
         stop_prop::iterations = 0;
 
         bool checked = false;
-        auto check = [&]() -> task<>
+        auto check = [&]() -> capy::task<>
         {
             // fail_fast is posted first on the single-threaded test
             // context, so its error requests stop before long_running
             // starts iterating.
-            auto r = co_await when_all(
+            auto r = co_await capy::when_all(
                 stop_prop::fail_fast(),
                 stop_prop::long_running());
-            BOOST_TEST(std::get<0>(r) == cond::timeout);
+            BOOST_TEST(std::get<0>(r) == capy::cond::timeout);
             checked = true;
         };
-        test::run_blocking()(check());
+        capy::test::run_blocking()(check());
         BOOST_TEST(checked);
         BOOST_TEST_EQ(stop_prop::iterations.load(), 0);
     }
 
     void testWhenAnyBasic()
     {
-        test::run_blocking()(any_basic::example());
+        capy::test::run_blocking()(any_basic::example());
 
         bool checked = false;
-        auto check = [&]() -> task<>
+        auto check = [&]() -> capy::task<>
         {
-            auto result = co_await when_any(
+            auto result = co_await capy::when_any(
                 any_basic::fetch_int(),
                 any_basic::fetch_string());
             static_assert(std::is_same_v<decltype(result),
@@ -519,44 +530,44 @@ struct composition_test
             BOOST_TEST_EQ(std::get<1>(result), 7);
             checked = true;
         };
-        test::run_blocking()(check());
+        capy::test::run_blocking()(check());
         BOOST_TEST(checked);
     }
 
     void testWrapTranslate()
     {
         bool checked = false;
-        auto check = [&]() -> task<>
+        auto check = [&]() -> capy::task<>
         {
             auto [ec] = co_await wrap_translate::wrapped();
             BOOST_TEST(!ec);
 
-            auto r = co_await when_any(wrap_translate::wrapped());
+            auto r = co_await capy::when_any(wrap_translate::wrapped());
             BOOST_TEST_EQ(r.index(), 1u);
             checked = true;
         };
-        test::run_blocking()(check());
+        capy::test::run_blocking()(check());
         BOOST_TEST(checked);
     }
 
     void testWrapLift()
     {
         bool checked = false;
-        auto check = [&]() -> task<>
+        auto check = [&]() -> capy::task<>
         {
-            auto r = co_await when_any(wrap_lift::wrapped());
+            auto r = co_await capy::when_any(wrap_lift::wrapped());
             BOOST_TEST_EQ(r.index(), 1u);
-            BOOST_TEST(std::get<1>(r) == cond::timeout);
+            BOOST_TEST(std::get<1>(r) == capy::cond::timeout);
             checked = true;
         };
-        test::run_blocking()(check());
+        capy::test::run_blocking()(check());
         BOOST_TEST(checked);
     }
 
     void testParallelFetch()
     {
         bool checked = false;
-        auto check = [&]() -> task<>
+        auto check = [&]() -> capy::task<>
         {
             auto [ec, pd] = co_await parallel::fetch_page_data("url");
             BOOST_TEST(!ec);
@@ -565,7 +576,7 @@ struct composition_test
             BOOST_TEST(pd.sidebar == "url:sidebar");
             checked = true;
         };
-        test::run_blocking()(check());
+        capy::test::run_blocking()(check());
         BOOST_TEST(checked);
     }
 
@@ -573,7 +584,7 @@ struct composition_test
     {
         std::vector<fanout::item> items = {{1}, {2}, {3}};
         int total = 0;
-        test::run_blocking([&](int v) { total = v; })(
+        capy::test::run_blocking([&](int v) { total = v; })(
             fanout::process_all(items));
         BOOST_TEST_EQ(total, 6);
     }

--- a/test/doc/snippets/4g_allocators.cpp
+++ b/test/doc/snippets/4g_allocators.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/4.coroutines/4g.allocators.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/ex/any_executor.hpp>
 #include <boost/capy/ex/frame_alloc_mixin.hpp>
@@ -60,11 +36,10 @@ namespace capy = boost::capy;
 
 namespace {
 
-using namespace boost::capy;
 
 std::atomic<int> tasks_completed{0};
 
-task<> my_task()
+capy::task<> my_task()
 {
     ++tasks_completed;
     co_return;
@@ -94,7 +69,7 @@ resumable clobber_tls(bool& resumed)
 {
     resumed = true;
     // Simulate another chain's await_resume overwriting TLS
-    set_current_frame_allocator(nullptr);
+    capy::set_current_frame_allocator(nullptr);
     co_return;
 }
 
@@ -123,12 +98,12 @@ struct [[nodiscard]] BOOST_CAPY_CORO_AWAIT_ELIDABLE
 
 } // namespace library_sketch
 
-task<int> compute()
+capy::task<int> compute()
 {
     co_return 42;
 }
 
-task<> halo_demo(std::vector<task<int>>& tasks, int& out)
+capy::task<> halo_demo(std::vector<capy::task<int>>& tasks, int& out)
 {
     // tag::halo_patterns[]
     // HALO can apply: task is awaited immediately
@@ -145,7 +120,7 @@ struct item {};
 
 int items_processed = 0;
 
-task<> process(item const&)
+capy::task<> process(item const&)
 {
     ++items_processed;
     co_return;
@@ -153,7 +128,7 @@ task<> process(item const&)
 
 // Bound to a blocking (inline) executor in the test so every frame is
 // released before the stack buffer backing the resource goes away.
-any_executor executor;
+capy::any_executor executor;
 
 // tag::batch_allocator[]
 void process_batch(std::vector<item> const& items)
@@ -164,7 +139,7 @@ void process_batch(std::vector<item> const& items)
 
     for (auto const& item : items)
     {
-        run_async(executor, &resource)(process(item));
+        capy::run_async(executor, &resource)(process(item));
     }
     // All frames deallocated when resource goes out of scope
 }
@@ -230,20 +205,20 @@ struct stream
     int reads = 0;
     int writes = 0;
 
-    task<io_step> read_some(char*)
+    capy::task<io_step> read_some(char*)
     {
         ++reads;
         co_return io_step{};
     }
 
-    task<io_step> write_some(char const*)
+    capy::task<io_step> write_some(char const*)
     {
         ++writes;
         co_return io_step{};
     }
 };
 
-task<> do_work(char*, std::size_t)
+capy::task<> do_work(char*, std::size_t)
 {
     co_return;
 }
@@ -256,7 +231,7 @@ namespace scope_bad {
 
 // tag::frame_scope_bad[]
 // BAD: buf lives in frame across all subsequent co_awaits
-task<> process(stream& s)
+capy::task<> process(stream& s)
 {
     char reply[] = "ok";
     char buf[4096];
@@ -272,7 +247,7 @@ namespace scope_good {
 
 // tag::frame_scope_good[]
 // GOOD: braces end buf's lifetime before next suspend
-task<> process(stream& s)
+capy::task<> process(stream& s)
 {
     char reply[] = "ok";
     {
@@ -290,7 +265,7 @@ namespace overlap_bad {
 
 // tag::pipeline_overlap_bad[]
 // BAD: both arrays in frame simultaneously (8K)
-task<> pipeline(stream& in, stream& out)
+capy::task<> pipeline(stream& in, stream& out)
 {
     char read_buf[4096];
     auto [ec1, n] = co_await in.read_some(read_buf);
@@ -307,7 +282,7 @@ namespace overlap_good {
 
 // tag::pipeline_overlap_good[]
 // GOOD: non-overlapping scopes allow frame reuse (4K)
-task<> pipeline(stream& in, stream& out)
+capy::task<> pipeline(stream& in, stream& out)
 {
     std::size_t n;
     {
@@ -330,11 +305,11 @@ struct allocators_test
     void
     testTwoCallSyntax()
     {
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         auto executor = pool.get_executor();
         int const before = tasks_completed.load();
         // tag::two_call[]
-        run_async(executor)(my_task());
+        capy::run_async(executor)(my_task());
         //        ↑         ↑
         //        1. Sets    2. Task allocated
         //        TLS        using TLS allocator
@@ -348,7 +323,7 @@ struct allocators_test
     {
         // The sentinel proves TLS survives a resume that clobbers it
         std::pmr::monotonic_buffer_resource sentinel;
-        set_current_frame_allocator(&sentinel);
+        capy::set_current_frame_allocator(&sentinel);
         bool resumed = false;
         auto r = clobber_tls(resumed);
         std::coroutine_handle<> h = r.handle;
@@ -357,22 +332,22 @@ struct allocators_test
         capy::safe_resume(h);   // saves and restores TLS around h.resume()
         // end::safe_resume[]
         BOOST_TEST(resumed);
-        BOOST_TEST(get_current_frame_allocator() == &sentinel);
-        set_current_frame_allocator(nullptr);
+        BOOST_TEST(capy::get_current_frame_allocator() == &sentinel);
+        capy::set_current_frame_allocator(nullptr);
         r.handle.destroy();
     }
 
     void
     testRunAsyncPmrAllocator()
     {
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         auto executor = pool.get_executor();
         int const before = tasks_completed.load();
         // tag::run_async_pmr_alloc[]
         std::pmr::monotonic_buffer_resource resource;
         std::pmr::polymorphic_allocator<std::byte> alloc(&resource);
 
-        run_async(executor, alloc)(my_task());
+        capy::run_async(executor, alloc)(my_task());
         // end::run_async_pmr_alloc[]
         pool.join();
         BOOST_TEST(tasks_completed.load() == before + 1);
@@ -381,12 +356,12 @@ struct allocators_test
     void
     testRunAsyncMemoryResource()
     {
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         auto executor = pool.get_executor();
         int const before = tasks_completed.load();
         // tag::run_async_memory_resource[]
         std::pmr::monotonic_buffer_resource resource;
-        run_async(executor, &resource)(my_task());
+        capy::run_async(executor, &resource)(my_task());
         // end::run_async_memory_resource[]
         pool.join();
         BOOST_TEST(tasks_completed.load() == before + 1);
@@ -404,8 +379,8 @@ struct allocators_test
 
         auto run_once = [&]
         {
-            thread_pool pool(1);
-            run_async(pool.get_executor(), &pooling)(my_task());
+            capy::thread_pool pool(1);
+            capy::run_async(pool.get_executor(), &pooling)(my_task());
             pool.join();   // task done: its frames are back in the pool
         };
 
@@ -427,9 +402,9 @@ struct allocators_test
     void
     testHaloPatterns()
     {
-        std::vector<task<int>> tasks;
+        std::vector<capy::task<int>> tasks;
         int out = 0;
-        test::run_blocking()(halo_demo(tasks, out));
+        capy::test::run_blocking()(halo_demo(tasks, out));
         BOOST_TEST(out == 42);
         BOOST_TEST(tasks.size() == 1u);
         // The escaped task is destroyed unawaited when the vector dies
@@ -438,21 +413,21 @@ struct allocators_test
     void
     testBatchAllocator()
     {
-        test::blocking_context ctx;
+        capy::test::blocking_context ctx;
         executor = ctx.get_executor();
         std::vector<item> items(3);
         int const before = items_processed;
         process_batch(items);
         BOOST_TEST(items_processed == before + 3);
-        executor = any_executor();
+        executor = capy::any_executor();
     }
 
     void
     testFrameScope()
     {
         stream s;
-        test::run_blocking()(scope_bad::process(s));
-        test::run_blocking()(scope_good::process(s));
+        capy::test::run_blocking()(scope_bad::process(s));
+        capy::test::run_blocking()(scope_good::process(s));
         BOOST_TEST(s.reads == 2);
         BOOST_TEST(s.writes == 2);
     }
@@ -462,8 +437,8 @@ struct allocators_test
     {
         stream in;
         stream out;
-        test::run_blocking()(overlap_bad::pipeline(in, out));
-        test::run_blocking()(overlap_good::pipeline(in, out));
+        capy::test::run_blocking()(overlap_bad::pipeline(in, out));
+        capy::test::run_blocking()(overlap_good::pipeline(in, out));
         BOOST_TEST(in.reads == 2);
         BOOST_TEST(out.writes == 2);
     }

--- a/test/doc/snippets/4h_lambda_captures.cpp
+++ b/test/doc/snippets/4h_lambda_captures.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -11,35 +12,7 @@
 // The fragments that demonstrate dangling captures are compiled but
 // never executed: running them would be undefined behavior.
 
-// Fragments deliberately leave structured bindings unused; page
-// comments explain the values instead.
-
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/buffers/make_buffer.hpp>
@@ -59,7 +32,6 @@ namespace capy = boost::capy;
 
 namespace {
 
-using namespace boost::capy;
 
 struct io_step
 {
@@ -73,14 +45,14 @@ int socket_reads = 0;
 // can run to completion under the blocking test executor.
 struct socket
 {
-    task<io_step> read_some(mutable_buffer)
+    capy::task<io_step> read_some(capy::mutable_buffer)
     {
         ++socket_reads;
         co_return io_step{};
     }
 };
 
-any_executor executor;
+capy::any_executor executor;
 
 int log_count = 0;
 
@@ -89,7 +61,7 @@ void log(char const*, std::string const&)
     ++log_count;
 }
 
-task<> handle_request()
+capy::task<> handle_request()
 {
     co_return;
 }
@@ -106,10 +78,10 @@ void process(socket& sock)
     capy::task<> started = [&sock]() -> capy::task<>
     {
         char buf[1024];
-        auto [ec, n] = co_await sock.read_some(make_buffer(buf));
+        auto [ec, n] = co_await sock.read_some(capy::make_buffer(buf));
     }();  // <-- called here, so the lambda is a temporary and dies now
 
-    run_async(executor)(std::move(started));
+    capy::run_async(executor)(std::move(started));
 }
 // end::dangling_capture[]
 
@@ -130,10 +102,10 @@ void process(socket& sock)
     auto task = [](socket* s) -> capy::task<>
     {
         char buf[1024];
-        auto [ec, n] = co_await s->read_some(make_buffer(buf));
+        auto [ec, n] = co_await s->read_some(capy::make_buffer(buf));
     }(&sock);
 
-    run_async(executor)(std::move(task));
+    capy::run_async(executor)(std::move(task));
 }
 // end::iife_parameter[]
 
@@ -205,7 +177,7 @@ class connection_handler
     {
         // 'this' is an implicit parameter, handled correctly
         char buf[1024];
-        co_await sock_.read_some(make_buffer(buf));
+        co_await sock_.read_some(capy::make_buffer(buf));
     }
 
 public:
@@ -223,13 +195,13 @@ struct lambda_captures_test
     void
     testIifeParameter()
     {
-        test::blocking_context ctx;
+        capy::test::blocking_context ctx;
         executor = ctx.get_executor();
         socket sock;
         int const before = socket_reads;
         iife_param::process(sock);
         BOOST_TEST(socket_reads == before + 1);
-        executor = any_executor();
+        executor = capy::any_executor();
     }
 
     void
@@ -237,7 +209,7 @@ struct lambda_captures_test
     {
         parameter_self::connection_handler h;
         int const before = log_count;
-        test::run_blocking()(h.run());
+        capy::test::run_blocking()(h.run());
         BOOST_TEST(log_count == before + 1);
     }
 
@@ -251,11 +223,12 @@ struct lambda_captures_test
         auto handler = [&sock]() -> capy::task<>
         {
             char buf[1024];
-            co_await sock.read_some(make_buffer(buf));
+            co_await sock.read_some(capy::make_buffer(buf));
         };
 
         // Lambda 'handler' still exists here
-        capy::test::run_blocking()(handler());  // Blocks until coroutine completes
+        // Blocks until coroutine completes
+        capy::test::run_blocking()(handler());
         // Lambda destroyed after coroutine finishes
         // end::stored_lambda_safe[]
         BOOST_TEST(socket_reads == before + 1);
@@ -266,7 +239,7 @@ struct lambda_captures_test
     {
         named_member::connection_handler h;
         int const before = socket_reads;
-        test::run_blocking()(h.run());
+        capy::test::run_blocking()(h.run());
         BOOST_TEST(socket_reads == before + 1);
     }
 

--- a/test/doc/snippets/5a_overview.cpp
+++ b/test/doc/snippets/5a_overview.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/5.buffers/5a.overview.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 
@@ -45,9 +21,9 @@
 
 #include "test_suite.hpp"
 
-namespace {
+namespace capy = boost::capy;
 
-using namespace boost::capy;
+namespace {
 
 // tag::span_signatures[]
 void write_data(std::span<std::byte const> data);
@@ -64,7 +40,7 @@ using BodyBuffers = std::array<std::span<std::byte const>, 3>;    // 3 buffers
 // end::span_aliases[]
 
 // tag::concept_signature[]
-template<ConstBufferSequence Buffers>
+template<capy::ConstBufferSequence Buffers>
 void write_data(Buffers const& buffers);
 // end::concept_signature[]
 

--- a/test/doc/snippets/5b_types.cpp
+++ b/test/doc/snippets/5b_types.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/5.buffers/5b.types.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 // tag::make_buffer_include[]
@@ -50,36 +26,36 @@
 
 #include "test_suite.hpp"
 
-namespace {
+namespace capy = boost::capy;
 
-using namespace boost::capy;
+namespace {
 
 // Records the size seen so the conversion fragment is observable.
 std::size_t processed_size = 0;
 
-void process(const_buffer buf)
+void process(capy::const_buffer buf)
 {
     processed_size = buf.size();
 }
 
 // tag::write_data_signature[]
-template<ConstBufferSequence Buffers>
+template<capy::ConstBufferSequence Buffers>
 void write_data(Buffers const& buffers);
 // end::write_data_signature[]
 
 // Logs the element count of every call so all three calls are observable.
 std::vector<std::size_t> write_data_lengths;
 
-template<ConstBufferSequence Buffers>
+template<capy::ConstBufferSequence Buffers>
 void write_data(Buffers const& buffers)
 {
-    write_data_lengths.push_back(buffer_length(buffers));
+    write_data_lengths.push_back(capy::buffer_length(buffers));
 }
 
 // The custom sequence used by the calls fragment.
 struct composite_buffers
 {
-    std::array<const_buffer, 2> parts;
+    std::array<capy::const_buffer, 2> parts;
     auto begin() const noexcept { return parts.begin(); }
     auto end() const noexcept { return parts.end(); }
 };
@@ -91,11 +67,11 @@ struct types_test
         // tag::const_buffer_construct[]
         // From pointer and size
         char data[] = "hello";
-        const_buffer buf(data, 5);
+        capy::const_buffer buf(data, 5);
 
         // From mutable_buffer (implicit)
-        mutable_buffer mbuf(data, 5);
-        const_buffer cbuf = mbuf;  // OK: mutable -> const
+        capy::mutable_buffer mbuf(data, 5);
+        capy::const_buffer cbuf = mbuf;  // OK: mutable -> const
         // end::const_buffer_construct[]
         BOOST_TEST(buf.data() == data);
         BOOST_TEST(buf.size() == 5);
@@ -107,7 +83,7 @@ struct types_test
     {
         char data[] = "hello";
         // tag::const_buffer_accessors[]
-        const_buffer buf(data, 5);
+        capy::const_buffer buf(data, 5);
 
         void const* ptr = buf.data();  // Pointer to first byte
         std::size_t len = buf.size();  // Number of bytes
@@ -120,7 +96,7 @@ struct types_test
     {
         char data[] = "0123456789";
         // tag::const_buffer_prefix[]
-        const_buffer buf(data, 10);
+        capy::const_buffer buf(data, 10);
 
         buf += 3;  // Remove first 3 bytes
         // buf.data() now points 3 bytes later
@@ -135,9 +111,9 @@ struct types_test
         char data[8] = {};
         std::size_t size = sizeof(data);
         // tag::mutable_to_const[]
-        void process(const_buffer buf);
+        void process(capy::const_buffer buf);
 
-        mutable_buffer mbuf(data, size);
+        capy::mutable_buffer mbuf(data, size);
         process(mbuf);  // OK: implicit conversion
         // end::mutable_to_const[]
         BOOST_TEST(processed_size == size);
@@ -150,31 +126,31 @@ struct types_test
         std::size_t size = sizeof(storage);
         // tag::make_buffer_sources[]
         // From pointer and size
-        auto buf = make_buffer(ptr, size);
+        auto buf = capy::make_buffer(ptr, size);
 
         // From C array
         char arr[10];
-        auto arr_buf = make_buffer(arr);
+        auto arr_buf = capy::make_buffer(arr);
 
         // From std::array
         std::array<char, 10> std_arr;
-        auto std_arr_buf = make_buffer(std_arr);
+        auto std_arr_buf = capy::make_buffer(std_arr);
 
         // From std::vector
         std::vector<char> vec(100);
-        auto vec_buf = make_buffer(vec);
+        auto vec_buf = capy::make_buffer(vec);
 
         // From std::string
         std::string str = "hello";
-        auto str_buf = make_buffer(str);
+        auto str_buf = capy::make_buffer(str);
 
         // From std::string_view
         std::string_view sv = "hello";
-        auto sv_buf = make_buffer(sv);
+        auto sv_buf = capy::make_buffer(sv);
 
         // From a span (std::span or boost::span)
         std::span<char> sp(arr);
-        auto sp_buf = make_buffer(sp);
+        auto sp_buf = capy::make_buffer(sp);
         // end::make_buffer_sources[]
         BOOST_TEST(buf.data() == storage);
         BOOST_TEST(buf.size() == 64);
@@ -189,12 +165,12 @@ struct types_test
 
     void testSingleAsSequence()
     {
-        const_buffer buf1, buf2, buf3;
+        capy::const_buffer buf1, buf2, buf3;
         composite_buffers my_composite{};
         write_data_lengths.clear();
         // tag::write_data_calls[]
         // All of these work:
-        write_data(make_buffer("hello"));         // Single buffer
+        write_data(capy::make_buffer("hello"));         // Single buffer
         write_data(std::array{buf1, buf2, buf3}); // Multiple buffers
         write_data(my_composite);                 // Custom sequence
         // end::write_data_calls[]
@@ -205,13 +181,13 @@ struct types_test
     void testBeginEnd()
     {
         // tag::begin_end_uniform[]
-        const_buffer single;
-        auto it = begin(single);  // Returns pointer to single
-        auto e = end(single);     // Returns pointer past single
+        capy::const_buffer single;
+        auto it = capy::begin(single);  // Returns pointer to single
+        auto e = capy::end(single);     // Returns pointer past single
 
-        std::array<const_buffer, 3> multi;
-        auto it2 = begin(multi);  // Returns multi.begin()
-        auto e2 = end(multi);     // Returns multi.end()
+        std::array<capy::const_buffer, 3> multi;
+        auto it2 = capy::begin(multi);  // Returns multi.begin()
+        auto e2 = capy::end(multi);     // Returns multi.end()
         // end::begin_end_uniform[]
         BOOST_TEST(it == &single);
         BOOST_TEST(e == &single + 1);

--- a/test/doc/snippets/5c_sequences.cpp
+++ b/test/doc/snippets/5c_sequences.cpp
@@ -10,32 +10,7 @@
 
 // Compiled fragments shown in pages/5.buffers/5c.sequences.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 // tag::buffer_slice_include[]
@@ -64,58 +39,58 @@
 // comment explains the loop body instead. The slice fragment discards
 // io_result values the same way.
 
+namespace capy = boost::capy;
+
 namespace {
 
-using namespace boost::capy;
-
-static_assert(ConstBufferSequence<const_buffer>);
-static_assert(ConstBufferSequence<std::vector<const_buffer>>);
-static_assert(!ConstBufferSequence<int>);
-static_assert(MutableBufferSequence<mutable_buffer>);
-static_assert(!MutableBufferSequence<const_buffer>);
+static_assert(capy::ConstBufferSequence<capy::const_buffer>);
+static_assert(capy::ConstBufferSequence<std::vector<capy::const_buffer>>);
+static_assert(!capy::ConstBufferSequence<int>);
+static_assert(capy::MutableBufferSequence<capy::mutable_buffer>);
+static_assert(!capy::MutableBufferSequence<capy::const_buffer>);
 
 // tag::send_signature[]
-template<ConstBufferSequence Buffers>
+template<capy::ConstBufferSequence Buffers>
 void send(Buffers const& bufs);
 // end::send_signature[]
 
 // Logs the element count of every call so all four calls are observable.
 std::vector<std::size_t> send_lengths;
 
-template<ConstBufferSequence Buffers>
+template<capy::ConstBufferSequence Buffers>
 void send(Buffers const& bufs)
 {
-    send_lengths.push_back(buffer_length(bufs));
+    send_lengths.push_back(capy::buffer_length(bufs));
 }
 
 // The custom type used by the heterogeneous-composition fragment.
 struct chained_buffers
 {
-    std::array<const_buffer, 3> parts;
+    std::array<capy::const_buffer, 3> parts;
     auto begin() const noexcept { return parts.begin(); }
     auto end() const noexcept { return parts.end(); }
 };
 
 // tag::iterate[]
-template<ConstBufferSequence Buffers>
+template<capy::ConstBufferSequence Buffers>
 void process(Buffers const& bufs)
 {
-    for (auto it = begin(bufs); it != end(bufs); ++it)
+    for (auto it = capy::begin(bufs); it != capy::end(bufs); ++it)
     {
-        const_buffer buf = *it;
+        capy::const_buffer buf = *it;
         // Process buf.data(), buf.size()
     }
 }
 // end::iterate[]
 
-using Stream = test::stream;
+using Stream = capy::test::stream;
 
 // tag::read_all[]
-template<MutableBufferSequence Buffers>
-task<std::size_t> read_all(Stream& stream, Buffers buffers)
+template<capy::MutableBufferSequence Buffers>
+capy::task<std::size_t> read_all(Stream& stream, Buffers buffers)
 {
-    consuming_buffers consuming(buffers);
-    std::size_t const total_size = buffer_size(buffers);
+    capy::consuming_buffers consuming(buffers);
+    std::size_t const total_size = capy::buffer_size(buffers);
     std::size_t total = 0;
 
     while (total < total_size)
@@ -131,16 +106,18 @@ task<std::size_t> read_all(Stream& stream, Buffers buffers)
 }
 // end::read_all[]
 
-task<> send_sliced(
+capy::task<> send_sliced(
     Stream& stream,
-    std::array<const_buffer, 2> const& bufs)
+    std::array<capy::const_buffer, 2> const& bufs)
 {
     // tag::buffer_slice[]
-    co_await write(stream, buffer_slice(bufs, 0, 16384));  // send only the first 16 KB
-    auto rest = buffer_slice(bufs, 16384);                 // everything after the first 16 KB
-    co_await write(stream, rest);
+    // send only the first 16 KB
+    co_await capy::write(stream, capy::buffer_slice(bufs, 0, 16384));
+    // everything after the first 16 KB
+    auto rest = capy::buffer_slice(bufs, 16384);
+    co_await capy::write(stream, rest);
     // end::buffer_slice[]
-    BOOST_TEST(buffer_size(rest) == buffer_size(bufs) - 16384);
+    BOOST_TEST(capy::buffer_size(rest) == capy::buffer_size(bufs) - 16384);
 }
 
 struct sequences_test
@@ -149,41 +126,43 @@ struct sequences_test
     {
         // tag::concept_models[]
         // Single buffers
-        const_buffer cb;                    // ConstBufferSequence
-        mutable_buffer mb;                  // MutableBufferSequence (and ConstBufferSequence)
+        capy::const_buffer cb;    // ConstBufferSequence
+        capy::mutable_buffer mb;  // MutableBufferSequence (and ConstBufferSequence)
 
         // Standard containers of buffers
-        std::vector<const_buffer> v;        // ConstBufferSequence
-        std::array<mutable_buffer, 3> a;    // MutableBufferSequence
+        std::vector<capy::const_buffer> v;        // ConstBufferSequence
+        std::array<capy::mutable_buffer, 3> a;    // MutableBufferSequence
 
         // String types (wrap with make_buffer to get a single buffer)
         std::string str;                    // make_buffer(str) -> mutable_buffer
         std::string_view sv;                // make_buffer(sv) -> const_buffer
         // end::concept_models[]
-        static_assert(ConstBufferSequence<decltype(cb)>);
-        static_assert(MutableBufferSequence<decltype(mb)>);
-        static_assert(ConstBufferSequence<decltype(v)>);
-        static_assert(MutableBufferSequence<decltype(a)>);
-        static_assert(!ConstBufferSequence<decltype(str)>);
-        static_assert(MutableBufferSequence<decltype(make_buffer(str))>);
-        static_assert(ConstBufferSequence<decltype(make_buffer(sv))>);
-        BOOST_TEST(buffer_size(cb) == 0);
+        static_assert(capy::ConstBufferSequence<decltype(cb)>);
+        static_assert(capy::MutableBufferSequence<decltype(mb)>);
+        static_assert(capy::ConstBufferSequence<decltype(v)>);
+        static_assert(capy::MutableBufferSequence<decltype(a)>);
+        static_assert(!capy::ConstBufferSequence<decltype(str)>);
+        static_assert(
+            capy::MutableBufferSequence<decltype(capy::make_buffer(str))>);
+        static_assert(
+            capy::ConstBufferSequence<decltype(capy::make_buffer(sv))>);
+        BOOST_TEST(capy::buffer_size(cb) == 0);
         BOOST_TEST(mb.size() == 0);
-        BOOST_TEST(buffer_size(v) == 0);
-        BOOST_TEST(buffer_size(a) == 0);
-        BOOST_TEST(make_buffer(str).size() == 0);
-        BOOST_TEST(make_buffer(sv).size() == 0);
+        BOOST_TEST(capy::buffer_size(v) == 0);
+        BOOST_TEST(capy::buffer_size(a) == 0);
+        BOOST_TEST(capy::make_buffer(str).size() == 0);
+        BOOST_TEST(capy::make_buffer(sv).size() == 0);
     }
 
     void testHeterogeneous()
     {
-        const_buffer buf1, buf2;
+        capy::const_buffer buf1, buf2;
         chained_buffers my_custom_buffer_sequence{};
         send_lengths.clear();
         // tag::send_calls[]
         // All of these work:
-        send(make_buffer("Hello"));                    // string literal
-        send(make_buffer(std::string_view{"Hello"}));  // string_view
+        send(capy::make_buffer("Hello"));                    // string literal
+        send(capy::make_buffer(std::string_view{"Hello"}));  // string_view
         send(std::array{buf1, buf2});                  // array of buffers
         send(my_custom_buffer_sequence);               // custom type
         // end::send_calls[]
@@ -194,22 +173,23 @@ struct sequences_test
     void testIterate()
     {
         char data[4] = {};
-        process(make_buffer(data));
-        process(std::array{const_buffer(data, 2), const_buffer(data + 2, 2)});
+        process(capy::make_buffer(data));
+        process(std::array{
+            capy::const_buffer(data, 2), capy::const_buffer(data + 2, 2)});
     }
 
     void testReadAll()
     {
-        auto [a, b] = test::make_stream_pair();
+        auto [a, b] = capy::test::make_stream_pair();
         b.provide("abcdefghijklmnopqrst");  // 20 bytes readable from a
         a.set_max_read_size(7);             // force several partial reads
 
         std::vector<char> head(8), tail(12);
-        std::array<mutable_buffer, 2> bufs{
-            make_buffer(head), make_buffer(tail)};
+        std::array<capy::mutable_buffer, 2> bufs{
+            capy::make_buffer(head), capy::make_buffer(tail)};
 
         std::size_t got = 0;
-        test::run_blocking([&](std::size_t n) { got = n; })(
+        capy::test::run_blocking([&](std::size_t n) { got = n; })(
             read_all(a, bufs));
 
         BOOST_TEST(got == 20);
@@ -219,13 +199,13 @@ struct sequences_test
 
     void testBufferSlice()
     {
-        auto [a, b] = test::make_stream_pair();
+        auto [a, b] = capy::test::make_stream_pair();
         std::string part1(10000, 'x');
         std::string part2(10000, 'y');
-        std::array<const_buffer, 2> bufs{
-            make_buffer(part1), make_buffer(part2)};
+        std::array<capy::const_buffer, 2> bufs{
+            capy::make_buffer(part1), capy::make_buffer(part2)};
 
-        test::run_blocking()(send_sliced(a, bufs));
+        capy::test::run_blocking()(send_sliced(a, bufs));
 
         BOOST_TEST(b.data() == part1 + part2);
     }

--- a/test/doc/snippets/5d_system_io.cpp
+++ b/test/doc/snippets/5d_system_io.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -11,32 +12,7 @@
 // OS-level fragments compile only where the platform headers exist;
 // guards keep this TU portable while the tags stay extractable.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 // tag::include_buffers[]
 #include <boost/capy/buffers.hpp>
@@ -61,13 +37,13 @@
 #include <liburing.h>
 #endif
 
+namespace capy = boost::capy;
+
 namespace {
 
-using namespace boost::capy;
-
 // tag::write_some_signature[]
-template<ConstBufferSequence Buffers>
-io_task<std::size_t> write_some(Buffers buffers);
+template<capy::ConstBufferSequence Buffers>
+capy::io_task<std::size_t> write_some(Buffers buffers);
 // end::write_some_signature[]
 
 #if defined(BOOST_CAPY_DOC_HAS_POSIX_IO)
@@ -133,24 +109,24 @@ use_registered_buffers(
 
 #endif // __has_include(<liburing.h>)
 
-const_buffer
+capy::const_buffer
 assemble_message()
 {
     static char const msg[] = "assembled message";
-    return const_buffer(msg, sizeof(msg) - 1);
+    return capy::const_buffer(msg, sizeof(msg) - 1);
 }
 
-[[maybe_unused]] task<>
-minimize_buffer_count(test::stream& stream)
+[[maybe_unused]] capy::task<>
+minimize_buffer_count(capy::test::stream& stream)
 {
     // tag::minimize_buffer_count[]
     // Prefer: single buffer when possible
     auto buf = assemble_message();  // Build in one buffer
-    co_await write(stream, buf);
+    co_await capy::write(stream, buf);
 
     // Avoid: many tiny buffers
-    std::array<const_buffer, 100> tiny_bufs;
-    co_await write(stream, tiny_bufs);  // 100-element translation
+    std::array<capy::const_buffer, 100> tiny_bufs;
+    co_await capy::write(stream, tiny_bufs);  // 100-element translation
     // end::minimize_buffer_count[]
 }
 

--- a/test/doc/snippets/5e_algorithms.cpp
+++ b/test/doc/snippets/5e_algorithms.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/5.buffers/5e.algorithms.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/buffers/buffer_copy.hpp>
@@ -59,17 +35,18 @@
 
 #include "test_suite.hpp"
 
+namespace capy = boost::capy;
+
 namespace {
 
-using namespace boost::capy;
 using namespace std::string_view_literals;
 
 // tag::read_loop[]
-template<ReadStream Stream, MutableBufferSequence Buffers>
-task<std::size_t> read_full(Stream& stream, Buffers buffers)
+template<capy::ReadStream Stream, capy::MutableBufferSequence Buffers>
+capy::task<std::size_t> read_full(Stream& stream, Buffers buffers)
 {
-    consuming_buffers remaining(buffers);
-    std::size_t const total_size = buffer_size(buffers);
+    capy::consuming_buffers remaining(buffers);
+    std::size_t const total_size = capy::buffer_size(buffers);
     std::size_t total = 0;
 
     while (total < total_size)
@@ -86,11 +63,11 @@ task<std::size_t> read_full(Stream& stream, Buffers buffers)
 // end::read_loop[]
 
 // tag::write_loop[]
-template<WriteStream Stream, ConstBufferSequence Buffers>
-task<std::size_t> write_full(Stream& stream, Buffers buffers)
+template<capy::WriteStream Stream, capy::ConstBufferSequence Buffers>
+capy::task<std::size_t> write_full(Stream& stream, Buffers buffers)
 {
-    consuming_buffers remaining(buffers);
-    std::size_t const total_size = buffer_size(buffers);
+    capy::consuming_buffers remaining(buffers);
+    std::size_t const total_size = capy::buffer_size(buffers);
     std::size_t total = 0;
 
     while (total < total_size)
@@ -118,41 +95,41 @@ load_body()
     return {'b', 'o', 'd', 'y'};
 }
 
-[[maybe_unused]] task<>
-zero_copy_write(test::stream& stream)
+[[maybe_unused]] capy::task<>
+zero_copy_write(capy::test::stream& stream)
 {
     // tag::zero_copy[]
     std::string header = build_header();
     std::vector<char> body = load_body();
 
     // No copying—header and body are written directly
-    std::array buffers = {make_buffer(header), make_buffer(body)};
-    co_await write(stream, buffers);
+    std::array buffers = {capy::make_buffer(header), capy::make_buffer(body)};
+    co_await capy::write(stream, buffers);
     // end::zero_copy[]
 }
 
-[[maybe_unused]] task<>
+[[maybe_unused]] capy::task<>
 scatter_gather_write(
-    test::stream& stream,
-    const_buffer header_buf, const_buffer separator_buf,
-    const_buffer body_buf, const_buffer footer_buf)
+    capy::test::stream& stream,
+    capy::const_buffer header_buf, capy::const_buffer separator_buf,
+    capy::const_buffer body_buf, capy::const_buffer footer_buf)
 {
     // tag::scatter_gather[]
     std::array buffers = {header_buf, separator_buf, body_buf, footer_buf};
-    co_await write(stream, buffers);  // Single system call
+    co_await capy::write(stream, buffers);  // Single system call
     // end::scatter_gather[]
 }
 
 #if __has_include(<sys/mman.h>)
 
-[[maybe_unused]] task<>
-send_mapped_file(test::stream& socket, int fd, std::size_t file_size)
+[[maybe_unused]] capy::task<>
+send_mapped_file(capy::test::stream& socket, int fd, std::size_t file_size)
 {
     // tag::mmap_buffer[]
     // Memory-mapped file
     void* mapped = mmap(nullptr, file_size, PROT_READ, MAP_PRIVATE, fd, 0);
-    const_buffer file_buf(mapped, file_size);
-    co_await write(socket, file_buf);  // Zero-copy network transmission
+    capy::const_buffer file_buf(mapped, file_size);
+    co_await capy::write(socket, file_buf);  // Zero-copy network transmission
     // end::mmap_buffer[]
 }
 
@@ -165,7 +142,7 @@ class chunk_iterator
     std::vector<std::vector<char>>::const_iterator it_;
 
 public:
-    using value_type = const_buffer;
+    using value_type = capy::const_buffer;
     using difference_type = std::ptrdiff_t;
 
     chunk_iterator() = default;
@@ -176,9 +153,9 @@ public:
     {
     }
 
-    const_buffer operator*() const
+    capy::const_buffer operator*() const
     {
-        return make_buffer(*it_);
+        return capy::make_buffer(*it_);
     }
 
     chunk_iterator& operator++()
@@ -222,20 +199,20 @@ public:
 // Satisfies ConstBufferSequence—works with all algorithms
 // end::custom_sequence[]
 
-static_assert(ConstBufferSequence<chunked_buffer_sequence>);
+static_assert(capy::ConstBufferSequence<chunked_buffer_sequence>);
 
-task<>
+capy::task<>
 read_full_driver(
-    test::stream& wr, test::stream& rd,
-    std::array<mutable_buffer, 2> bufs, std::size_t& got)
+    capy::test::stream& wr, capy::test::stream& rd,
+    std::array<capy::mutable_buffer, 2> bufs, std::size_t& got)
 {
-    co_await write(wr, make_buffer("hello world"sv));
+    co_await capy::write(wr, capy::make_buffer("hello world"sv));
     got = co_await read_full(rd, bufs);
 }
 
-task<>
+capy::task<>
 write_full_driver(
-    test::stream& wr, std::array<const_buffer, 2> bufs,
+    capy::test::stream& wr, std::array<capy::const_buffer, 2> bufs,
     std::size_t& put)
 {
     put = co_await write_full(wr, bufs);
@@ -247,11 +224,11 @@ struct algorithms_test
     testBufferSize()
     {
         // tag::buffer_size_example[]
-        auto buf1 = make_buffer("hello"sv);  // 5 bytes
-        auto buf2 = make_buffer("world"sv);  // 5 bytes
+        auto buf1 = capy::make_buffer("hello"sv);  // 5 bytes
+        auto buf2 = capy::make_buffer("world"sv);  // 5 bytes
         auto combined = std::array{buf1, buf2};
 
-        std::size_t total = buffer_size(combined);  // 10
+        std::size_t total = capy::buffer_size(combined);  // 10
         // end::buffer_size_example[]
         BOOST_TEST(total == 10);
     }
@@ -260,31 +237,31 @@ struct algorithms_test
     testBufferEmpty()
     {
         // tag::buffer_empty_example[]
-        const_buffer empty_buf;
-        buffer_empty(empty_buf);  // true
+        capy::const_buffer empty_buf;
+        capy::buffer_empty(empty_buf);  // true
 
-        const_buffer non_empty("data", 4);
-        buffer_empty(non_empty);  // false
+        capy::const_buffer non_empty("data", 4);
+        capy::buffer_empty(non_empty);  // false
         // end::buffer_empty_example[]
-        BOOST_TEST(buffer_empty(empty_buf));
-        BOOST_TEST(! buffer_empty(non_empty));
+        BOOST_TEST(capy::buffer_empty(empty_buf));
+        BOOST_TEST(! capy::buffer_empty(non_empty));
     }
 
     void
     testBufferLength()
     {
-        const_buffer buf1("one", 3);
-        const_buffer buf2("two", 3);
-        const_buffer buf3("three", 5);
+        capy::const_buffer buf1("one", 3);
+        capy::const_buffer buf2("two", 3);
+        capy::const_buffer buf3("three", 5);
         // tag::buffer_length_example[]
-        auto single = make_buffer("hello"sv);
-        buffer_length(single);  // 1
+        auto single = capy::make_buffer("hello"sv);
+        capy::buffer_length(single);  // 1
 
         auto arr = std::array{buf1, buf2, buf3};
-        buffer_length(arr);  // 3
+        capy::buffer_length(arr);  // 3
         // end::buffer_length_example[]
-        BOOST_TEST(buffer_length(single) == 1);
-        BOOST_TEST(buffer_length(arr) == 3);
+        BOOST_TEST(capy::buffer_length(single) == 1);
+        BOOST_TEST(capy::buffer_length(arr) == 3);
     }
 
     void
@@ -294,10 +271,10 @@ struct algorithms_test
         char source_data[] = "hello world";
         char dest_data[20];
 
-        const_buffer src(source_data, 11);
-        mutable_buffer dst(dest_data, 20);
+        capy::const_buffer src(source_data, 11);
+        capy::mutable_buffer dst(dest_data, 20);
 
-        std::size_t copied = buffer_copy(dst, src);  // 11
+        std::size_t copied = capy::buffer_copy(dst, src);  // 11
         // end::buffer_copy_example[]
         BOOST_TEST(copied == 11);
         BOOST_TEST(std::memcmp(dest_data, "hello world", 11) == 0);
@@ -308,10 +285,11 @@ struct algorithms_test
     {
         char source_data[] = "hello world";
         char dest_data[20] = {};
-        const_buffer src(source_data, 11);
-        mutable_buffer dst(dest_data, 20);
+        capy::const_buffer src(source_data, 11);
+        capy::mutable_buffer dst(dest_data, 20);
         // tag::buffer_copy_at_most[]
-        std::size_t copied = buffer_copy(dst, src, 5);  // Copy at most 5 bytes
+        // Copy at most 5 bytes
+        std::size_t copied = capy::buffer_copy(dst, src, 5);
         // end::buffer_copy_at_most[]
         BOOST_TEST(copied == 5);
         BOOST_TEST(std::memcmp(dest_data, "hello", 5) == 0);
@@ -320,22 +298,22 @@ struct algorithms_test
     void
     testCrossSequenceCopy()
     {
-        const_buffer buf1("abc", 3);
-        const_buffer buf2("defg", 4);
-        const_buffer buf3("hi", 2);
+        capy::const_buffer buf1("abc", 3);
+        capy::const_buffer buf2("defg", 4);
+        capy::const_buffer buf3("hi", 2);
         char big_data[6] = {};
         char small_data[2] = {};
-        mutable_buffer large_buf(big_data, 6);
-        mutable_buffer small_buf(small_data, 2);
+        capy::mutable_buffer large_buf(big_data, 6);
+        capy::mutable_buffer small_buf(small_data, 2);
         // tag::buffer_copy_cross[]
         // Source: 3 buffers
-        std::array<const_buffer, 3> src = {buf1, buf2, buf3};
+        std::array<capy::const_buffer, 3> src = {buf1, buf2, buf3};
 
         // Target: 2 buffers with different sizes
-        std::array<mutable_buffer, 2> dst = {large_buf, small_buf};
+        std::array<capy::mutable_buffer, 2> dst = {large_buf, small_buf};
 
         // Copies across buffer boundaries as needed
-        std::size_t copied = buffer_copy(dst, src);
+        std::size_t copied = capy::buffer_copy(dst, src);
         // end::buffer_copy_cross[]
         BOOST_TEST(copied == 8);
         BOOST_TEST(std::memcmp(big_data, "abcdef", 6) == 0);
@@ -345,14 +323,14 @@ struct algorithms_test
     void
     testReadFull()
     {
-        auto [a, b] = test::make_stream_pair();
+        auto [a, b] = capy::test::make_stream_pair();
         char storage1[6] = {};
         char storage2[5] = {};
-        std::array<mutable_buffer, 2> bufs = {
-            mutable_buffer(storage1, 6),
-            mutable_buffer(storage2, 5)};
+        std::array<capy::mutable_buffer, 2> bufs = {
+            capy::mutable_buffer(storage1, 6),
+            capy::mutable_buffer(storage2, 5)};
         std::size_t got = 0;
-        test::run_blocking()(read_full_driver(a, b, bufs, got));
+        capy::test::run_blocking()(read_full_driver(a, b, bufs, got));
         BOOST_TEST(got == 11);
         BOOST_TEST(std::memcmp(storage1, "hello ", 6) == 0);
         BOOST_TEST(std::memcmp(storage2, "world", 5) == 0);
@@ -361,12 +339,12 @@ struct algorithms_test
     void
     testWriteFull()
     {
-        auto [a, b] = test::make_stream_pair();
-        std::array<const_buffer, 2> bufs = {
-            make_buffer("hello "sv),
-            make_buffer("world"sv)};
+        auto [a, b] = capy::test::make_stream_pair();
+        std::array<capy::const_buffer, 2> bufs = {
+            capy::make_buffer("hello "sv),
+            capy::make_buffer("world"sv)};
         std::size_t put = 0;
-        test::run_blocking()(write_full_driver(a, bufs, put));
+        capy::test::run_blocking()(write_full_driver(a, bufs, put));
         BOOST_TEST(put == 11);
         BOOST_TEST(b.data() == "hello world");
     }

--- a/test/doc/snippets/6a_overview.cpp
+++ b/test/doc/snippets/6a_overview.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/6.streams/6a.overview.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/buffers/buffer_copy.hpp>
@@ -56,12 +32,11 @@ namespace capy = boost::capy;
 
 namespace {
 
-using namespace boost::capy;
 
-task<> partial_read(test::stream& stream)
+capy::task<> partial_read(capy::test::stream& stream)
 {
     char storage[1024];
-    auto buffer = make_buffer(storage);
+    auto buffer = capy::make_buffer(storage);
     // tag::read_stream_partial[]
     // ReadStream: may return fewer bytes than buffer can hold
     auto [ec, n] = co_await stream.read_some(buffer);
@@ -71,9 +46,9 @@ task<> partial_read(test::stream& stream)
     BOOST_TEST(n >= 1);
 }
 
-task<> partial_write(test::stream& stream)
+capy::task<> partial_write(capy::test::stream& stream)
 {
-    const_buffer buffers("hello", 5);
+    capy::const_buffer buffers("hello", 5);
     // tag::write_stream_partial[]
     // WriteStream: may write fewer bytes than provided
     auto [ec, n] = co_await stream.write_some(buffers);
@@ -85,14 +60,15 @@ task<> partial_write(test::stream& stream)
 
 // tag::any_stream_echo[]
 // This function works with any stream implementation
-task<> echo(any_stream& stream)
+capy::task<> echo(capy::any_stream& stream)
 {
     char buf[1024];
     for (;;)
     {
-        auto [ec, n] = co_await stream.read_some(make_buffer(buf));
+        auto [ec, n] = co_await stream.read_some(capy::make_buffer(buf));
 
-        auto [wec, wn] = co_await write(stream, const_buffer(buf, n));
+        auto [wec, wn] = co_await capy::write(
+            stream, capy::const_buffer(buf, n));
 
         if (ec)
             co_return;
@@ -108,10 +84,10 @@ struct overview_test
     void
     testPartialReadWrite()
     {
-        auto [a, b] = test::make_stream_pair();
+        auto [a, b] = capy::test::make_stream_pair();
         b.provide("hello");
-        test::run_blocking()(partial_read(a));
-        test::run_blocking()(partial_write(a));
+        capy::test::run_blocking()(partial_read(a));
+        capy::test::run_blocking()(partial_write(a));
         BOOST_TEST(b.data() == "hello");
     }
 
@@ -119,13 +95,13 @@ struct overview_test
     testCallerDecides()
     {
         // tag::caller_decides[]
-        auto [client, server] = test::make_stream_pair();
+        auto [client, server] = capy::test::make_stream_pair();
 
         // Owns the moved-in stream (the by-value form takes ownership)
-        any_stream s1{std::move(client)};
+        capy::any_stream s1{std::move(client)};
 
         // Wraps the server end by pointer (reference semantics, must outlive s2)
-        any_stream s2{&server};
+        capy::any_stream s2{&server};
         // end::caller_decides[]
 
         // Feed the client end and signal eof so echo() terminates.
@@ -135,15 +111,15 @@ struct overview_test
         // tag::caller_decides[]
 
         // Same echo() coroutine regardless of how the wrapper was built
-        test::run_blocking()(echo(s1));
+        capy::test::run_blocking()(echo(s1));
         // end::caller_decides[]
 
         // The echoed bytes arrive on the server end; read them
         // through s2 to exercise the reference-mode wrapper.
-        test::run_blocking()([](any_stream& s) -> task<>
+        capy::test::run_blocking()([](capy::any_stream& s) -> capy::task<>
         {
             char buf[8];
-            auto [ec, n] = co_await s.read_some(make_buffer(buf));
+            auto [ec, n] = co_await s.read_some(capy::make_buffer(buf));
             BOOST_TEST(! ec);
             BOOST_TEST(std::string_view(buf, n) == "ping");
         }(s2));

--- a/test/doc/snippets/6b_streams.cpp
+++ b/test/doc/snippets/6b_streams.cpp
@@ -10,32 +10,7 @@
 
 // Compiled fragments shown in pages/6.streams/6b.streams.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/buffers/make_buffer.hpp>
@@ -69,16 +44,15 @@ namespace capy = boost::capy;
 
 namespace {
 
-using namespace boost::capy;
 
 static_assert(capy::ReadStream<capy::test::stream>);
 static_assert(capy::WriteStream<capy::test::stream>);
 
-task<> partial_read(test::stream& stream)
+capy::task<> partial_read(capy::test::stream& stream)
 {
     // tag::read_partial[]
     char buf[1024];
-    auto [ec, n] = co_await stream.read_some(make_buffer(buf));
+    auto [ec, n] = co_await stream.read_some(capy::make_buffer(buf));
     // n might be 1, might be 500, might be 1024
     // if !ec, then n >= 1
     // end::read_partial[]
@@ -87,14 +61,14 @@ task<> partial_read(test::stream& stream)
 }
 
 // tag::dump_stream[]
-template<ReadStream Stream>
-task<> dump_stream(Stream& stream)
+template<capy::ReadStream Stream>
+capy::task<> dump_stream(Stream& stream)
 {
     char buf[256];
 
     for (;;)
     {
-        auto [ec, n] = co_await stream.read_some(make_buffer(buf));
+        auto [ec, n] = co_await stream.read_some(capy::make_buffer(buf));
 
         std::cout.write(buf, n);
 
@@ -104,10 +78,11 @@ task<> dump_stream(Stream& stream)
 }
 // end::dump_stream[]
 
-task<> partial_write(test::stream& stream, std::string const& large_data)
+capy::task<> partial_write(
+    capy::test::stream& stream, std::string const& large_data)
 {
     // tag::write_partial[]
-    auto [ec, n] = co_await stream.write_some(make_buffer(large_data));
+    auto [ec, n] = co_await stream.write_some(capy::make_buffer(large_data));
     // n might be less than large_data.size()
     // end::write_partial[]
     BOOST_TEST(! ec);
@@ -123,11 +98,11 @@ class any_read_stream
 public:
     // tag::any_read_stream_ctors[]
     // Owning: takes ownership of a moved-in stream
-    template<ReadStream S>
+    template<capy::ReadStream S>
     any_read_stream(S stream);
 
     // Reference: wraps by pointer without ownership
-    template<ReadStream S>
+    template<capy::ReadStream S>
     any_read_stream(S* stream);
     // end::any_read_stream_ctors[]
 };
@@ -136,10 +111,10 @@ class any_write_stream
 {
 public:
     // tag::any_write_stream_ctors[]
-    template<WriteStream S>
+    template<capy::WriteStream S>
     any_write_stream(S stream);   // owning
 
-    template<WriteStream S>
+    template<capy::WriteStream S>
     any_write_stream(S* stream);  // reference
     // end::any_write_stream_ctors[]
 };
@@ -149,11 +124,11 @@ class any_stream
 public:
     // tag::any_stream_ctors[]
     template<class S>
-        requires ReadStream<S> && WriteStream<S>
+        requires capy::ReadStream<S> && capy::WriteStream<S>
     any_stream(S stream);   // owning
 
     template<class S>
-        requires ReadStream<S> && WriteStream<S>
+        requires capy::ReadStream<S> && capy::WriteStream<S>
     any_stream(S* stream);  // reference
     // end::any_stream_ctors[]
 };
@@ -161,11 +136,11 @@ public:
 } // namespace synopsis
 
 // Scaffolding target for the wrapper_usage fragment.
-void process_stream(any_stream& stream)
+void process_stream(capy::any_stream& stream)
 {
-    test::run_blocking()([](any_stream& s) -> task<>
+    capy::test::run_blocking()([](capy::any_stream& s) -> capy::task<>
     {
-        auto [ec, n] = co_await s.write_some(const_buffer("ok", 2));
+        auto [ec, n] = co_await s.write_some(capy::const_buffer("ok", 2));
         BOOST_TEST(! ec);
         BOOST_TEST(n == 2);
     }(stream));
@@ -173,18 +148,19 @@ void process_stream(any_stream& stream)
 
 // tag::echo_server[]
 // echo.hpp - Header only declares the signature
-task<> handle_connection(any_stream& stream);
+capy::task<> handle_connection(capy::any_stream& stream);
 
 // echo.cpp - Implementation in separate translation unit
-task<> handle_connection(any_stream& stream)
+capy::task<> handle_connection(capy::any_stream& stream)
 {
     char buf[1024];
 
     for (;;)
     {
-        auto [ec, n] = co_await stream.read_some(make_buffer(buf));
+        auto [ec, n] = co_await stream.read_some(capy::make_buffer(buf));
 
-        auto [wec, wn] = co_await write(stream, const_buffer(buf, n));
+        auto [wec, wn] = co_await capy::write(
+            stream, capy::const_buffer(buf, n));
 
         if (ec)
             break;
@@ -200,22 +176,22 @@ struct streams_test
     void
     testPartialRead()
     {
-        auto [a, b] = test::make_stream_pair();
+        auto [a, b] = capy::test::make_stream_pair();
         b.provide("hello");
-        test::run_blocking()(partial_read(a));
+        capy::test::run_blocking()(partial_read(a));
     }
 
     void
     testDumpStream()
     {
-        auto [a, b] = test::make_stream_pair();
+        auto [a, b] = capy::test::make_stream_pair();
         b.provide("dumped");
         b.close();
 
         // Capture std::cout so the fragment's output is observable.
         std::ostringstream out;
         auto* old = std::cout.rdbuf(out.rdbuf());
-        test::run_blocking()(dump_stream(a));
+        capy::test::run_blocking()(dump_stream(a));
         std::cout.rdbuf(old);
         BOOST_TEST(out.str() == "dumped");
     }
@@ -223,9 +199,9 @@ struct streams_test
     void
     testPartialWrite()
     {
-        auto [a, b] = test::make_stream_pair();
+        auto [a, b] = capy::test::make_stream_pair();
         std::string large_data(64, 'x');
-        test::run_blocking()(partial_write(a, large_data));
+        capy::test::run_blocking()(partial_write(a, large_data));
         BOOST_TEST(b.data() == large_data);
     }
 
@@ -233,12 +209,14 @@ struct streams_test
     testWrapperUsage()
     {
         // tag::wrapper_usage[]
-        void process_stream(any_stream& stream);
+        void process_stream(capy::any_stream& stream);
 
-        auto [client, server] = test::make_stream_pair();
+        auto [client, server] = capy::test::make_stream_pair();
 
-        any_stream wrapped{&client};  // Type erasure, references the existing stream
-        process_stream(wrapped);      // process_stream doesn't know about test::stream
+        // Type erasure, references the existing stream
+        capy::any_stream wrapped{&client};
+        // process_stream doesn't know about test::stream
+        process_stream(wrapped);
         // end::wrapper_usage[]
         BOOST_TEST(server.data() == "ok");
     }
@@ -246,11 +224,11 @@ struct streams_test
     void
     testEchoServer()
     {
-        auto [a, b] = test::make_stream_pair();
+        auto [a, b] = capy::test::make_stream_pair();
         b.provide("echo!");
         b.close();
-        any_stream stream{&a};
-        test::run_blocking()(handle_connection(stream));
+        capy::any_stream stream{&a};
+        capy::test::run_blocking()(handle_connection(stream));
         BOOST_TEST(b.data() == "echo!");
     }
 

--- a/test/doc/snippets/6f_isolation.cpp
+++ b/test/doc/snippets/6f_isolation.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -12,32 +13,7 @@
 // page's protocol.hpp and http_client.hpp live next to this file.
 
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 // The user_code fragment deliberately omits the headers field in a
 // designated initializer; the default is part of the lesson.
@@ -71,21 +47,23 @@
 
 #include "test_suite.hpp"
 
+namespace capy = boost::capy;
+
 // tag::protocol_impl[]
 
-task<> handle_protocol(any_stream& stream)
+capy::task<> handle_protocol(capy::any_stream& stream)
 {
     char buf[1024];
 
     for (;;)
     {
-        auto [ec, n] = co_await stream.read_some(make_buffer(buf));
+        auto [ec, n] = co_await stream.read_some(capy::make_buffer(buf));
         if (ec)
             co_return;
 
         // Process and respond...
         std::string response(buf, n);
-        co_await write(stream, make_buffer(response));
+        co_await capy::write(stream, capy::make_buffer(response));
     }
 }
 // end::protocol_impl[]
@@ -99,18 +77,18 @@ namespace tcp {
 
 class socket
 {
-    std::pair<test::stream, test::stream> loop_ =
-        test::make_stream_pair();
-    test::fuse f_;
-    test::write_stream sink_{f_};
+    std::pair<capy::test::stream, capy::test::stream> loop_ =
+        capy::test::make_stream_pair();
+    capy::test::fuse f_;
+    capy::test::write_stream sink_{f_};
 
 public:
-    auto read_some(MutableBufferSequence auto b)
+    auto read_some(capy::MutableBufferSequence auto b)
     {
         return loop_.first.read_some(b);
     }
 
-    auto write_some(ConstBufferSequence auto b)
+    auto write_some(capy::ConstBufferSequence auto b)
     {
         return sink_.write_some(b);
     }
@@ -122,11 +100,11 @@ namespace tls {
 
 class stream
 {
-    test::fuse f_;
-    test::write_stream sink_{f_};
+    capy::test::fuse f_;
+    capy::test::write_stream sink_{f_};
 
 public:
-    auto write_some(ConstBufferSequence auto b)
+    auto write_some(capy::ConstBufferSequence auto b)
     {
         return sink_.write_some(b);
     }
@@ -142,20 +120,20 @@ struct message
 
 // tag::send_message[]
 // Your library code
-task<> send_message(any_write_stream& stream, message const& msg)
+capy::task<> send_message(capy::any_write_stream& stream, message const& msg)
 {
-    co_await write(stream, make_buffer(msg.header));
-    co_await write(stream, make_buffer(msg.body));
+    co_await capy::write(stream, capy::make_buffer(msg.header));
+    co_await capy::write(stream, capy::make_buffer(msg.body));
 }
 // end::send_message[]
 
-task<> use_transports(message const& msg)
+capy::task<> use_transports(message const& msg)
 {
     {
         // tag::callers[]
         // TCP socket
         tcp::socket socket;
-        any_write_stream stream{&socket};  // references socket
+        capy::any_write_stream stream{&socket};  // references socket
         co_await send_message(stream, msg);
         // end::callers[]
     }
@@ -164,17 +142,17 @@ task<> use_transports(message const& msg)
 
         // TLS stream
         tls::stream tls;
-        any_write_stream stream{&tls};  // references tls
+        capy::any_write_stream stream{&tls};  // references tls
         co_await send_message(stream, msg);
         // end::callers[]
     }
     {
-        test::fuse f;
+        capy::test::fuse f;
         // tag::callers[]
 
         // Test mock
-        test::write_stream mock(f);
-        any_write_stream stream{&mock};  // references mock
+        capy::test::write_stream mock(f);
+        capy::any_write_stream stream{&mock};  // references mock
         co_await send_message(stream, msg);
         // end::callers[]
         BOOST_TEST(mock.data() == msg.header + msg.body);
@@ -191,7 +169,7 @@ namespace before_after_6f {
 // tag::templates_before[]
 // Old approach: template propagates everywhere
 template<typename Stream>
-task<> handle_protocol(Stream& stream);
+capy::task<> handle_protocol(Stream& stream);
 
 // Every caller instantiates for their stream type
 // Changes force recompilation of all callers
@@ -199,7 +177,7 @@ task<> handle_protocol(Stream& stream);
 
 // tag::type_erasure_after[]
 // New approach: concrete signature
-task<> handle_protocol(any_stream& stream);
+capy::task<> handle_protocol(capy::any_stream& stream);
 
 // Implementation compiles once
 // Callers only depend on the signature
@@ -211,22 +189,22 @@ namespace guidelines_6f {
 
 // tag::accept_type_erased[]
 // Good: accepts any stream
-task<> process(any_stream& stream);
+capy::task<> process(capy::any_stream& stream);
 
 // Avoid: forces specific type
-task<> process(tcp::socket& socket);
+capy::task<> process(tcp::socket& socket);
 // end::accept_type_erased[]
 
 // Definition so the callers below link.
-task<> process(any_stream&)
+capy::task<> process(capy::any_stream&)
 {
     co_return;
 }
 
 // tag::wrap_call_site[]
-task<> caller(tcp::socket& socket)
+capy::task<> caller(tcp::socket& socket)
 {
-    any_stream stream{&socket};  // Wrap by reference here
+    capy::any_stream stream{&socket};  // Wrap by reference here
     co_await process(stream);    // Call with erased type
 }
 // end::wrap_call_site[]
@@ -241,12 +219,12 @@ tcp::socket create_socket()
     return {};
 }
 
-task<> wrap_if_needed()
+capy::task<> wrap_if_needed()
 {
     // tag::return_concrete_use[]
     // Then caller wraps if needed
     auto socket = create_socket();
-    any_stream stream{&socket};  // reference; socket must outlive stream
+    capy::any_stream stream{&socket};  // reference; socket must outlive stream
     // or: any_stream stream{std::move(socket)};  // wrapper takes ownership
     // end::return_concrete_use[]
     co_await process(stream);
@@ -257,14 +235,14 @@ task<> wrap_if_needed()
 namespace {
 
 // The request literal intentionally leaves `headers` defaulted.
-task<> user_code()
+capy::task<> user_code()
 {
     // tag::user_code[]
     // User code
     tcp::socket socket;
     // ... connect ...
 
-    any_stream conn{&socket};  // references socket
+    capy::any_stream conn{&socket};  // references socket
     http_request req{
         .method = "GET",
         .url = "/api/data"
@@ -273,7 +251,7 @@ task<> user_code()
 
     // Read body through type-erased source
     char storage[4096];
-    mutable_buffer buf(storage, sizeof(storage));
+    capy::mutable_buffer buf(storage, sizeof(storage));
     auto [ec, n] = co_await response.body.read_some(buf);
     // end::user_code[]
     BOOST_TEST(!ec);
@@ -286,11 +264,11 @@ struct isolation_test
     void
     testHandleProtocol()
     {
-        auto [a, b] = test::make_stream_pair();
+        auto [a, b] = capy::test::make_stream_pair();
         b.provide("ping");
         b.close();
-        any_stream stream{&a};
-        test::run_blocking()(handle_protocol(stream));
+        capy::any_stream stream{&a};
+        capy::test::run_blocking()(handle_protocol(stream));
         // The protocol echoes what it read back to the peer.
         BOOST_TEST(b.data() == "ping");
     }
@@ -298,10 +276,10 @@ struct isolation_test
     void
     testSendMessage()
     {
-        test::fuse f;
-        test::write_stream mock(f);
-        any_write_stream stream{&mock};
-        test::run_blocking()(
+        capy::test::fuse f;
+        capy::test::write_stream mock(f);
+        capy::any_write_stream stream{&mock};
+        capy::test::run_blocking()(
             send_message(stream, {"HDR", "BODY"}));
         BOOST_TEST(mock.data() == "HDRBODY");
     }
@@ -309,7 +287,7 @@ struct isolation_test
     void
     testTransports()
     {
-        test::run_blocking()(
+        capy::test::run_blocking()(
             use_transports({"HDR", "BODY"}));
     }
 
@@ -317,14 +295,14 @@ struct isolation_test
     testGuidelines()
     {
         tcp::socket socket;
-        test::run_blocking()(guidelines_6f::caller(socket));
-        test::run_blocking()(guidelines_6f::wrap_if_needed());
+        capy::test::run_blocking()(guidelines_6f::caller(socket));
+        capy::test::run_blocking()(guidelines_6f::wrap_if_needed());
     }
 
     void
     testUserCode()
     {
-        test::run_blocking()(user_code());
+        capy::test::run_blocking()(user_code());
     }
 
     void
@@ -342,12 +320,12 @@ struct isolation_test
 
 // Definition so the user-code fragment links; a real client would parse
 // an HTTP response off the wire.
-task<http_response> send_request(any_stream&, http_request const&)
+capy::task<http_response> send_request(capy::any_stream&, http_request const&)
 {
-    test::fuse f;
-    test::read_stream body(f);
+    capy::test::fuse f;
+    capy::test::read_stream body(f);
     body.provide("{}");
-    co_return http_response{200, {}, any_read_stream(std::move(body))};
+    co_return http_response{200, {}, capy::any_read_stream(std::move(body))};
 }
 
 TEST_SUITE(isolation_test, "boost.capy.doc.6f_isolation");

--- a/test/doc/snippets/7a_drivers.cpp
+++ b/test/doc/snippets/7a_drivers.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/7.testing/7a.drivers.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers/make_buffer.hpp>
 #include <boost/capy/cond.hpp>
@@ -63,10 +39,9 @@ namespace {
 #include <boost/capy/task.hpp>
 #include <boost/capy/test/run_blocking.hpp>
 
-using namespace boost::capy;
-using namespace boost::capy::test;
+namespace capy = boost::capy;
 
-task<int> compute(int x)
+capy::task<int> compute(int x)
 {
     co_return x * 2;
 }
@@ -74,12 +49,12 @@ task<int> compute(int x)
 void test_compute()
 {
     int result = 0;
-    run_blocking([&](int v) { result = v; })(compute(21));
+    capy::test::run_blocking([&](int v) { result = v; })(compute(21));
     BOOST_TEST(result == 42);
 }
 // end::run_blocking_basic[]
 
-task<> my_task()
+capy::task<> my_task()
 {
     co_return;
 }
@@ -87,13 +62,12 @@ task<> my_task()
 // tag::fuse_basic[]
 #include <boost/capy/test/fuse.hpp>
 
-using namespace boost::capy;
-using namespace boost::capy::test;
+namespace capy = boost::capy;
 
 void test_with_fuse()
 {
-    fuse f;
-    auto r = f.armed([](fuse& f) {
+    capy::test::fuse f;
+    auto r = f.armed([](capy::test::fuse& f) {
         auto ec = f.maybe_fail();
         if(ec)
             return;  // injected error: exit gracefully
@@ -107,7 +81,8 @@ void test_with_fuse()
 // end::fuse_basic[]
 
 // The two patterns redeclare [ec, n], so each needs its own scope.
-task<void> correct_pattern(read_stream& rs, mutable_buffer buf)
+capy::task<void> correct_pattern(
+    capy::test::read_stream& rs, capy::mutable_buffer buf)
 {
     // tag::early_return[]
     // Correct: early return on injected error
@@ -117,7 +92,8 @@ task<void> correct_pattern(read_stream& rs, mutable_buffer buf)
     // end::early_return[]
 }
 
-task<void> wrong_pattern(read_stream& rs, mutable_buffer buf)
+capy::task<void> wrong_pattern(
+    capy::test::read_stream& rs, capy::mutable_buffer buf)
 {
     // tag::early_return[]
 
@@ -131,18 +107,17 @@ task<void> wrong_pattern(read_stream& rs, mutable_buffer buf)
 #include <boost/capy/task.hpp>
 #include <boost/capy/test/fuse.hpp>
 
-using namespace boost::capy;
-using namespace boost::capy::test;
+namespace capy = boost::capy;
 
-task<int> add(int a, int b)
+capy::task<int> add(int a, int b)
 {
     co_return a + b;
 }
 
 void test_add()
 {
-    fuse f;
-    auto r = f.armed([&](fuse&) -> task<void> {
+    capy::test::fuse f;
+    auto r = f.armed([&](capy::test::fuse&) -> capy::task<void> {
         auto sum = co_await add(3, 4);
         BOOST_TEST(sum == 7);
     });
@@ -163,27 +138,28 @@ struct drivers_test
     {
         // tag::run_blocking_overloads[]
         // Discard result; rethrow on exception
-        run_blocking()(my_task());
+        capy::test::run_blocking()(my_task());
 
         // Capture result; rethrow on exception
         int out = 0;
-        run_blocking([&](int v) { out = v; })(compute(21));
+        capy::test::run_blocking([&](int v) { out = v; })(compute(21));
 
         // Capture result; handle exception separately
-        run_blocking(
+        capy::test::run_blocking(
             [&](int v) { out = v; },
             [](std::exception_ptr ep) { std::rethrow_exception(ep); }
         )(compute(21));
 
         // With a stop token (discards result)
         std::stop_source src;
-        run_blocking(src.get_token())(my_task());
+        capy::test::run_blocking(src.get_token())(my_task());
 
         // With a stop token and a result handler
-        run_blocking(src.get_token(), [&](int v) { out = v; })(compute(21));
+        capy::test::run_blocking(
+            src.get_token(), [&](int v) { out = v; })(compute(21));
 
         // With a stop token and separate handlers
-        run_blocking(
+        capy::test::run_blocking(
             src.get_token(),
             [&](int v) { out = v; },
             [](std::exception_ptr ep) { std::rethrow_exception(ep); }
@@ -199,14 +175,14 @@ struct drivers_test
         std::stop_source src;
         src.request_stop();
 
-        run_blocking(src.get_token())([&]() -> task<>
+        capy::test::run_blocking(src.get_token())([&]() -> capy::task<>
         {
-            read_stream rs;
+            capy::test::read_stream rs;
             rs.provide("ignored");
 
             char buf[32];
-            auto [ec, n] = co_await rs.read_some(make_buffer(buf));
-            assert(ec == cond::canceled);   // honored the stop token
+            auto [ec, n] = co_await rs.read_some(capy::make_buffer(buf));
+            assert(ec == capy::cond::canceled);   // honored the stop token
         }());
         // end::run_blocking_cancellation[]
     }
@@ -221,27 +197,27 @@ struct drivers_test
     testInertVsArmed()
     {
         // tag::inert_vs_armed[]
-        fuse f;
+        capy::test::fuse f;
 
         // Smoke test: happy path
-        auto r1 = f.inert([&](fuse&) -> task<void> {
-            read_stream rs(f);
+        auto r1 = f.inert([&](capy::test::fuse&) -> capy::task<void> {
+            capy::test::read_stream rs(f);
             rs.provide("hello");
 
             char buf[8];
-            auto [ec, n] = co_await rs.read_some(make_buffer(buf));
+            auto [ec, n] = co_await rs.read_some(capy::make_buffer(buf));
             BOOST_TEST(!ec);
             BOOST_TEST(std::string_view(buf, n) == "hello");
         });
         BOOST_TEST(r1.success);
 
         // Fault coverage: every error site
-        auto r2 = f.armed([&](fuse&) -> task<void> {
-            read_stream rs(f);
+        auto r2 = f.armed([&](capy::test::fuse&) -> capy::task<void> {
+            capy::test::read_stream rs(f);
             rs.provide("hello");
 
             char buf[8];
-            auto [ec, n] = co_await rs.read_some(make_buffer(buf));
+            auto [ec, n] = co_await rs.read_some(capy::make_buffer(buf));
             if(ec)
                 co_return;  // fuse injected an error; exit gracefully
             BOOST_TEST(std::string_view(buf, n) == "hello");
@@ -257,8 +233,8 @@ struct drivers_test
         // the capture-less lambda the page shows.
         bool const some_condition_failed = false;
         // tag::inert_fail[]
-        fuse f;
-        auto r = f.inert([](fuse& f) {
+        capy::test::fuse f;
+        auto r = f.inert([](capy::test::fuse& f) {
             auto ec = f.maybe_fail();  // always returns {}
             assert(!ec);
 
@@ -272,22 +248,22 @@ struct drivers_test
     void
     testEarlyReturn()
     {
-        fuse f;
-        auto r = f.armed([&](fuse&) -> task<void> {
-            read_stream rs(f);
+        capy::test::fuse f;
+        auto r = f.armed([&](capy::test::fuse&) -> capy::task<void> {
+            capy::test::read_stream rs(f);
             rs.provide("data");
             char arr[8];
-            co_await correct_pattern(rs, make_buffer(arr));
+            co_await correct_pattern(rs, capy::make_buffer(arr));
         });
         BOOST_TEST(r.success);
 
         // The wrong pattern asserts success, so only run it un-armed.
-        fuse f2;
-        auto r2 = f2.inert([&](fuse&) -> task<void> {
-            read_stream rs(f2);
+        capy::test::fuse f2;
+        auto r2 = f2.inert([&](capy::test::fuse&) -> capy::task<void> {
+            capy::test::read_stream rs(f2);
             rs.provide("data");
             char arr[8];
-            co_await wrong_pattern(rs, make_buffer(arr));
+            co_await wrong_pattern(rs, capy::make_buffer(arr));
         });
         BOOST_TEST(r2.success);
     }
@@ -295,13 +271,13 @@ struct drivers_test
     void
     testCoroutineSupport()
     {
-        read_stream rs;
+        capy::test::read_stream rs;
         rs.provide("data");
         char arr[8];
-        auto buf = make_buffer(arr);
+        auto buf = capy::make_buffer(arr);
         // tag::armed_coroutine[]
-        fuse f;
-        auto r = f.armed([&](fuse&) -> task<void> {
+        capy::test::fuse f;
+        auto r = f.armed([&](capy::test::fuse&) -> capy::task<void> {
             auto ec = f.maybe_fail();
             if(ec)
                 co_return;
@@ -320,9 +296,9 @@ struct drivers_test
         // tag::custom_fail_points[]
         class widget
         {
-            fuse& f_;
+            capy::test::fuse& f_;
         public:
-            explicit widget(fuse& f) : f_(f) {}
+            explicit widget(capy::test::fuse& f) : f_(f) {}
 
             std::error_code process()
             {
@@ -334,11 +310,12 @@ struct drivers_test
             }
         };
 
-        fuse f;
+        capy::test::fuse f;
         widget w(f);
         w.process();                                    // maybe_fail() returns {}
 
-        auto r = f.armed([&](fuse&) { w.process(); });  // both branches exercised
+        // both branches exercised
+        auto r = f.armed([&](capy::test::fuse&) { w.process(); });
         BOOST_TEST(r.success);
         // end::custom_fail_points[]
     }
@@ -347,8 +324,9 @@ struct drivers_test
     testCustomErrorCode()
     {
         // tag::custom_error_code[]
-        fuse f(std::make_error_code(std::errc::operation_canceled));
-        auto r = f.armed([](fuse& f) {
+        capy::test::fuse f(
+            std::make_error_code(std::errc::operation_canceled));
+        auto r = f.armed([](capy::test::fuse& f) {
             auto ec = f.maybe_fail();
             if(ec)
             {
@@ -369,11 +347,11 @@ struct drivers_test
         #include <boost/capy/task.hpp>
         #include <boost/capy/test/thread_name.hpp>
 
-        using namespace boost::capy;
+        namespace capy = boost::capy;
 
-        thread_pool pool(4);
-        run_async(pool.get_executor())([]() -> task<void> {
-            set_current_thread_name("test-worker-0");
+        capy::thread_pool pool(4);
+        capy::run_async(pool.get_executor())([]() -> capy::task<void> {
+            capy::set_current_thread_name("test-worker-0");
             // ... test work runs here; name appears in gdb thread list
             co_return;
         }());

--- a/test/doc/snippets/7b_mock_streams.cpp
+++ b/test/doc/snippets/7b_mock_streams.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/7.testing/7b.mock-streams.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 // GCC gives false positive -Wmaybe-uninitialized on structured bindings
 // via the tuple protocol inside coroutine frames.
@@ -69,20 +45,19 @@ namespace {
 #include <boost/capy/buffers/make_buffer.hpp>
 #include <boost/capy/task.hpp>
 
-using namespace boost::capy;
-using namespace boost::capy::test;
+namespace capy = boost::capy;
 
 void test_read_stream()
 {
-    fuse f;
-    read_stream rs(f);
+    capy::test::fuse f;
+    capy::test::read_stream rs(f);
     rs.provide("Hello, ");
     rs.provide("World!");
 
-    auto r = f.armed([&](fuse&) -> task<void> {
+    auto r = f.armed([&](capy::test::fuse&) -> capy::task<void> {
         char buf[32];
         auto [ec, n] = co_await rs.read_some(
-            mutable_buffer(buf, sizeof(buf)));
+            capy::mutable_buffer(buf, sizeof(buf)));
         if(ec)
             co_return;
         BOOST_TEST(std::string_view(buf, n) == "Hello, World!");
@@ -97,18 +72,17 @@ void test_read_stream()
 #include <boost/capy/buffers/make_buffer.hpp>
 #include <boost/capy/task.hpp>
 
-using namespace boost::capy;
-using namespace boost::capy::test;
+namespace capy = boost::capy;
 
 void test_write_stream()
 {
-    fuse f;
+    capy::test::fuse f;
 
-    auto r = f.armed([&](fuse&) -> task<void> {
-        write_stream ws(f);
+    auto r = f.armed([&](capy::test::fuse&) -> capy::task<void> {
+        capy::test::write_stream ws(f);
 
         auto [ec, n] = co_await ws.write_some(
-            const_buffer("Hello", 5));
+            capy::const_buffer("Hello", 5));
         if(ec)
             co_return;
         BOOST_TEST(ws.data() == "Hello");
@@ -123,24 +97,23 @@ void test_write_stream()
 #include <boost/capy/buffers/make_buffer.hpp>
 #include <boost/capy/task.hpp>
 
-using namespace boost::capy;
-using namespace boost::capy::test;
+namespace capy = boost::capy;
 
 void test_stream_pair()
 {
-    fuse f;
+    capy::test::fuse f;
 
-    auto r = f.armed([&](fuse&) -> task<void> {
-        auto [a, b] = make_stream_pair(f);
+    auto r = f.armed([&](capy::test::fuse&) -> capy::task<void> {
+        auto [a, b] = capy::test::make_stream_pair(f);
 
         auto [ec, n] = co_await a.write_some(
-            const_buffer("hello", 5));
+            capy::const_buffer("hello", 5));
         if(ec)
             co_return;
 
         char buf[32];
         auto [ec2, n2] = co_await b.read_some(
-            mutable_buffer(buf, sizeof(buf)));
+            capy::mutable_buffer(buf, sizeof(buf)));
         if(ec2)
             co_return;
         BOOST_TEST(std::string_view(buf, n2) == "hello");
@@ -156,12 +129,11 @@ void test_stream_pair()
 #include <boost/capy/test/fuse.hpp>
 #include <boost/capy/test/read_stream.hpp>
 
-using namespace boost::capy;
-using namespace boost::capy::test;
+namespace capy = boost::capy;
 
 // Function under test: read until '\n' or EOF
-template<ReadStream S>
-task<std::pair<std::error_code, std::string>>
+template<capy::ReadStream S>
+capy::task<std::pair<std::error_code, std::string>>
 read_line(S& stream)
 {
     std::string line;
@@ -169,7 +141,7 @@ read_line(S& stream)
     for(;;)
     {
         auto [ec, n] = co_await stream.read_some(
-            mutable_buffer(&ch, 1));
+            capy::mutable_buffer(&ch, 1));
         if(ec)
             co_return {ec, std::move(line)};
         if(ch == '\n')
@@ -181,9 +153,9 @@ read_line(S& stream)
 
 void test_read_line()
 {
-    fuse f;
-    auto r = f.armed([&](fuse&) -> task<void> {
-        read_stream rs(f);
+    capy::test::fuse f;
+    auto r = f.armed([&](capy::test::fuse&) -> capy::task<void> {
+        capy::test::read_stream rs(f);
         rs.provide("hello\n");
 
         auto [ec, line] = co_await read_line(rs);
@@ -208,14 +180,14 @@ struct mock_streams_test
     {
         // tag::read_stream_chunked[]
         // At most 4 bytes per read_some call
-        fuse f;
-        read_stream rs(f, 4);
+        capy::test::fuse f;
+        capy::test::read_stream rs(f, 4);
         rs.provide("Hello, World!");
 
-        auto r = f.armed([&](fuse&) -> task<void> {
+        auto r = f.armed([&](capy::test::fuse&) -> capy::task<void> {
             char buf[32];
             auto [ec, n] = co_await rs.read_some(
-                mutable_buffer(buf, sizeof(buf)));
+                capy::mutable_buffer(buf, sizeof(buf)));
             if(ec)
                 co_return;
             BOOST_TEST(n == 4);  // "Hell"
@@ -228,22 +200,22 @@ struct mock_streams_test
     testReadStreamEof()
     {
         // tag::read_stream_eof[]
-        fuse f;
-        read_stream rs(f);
+        capy::test::fuse f;
+        capy::test::read_stream rs(f);
         rs.provide("hi");
 
-        auto r = f.inert([&](fuse&) -> task<void> {
+        auto r = f.inert([&](capy::test::fuse&) -> capy::task<void> {
             char buf[8];
             // First read: consumes "hi"
             auto [ec, n] = co_await rs.read_some(
-                mutable_buffer(buf, sizeof(buf)));
+                capy::mutable_buffer(buf, sizeof(buf)));
             BOOST_TEST(!ec);
             BOOST_TEST(std::string_view(buf, n) == "hi");
 
             // Second read: EOF
             auto [ec2, n2] = co_await rs.read_some(
-                mutable_buffer(buf, sizeof(buf)));
-            BOOST_TEST(ec2 == cond::eof);
+                capy::mutable_buffer(buf, sizeof(buf)));
+            BOOST_TEST(ec2 == capy::cond::eof);
             BOOST_TEST(n2 == 0);
         });
         BOOST_TEST(r.success);
@@ -260,12 +232,12 @@ struct mock_streams_test
     testWriteStreamChunked()
     {
         // tag::write_stream_chunked[]
-        fuse f;
-        write_stream ws(f, 4);  // accept at most 4 bytes per call
+        capy::test::fuse f;
+        capy::test::write_stream ws(f, 4);  // accept at most 4 bytes per call
 
-        auto r = f.inert([&](fuse&) -> task<void> {
+        auto r = f.inert([&](capy::test::fuse&) -> capy::task<void> {
             auto [ec, n] = co_await ws.write_some(
-                const_buffer("Hello", 5));
+                capy::const_buffer("Hello", 5));
             BOOST_TEST(!ec);
             BOOST_TEST(n == 4);  // only "Hell" was accepted
         });
@@ -277,14 +249,14 @@ struct mock_streams_test
     testWriteStreamExpect()
     {
         // tag::write_stream_expect[]
-        fuse f;
-        write_stream ws(f);
+        capy::test::fuse f;
+        capy::test::write_stream ws(f);
         ws.expect("Hello World");
 
-        auto r = f.inert([&](fuse&) -> task<void> {
+        auto r = f.inert([&](capy::test::fuse&) -> capy::task<void> {
             // Writing matching data succeeds
             auto [ec, n] = co_await ws.write_some(
-                const_buffer("Hello World", 11));
+                capy::const_buffer("Hello World", 11));
             BOOST_TEST(!ec);
         });
         BOOST_TEST(r.success);

--- a/test/doc/snippets/7e_buffer_inspection.cpp
+++ b/test/doc/snippets/7e_buffer_inspection.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -12,32 +13,7 @@
 // The all-splits fragment binds both halves without using them; the
 // page comment explains the loop body instead.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers/make_buffer.hpp>
 #include <boost/capy/task.hpp>
@@ -64,21 +40,20 @@ namespace {
 #include <boost/capy/buffers/make_buffer.hpp>
 #include <boost/capy/task.hpp>
 
-using namespace boost::capy;
-using namespace boost::capy::test;
+namespace capy = boost::capy;
 
 void test_all_splits()
 {
     std::string data = "hello";
-    auto cb = make_buffer(data);
+    auto cb = capy::make_buffer(data);
 
-    fuse f;
-    auto r = f.inert([&](fuse&) -> task<> {
-        bufgrind bg(cb);
+    capy::test::fuse f;
+    auto r = f.inert([&](capy::test::fuse&) -> capy::task<> {
+        capy::test::bufgrind bg(cb);
         while(bg)
         {
             auto [b1, b2] = co_await bg.next();
-            BOOST_TEST_EQ(buffer_to_string(b1, b2), data);
+            BOOST_TEST_EQ(capy::test::buffer_to_string(b1, b2), data);
         }
     });
     BOOST_TEST(r.success);
@@ -87,13 +62,13 @@ void test_all_splits()
 
 void test_step_size()
 {
-    fuse f;
-    auto r = f.inert([&](fuse&) -> task<> {
+    capy::test::fuse f;
+    auto r = f.inert([&](capy::test::fuse&) -> capy::task<> {
         // tag::step_size[]
         std::string data = "0123456789";  // 10 bytes
-        auto cb = make_buffer(data);
+        auto cb = capy::make_buffer(data);
 
-        bufgrind bg(cb, 3);
+        capy::test::bufgrind bg(cb, 3);
         // Visits positions: 0, 3, 6, 9, 10
         while(bg)
         {
@@ -107,19 +82,19 @@ void test_step_size()
 
 void test_mutability()
 {
-    fuse f;
-    auto r = f.inert([&](fuse&) -> task<> {
+    capy::test::fuse f;
+    auto r = f.inert([&](capy::test::fuse&) -> capy::task<> {
         // tag::mutability[]
         char data[] = "hello";
-        mutable_buffer mb(data, 5);
+        capy::mutable_buffer mb(data, 5);
 
-        bufgrind bg(mb);
+        capy::test::bufgrind bg(mb);
         while(bg)
         {
             auto [b1, b2] = co_await bg.next();
             // each half is itself a buffer sequence; a mutable input
             // yields MutableBufferSequence halves callers may write into
-            static_assert(MutableBufferSequence<decltype(b1)>);
+            static_assert(capy::MutableBufferSequence<decltype(b1)>);
         }
         // end::mutability[]
     });
@@ -130,19 +105,18 @@ void test_mutability()
 #include <boost/capy/test/buffer_to_string.hpp>
 #include <boost/capy/buffers/make_buffer.hpp>
 
-using namespace boost::capy;
-using namespace boost::capy::test;
+namespace capy = boost::capy;
 
 void test_buffer_to_string()
 {
     // Single buffer sequence
-    const_buffer cb(make_buffer(std::string_view("hello")));
-    BOOST_TEST_EQ(buffer_to_string(cb), "hello");
+    capy::const_buffer cb(capy::make_buffer(std::string_view("hello")));
+    BOOST_TEST_EQ(capy::test::buffer_to_string(cb), "hello");
 
     // Multiple buffer sequences concatenated in order
-    const_buffer b1(make_buffer(std::string_view("hello")));
-    const_buffer b2(make_buffer(std::string_view(" world")));
-    BOOST_TEST_EQ(buffer_to_string(b1, b2), "hello world");
+    capy::const_buffer b1(capy::make_buffer(std::string_view("hello")));
+    capy::const_buffer b2(capy::make_buffer(std::string_view(" world")));
+    BOOST_TEST_EQ(capy::test::buffer_to_string(b1, b2), "hello world");
 }
 // end::buffer_to_string[]
 
@@ -150,15 +124,15 @@ void test_reconstruct()
 {
     // tag::reconstruct[]
     std::string original = "hello world";
-    auto cb = make_buffer(original);
+    auto cb = capy::make_buffer(original);
 
-    fuse f;
-    auto r = f.inert([&](fuse&) -> task<> {
-        bufgrind bg(cb);
+    capy::test::fuse f;
+    auto r = f.inert([&](capy::test::fuse&) -> capy::task<> {
+        capy::test::bufgrind bg(cb);
         while(bg)
         {
             auto [b1, b2] = co_await bg.next();
-            BOOST_TEST_EQ(buffer_to_string(b1, b2), original);
+            BOOST_TEST_EQ(capy::test::buffer_to_string(b1, b2), original);
         }
     });
     BOOST_TEST(r.success);
@@ -176,17 +150,16 @@ void test_reconstruct()
 #include <array>
 #include <string>
 
-using namespace boost::capy;
-using namespace boost::capy::test;
+namespace capy = boost::capy;
 
 // Hypothetical parser: reads all bytes from a ReadStream
-task<std::string> read_all(read_stream& rs)
+capy::task<std::string> read_all(capy::test::read_stream& rs)
 {
     std::string out;
     std::array<char, 64> buf;
     for(;;)
     {
-        auto [ec, n] = co_await rs.read_some(make_buffer(buf));
+        auto [ec, n] = co_await rs.read_some(capy::make_buffer(buf));
         if(ec)
             co_return out;
         out.append(buf.data(), n);
@@ -196,19 +169,19 @@ task<std::string> read_all(read_stream& rs)
 void test_parser_all_splits()
 {
     std::string input = "GET / HTTP/1.1\r\n";
-    auto cb = make_buffer(input);
+    auto cb = capy::make_buffer(input);
 
-    fuse f;
-    auto r = f.inert([&](fuse&) -> task<> {
-        bufgrind bg(cb);
+    capy::test::fuse f;
+    auto r = f.inert([&](capy::test::fuse&) -> capy::task<> {
+        capy::test::bufgrind bg(cb);
         while(bg)
         {
             auto [b1, b2] = co_await bg.next();
 
             // Feed the split as two discrete reads
-            read_stream rs(f);
-            rs.provide(buffer_to_string(b1));
-            rs.provide(buffer_to_string(b2));
+            capy::test::read_stream rs(f);
+            rs.provide(capy::test::buffer_to_string(b1));
+            rs.provide(capy::test::buffer_to_string(b2));
 
             std::string got = co_await read_all(rs);
             BOOST_TEST_EQ(got, input);

--- a/test/doc/snippets/8c_buffer_composition.cpp
+++ b/test/doc/snippets/8c_buffer_composition.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/8.examples/8c.buffer-composition.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/io/any_stream.hpp>
@@ -58,7 +34,7 @@ send_response(
     std::array<capy::const_buffer, 5> const& http_response)
 {
     // tag::write_gather[]
-    co_await write(stream, http_response);
+    co_await capy::write(stream, http_response);
     // end::write_gather[]
 }
 

--- a/test/doc/snippets/8d_mock_stream_testing.cpp
+++ b/test/doc/snippets/8d_mock_stream_testing.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/8.examples/8d.mock-stream-testing.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/io/any_stream.hpp>

--- a/test/doc/snippets/8f_timeout_cancellation.cpp
+++ b/test/doc/snippets/8f_timeout_cancellation.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/8.examples/8f.timeout-cancellation.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/task.hpp>
 #include <boost/capy/ex/run_async.hpp>

--- a/test/doc/snippets/9a_capy_layering.cpp
+++ b/test/doc/snippets/9a_capy_layering.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/9.design/9a.CapyLayering.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/buffers/make_buffer.hpp>
@@ -52,19 +28,18 @@ namespace capy = boost::capy;
 
 namespace {
 
-using namespace boost::capy;
 
 // tag::any_stream_echo[]
-task<> echo(any_stream& stream)
+capy::task<> echo(capy::any_stream& stream)
 {
     char buf[1024];
     for(;;)
     {
         auto [ec, n] = co_await stream.read_some(
-            make_buffer(buf));
+            capy::make_buffer(buf));
         if(ec)
             co_return;
-        co_await write(stream, const_buffer(buf, n));
+        co_await capy::write(stream, capy::const_buffer(buf, n));
     }
 }
 // end::any_stream_echo[]
@@ -74,10 +49,10 @@ namespace coroutine_layer {
 // tag::connection_base[]
 class connection_base {
 public:
-    task<> run();
+    capy::task<> run();
 protected:
-    virtual task<> do_handshake() = 0;
-    virtual task<> do_shutdown() = 0;
+    virtual capy::task<> do_handshake() = 0;
+    virtual capy::task<> do_shutdown() = 0;
 };
 // end::connection_base[]
 

--- a/test/doc/snippets/9c_read_stream.cpp
+++ b/test/doc/snippets/9c_read_stream.cpp
@@ -10,32 +10,7 @@
 
 // Compiled fragments shown in pages/9.design/9c.ReadStream.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/buffers/make_buffer.hpp>
@@ -61,28 +36,27 @@ namespace capy = boost::capy;
 
 namespace {
 
-using namespace boost::capy;
 
 static_assert(capy::ReadStream<capy::test::read_stream>);
 
 namespace composed {
 
 // tag::read_signature[]
-auto read(ReadStream auto& stream,
-          MutableBufferSequence auto buffers)
-    -> io_task<std::size_t>;
+auto read(capy::ReadStream auto& stream,
+          capy::MutableBufferSequence auto buffers)
+    -> capy::io_task<std::size_t>;
 // end::read_signature[]
 
 } // namespace composed
 
 // tag::read_header[]
-template<ReadStream Stream>
-task<> read_header(Stream& stream)
+template<capy::ReadStream Stream>
+capy::task<> read_header(Stream& stream)
 {
     char header[16];
-    auto [ec, n] = co_await read(
-        stream, make_buffer(header));
-    if(ec == cond::eof)
+    auto [ec, n] = co_await capy::read(
+        stream, capy::make_buffer(header));
+    if(ec == capy::cond::eof)
         co_return;  // clean shutdown
     if(ec)
         co_return;
@@ -91,17 +65,17 @@ task<> read_header(Stream& stream)
 // end::read_header[]
 
 // tag::echo[]
-template<ReadStream Stream>
-task<> echo(Stream& stream, WriteStream auto& dest)
+template<capy::ReadStream Stream>
+capy::task<> echo(Stream& stream, capy::WriteStream auto& dest)
 {
     char buf[4096];
     for(;;)
     {
         auto [ec, n] = co_await stream.read_some(
-            make_buffer(buf));
+            capy::make_buffer(buf));
 
         auto [wec, nw] = co_await dest.write_some(
-            const_buffer(buf, n));
+            capy::const_buffer(buf, n));
 
         if(ec)
             co_return;
@@ -113,15 +87,15 @@ task<> echo(Stream& stream, WriteStream auto& dest)
 // end::echo[]
 
 // Scaffold for the canonical advance-then-check loop.
-template<ReadStream S>
-task<> read_all(S& s, char* buf, std::size_t size)
+template<capy::ReadStream S>
+capy::task<> read_all(S& s, char* buf, std::size_t size)
 {
     std::size_t total = 0;
     while(total < size)
     {
         // tag::canonical_loop[]
         auto [ec, n] = co_await s.read_some(
-            mutable_buffer(buf + total, size - total));
+            capy::mutable_buffer(buf + total, size - total));
         total += n;
         if(ec)
             co_return;

--- a/test/doc/snippets/9f_write_stream.cpp
+++ b/test/doc/snippets/9f_write_stream.cpp
@@ -10,32 +10,7 @@
 
 // Compiled fragments shown in pages/9.design/9f.WriteStream.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/concept/read_stream.hpp>
@@ -59,10 +34,9 @@ namespace capy = boost::capy;
 
 namespace {
 
-using namespace boost::capy;
 
-static_assert(capy::WriteStream<test::write_stream>);
-static_assert(!capy::WriteStream<test::read_stream>);
+static_assert(capy::WriteStream<capy::test::write_stream>);
+static_assert(!capy::WriteStream<capy::test::read_stream>);
 
 // The real algorithms live in <boost/capy/write.hpp> and
 // <boost/capy/io/write_now.hpp>; these sketches mirror the interface
@@ -70,44 +44,44 @@ static_assert(!capy::WriteStream<test::read_stream>);
 namespace api_sketch {
 
 // tag::write_signature[]
-auto write(WriteStream auto& stream,
-           ConstBufferSequence auto buffers)
-    -> io_task<std::size_t>;
+auto write(capy::WriteStream auto& stream,
+           capy::ConstBufferSequence auto buffers)
+    -> capy::io_task<std::size_t>;
 // end::write_signature[]
 
 // tag::write_now_sketch[]
-template<WriteStream Stream>
+template<capy::WriteStream Stream>
 class write_now
 {
 public:
     explicit write_now(Stream& s) noexcept;
 
-    IoAwaitable auto operator()(ConstBufferSequence auto buffers);
+    capy::IoAwaitable auto operator()(capy::ConstBufferSequence auto buffers);
 };
 // end::write_now_sketch[]
 
 } // namespace api_sketch
 
-static_assert(requires(test::write_stream& s, const_buffer b) {
-    { capy::write(s, b) } -> std::same_as<io_task<std::size_t>>;
+static_assert(requires(capy::test::write_stream& s, capy::const_buffer b) {
+    { capy::write(s, b) } -> std::same_as<capy::io_task<std::size_t>>;
 });
 static_assert(
     std::constructible_from<
-        capy::write_now<test::write_stream>, test::write_stream&>);
+        capy::write_now<capy::test::write_stream>, capy::test::write_stream&>);
 
 // tag::relay_with_write_now[]
-template<ReadStream Source, WriteStream Stream>
-task<> relay_with_write_now(Source& src, Stream& dest)
+template<capy::ReadStream Source, capy::WriteStream Stream>
+capy::task<> relay_with_write_now(Source& src, Stream& dest)
 {
     char buf[65536];
-    write_now wn(dest);
+    capy::write_now wn(dest);
 
     for(;;)
     {
         // Read a chunk from the source
         auto [rec, nr] = co_await src.read_some(
-            mutable_buffer(buf, sizeof(buf)));
-        if(rec == cond::eof && nr == 0)
+            capy::mutable_buffer(buf, sizeof(buf)));
+        if(rec == capy::cond::eof && nr == 0)
             co_return;
 
         // write_now drains the chunk to completion.
@@ -117,11 +91,11 @@ task<> relay_with_write_now(Source& src, Stream& dest)
         // syscall. The caller cannot top up between
         // write_now's internal iterations.
         auto [wec, nw] = co_await wn(
-            const_buffer(buf, nr));
+            capy::const_buffer(buf, nr));
         if(wec)
             co_return;
 
-        if(rec == cond::eof)
+        if(rec == capy::cond::eof)
             co_return;
     }
 }
@@ -132,11 +106,11 @@ struct write_stream_test
     void
     testRelayWithWriteNow()
     {
-        test::fuse f;
-        test::read_stream src(f);
+        capy::test::fuse f;
+        capy::test::read_stream src(f);
         src.provide("relayed data");
-        test::write_stream dest(f);
-        test::run_blocking()(relay_with_write_now(src, dest));
+        capy::test::write_stream dest(f);
+        capy::test::run_blocking()(relay_with_write_now(src, dest));
         BOOST_TEST_EQ(dest.data(), "relayed data");
     }
 
@@ -144,11 +118,11 @@ struct write_stream_test
     testRelayChunked()
     {
         // Partial writes force write_now's internal drain loop
-        test::fuse f;
-        test::read_stream src(f);
+        capy::test::fuse f;
+        capy::test::read_stream src(f);
         src.provide("relayed data");
-        test::write_stream dest(f, 3);
-        test::run_blocking()(relay_with_write_now(src, dest));
+        capy::test::write_stream dest(f, 3);
+        capy::test::run_blocking()(relay_with_write_now(src, dest));
         BOOST_TEST_EQ(dest.data(), "relayed data");
     }
 

--- a/test/doc/snippets/9k_executor.cpp
+++ b/test/doc/snippets/9k_executor.cpp
@@ -10,32 +10,7 @@
 
 // Compiled fragments shown in pages/9.design/9k.Executor.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/concept/executor.hpp>
 #include <boost/capy/continuation.hpp>
@@ -56,10 +31,9 @@ namespace capy = boost::capy;
 
 namespace {
 
-using namespace boost::capy;
 
-static_assert(capy::Executor<thread_pool::executor_type>);
-static_assert(capy::Executor<executor_ref>);
+static_assert(capy::Executor<capy::thread_pool::executor_type>);
+static_assert(capy::Executor<capy::executor_ref>);
 static_assert(!capy::Executor<int>);
 
 // Scaffolding context so the conforming dispatch shown on the page
@@ -71,11 +45,11 @@ class dispatching_executor
         bool running_in_this_thread() const noexcept { return true; }
     } ctx_;
 
-    void post(continuation&) const {}
+    void post(capy::continuation&) const {}
 
 public:
     // tag::dispatch_impl[]
-    std::coroutine_handle<> dispatch(continuation& c) const
+    std::coroutine_handle<> dispatch(capy::continuation& c) const
     {
         if(ctx_.running_in_this_thread())
             return c.h;            // symmetric transfer
@@ -128,7 +102,7 @@ public:
 class tcp_socket
 {
 public:
-    explicit tcp_socket(execution_context&) {}
+    explicit tcp_socket(capy::execution_context&) {}
 
     // tag::socket_ctor[]
     template<class Ex>
@@ -145,8 +119,8 @@ namespace layout_sketch {
 // tag::executor_ref_layout[]
 class executor_ref
 {
-    void const* ex_;                       // pointer to the executor
-    detail::executor_vtable const* vt_;    // pointer to the vtable
+    void const* ex_;                           // pointer to the executor
+    capy::detail::executor_vtable const* vt_;  // pointer to the vtable
 };
 // end::executor_ref_layout[]
 
@@ -159,14 +133,14 @@ static_assert(sizeof(layout_sketch::executor_ref)
 // and an executor_ref for completion dispatch.
 struct io_awaitable_sketch
 {
-    continuation cont_;
-    executor_ref ex_;
+    capy::continuation cont_;
+    capy::executor_ref ex_;
 
     // tag::capture_at_initiation[]
     std::coroutine_handle<>
     await_suspend(
         std::coroutine_handle<> h,
-        io_env const* env) noexcept
+        capy::io_env const* env) noexcept
     {
         cont_.h = h;
         ex_ = env->executor;
@@ -190,13 +164,13 @@ struct io_awaitable_sketch
 class my_executor
 {
 public:
-    execution_context& context() const noexcept;
+    capy::execution_context& context() const noexcept;
 
     void on_work_started() const noexcept;
     void on_work_finished() const noexcept;
 
-    std::coroutine_handle<> dispatch(continuation& c) const;
-    void post(continuation& c) const;
+    std::coroutine_handle<> dispatch(capy::continuation& c) const;
+    void post(capy::continuation& c) const;
 
     bool operator==(my_executor const&) const noexcept;
 };
@@ -209,7 +183,7 @@ struct executor_design_test
     void testDispatchReturnsHandle()
     {
         dispatching_executor ex;
-        continuation c;
+        capy::continuation c;
         BOOST_TEST(ex.dispatch(c) == std::coroutine_handle<>());
     }
 
@@ -222,7 +196,7 @@ struct executor_design_test
 
     void testSocketFromExecutor()
     {
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         tcp_socket sock(pool.get_executor());
         (void)sock;
     }

--- a/test/doc/snippets/9l_run_api.cpp
+++ b/test/doc/snippets/9l_run_api.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/9.design/9l.RunApi.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/ex/frame_allocator.hpp>
 #include <boost/capy/ex/run.hpp>
@@ -52,56 +28,56 @@
 
 #include "test_suite.hpp"
 
-namespace {
+namespace capy = boost::capy;
 
-using namespace boost::capy;
+namespace {
 
 std::atomic<int> tasks_run{0};
 std::atomic<int> connections_handled{0};
 
-task<void> my_task()
+capy::task<void> my_task()
 {
     ++tasks_run;
     co_return;
 }
 
-task<void> cancellable_task() { co_return; }
-task<int> compute_value() { co_return 42; }
-task<int> compute_on_worker() { co_return 42; }
-task<void> subtask() { co_return; }
-task<void> cpu_bound_task() { co_return; }
+capy::task<void> cancellable_task() { co_return; }
+capy::task<int> compute_value() { co_return 42; }
+capy::task<int> compute_on_worker() { co_return 42; }
+capy::task<void> subtask() { co_return; }
+capy::task<void> cpu_bound_task() { co_return; }
 
 // Executor a coroutine can hop to; kept alive for the whole test run
 // because the run_usage fragments name it at namespace scope.
-thread_pool worker_pool(1);
-thread_pool::executor_type worker_ex = worker_pool.get_executor();
+capy::thread_pool worker_pool(1);
+capy::thread_pool::executor_type worker_ex = worker_pool.get_executor();
 std::pmr::memory_resource* my_alloc = std::pmr::new_delete_resource();
 
 // tag::run_usage[]
 // Switch to a different executor for CPU-bound work
-task<void> parent()
+capy::task<void> parent()
 {
-    int result = co_await run(worker_ex)(compute_on_worker());
+    int result = co_await capy::run(worker_ex)(compute_on_worker());
     // Completion returns to parent's executor
 }
 
 // Customize stop token, inherit caller's executor
-task<void> with_timeout()
+capy::task<void> with_timeout()
 {
     std::stop_source source;
-    co_await run(source.get_token())(subtask());
+    co_await capy::run(source.get_token())(subtask());
 }
 
 // Customize allocator, inherit caller's executor
-task<void> with_custom_alloc()
+capy::task<void> with_custom_alloc()
 {
-    co_await run(my_alloc)(subtask());
+    co_await capy::run(my_alloc)(subtask());
 }
 
 // Switch executor AND customize allocator
-task<void> full_control()
+capy::task<void> full_control()
 {
-    co_await run(worker_ex, my_alloc)(cpu_bound_task());
+    co_await capy::run(worker_ex, my_alloc)(cpu_bound_task());
 }
 // end::run_usage[]
 
@@ -111,9 +87,9 @@ namespace tcp {
 struct socket {};
 } // namespace tcp
 
-thread_pool& ioc = worker_pool;
+capy::thread_pool& ioc = worker_pool;
 
-task<void> handle_connection(tcp::socket)
+capy::task<void> handle_connection(tcp::socket)
 {
     ++connections_handled;
     co_return;
@@ -122,8 +98,8 @@ task<void> handle_connection(tcp::socket)
 // tag::run_async_strand[]
 void on_accept(tcp::socket sock)
 {
-    strand my_strand(ioc.get_executor());
-    run_async(my_strand)(handle_connection(std::move(sock)));
+    capy::strand my_strand(ioc.get_executor());
+    capy::run_async(my_strand)(handle_connection(std::move(sock)));
 }
 // end::run_async_strand[]
 
@@ -131,30 +107,31 @@ void on_accept(tcp::socket sock)
 // against the real detail machinery keeps the page in sync.
 namespace wrapper_sketch {
 
-template<Executor Ex, class Handlers, class Alloc>
+template<capy::Executor Ex, class Handlers, class Alloc>
 class run_async_wrapper
 {
-    detail::run_async_trampoline<Ex, Handlers, Alloc> tr_;
+    capy::detail::run_async_trampoline<Ex, Handlers, Alloc> tr_;
     std::stop_token st_;
     std::pmr::memory_resource* saved_tls_;
 
 public:
     // tag::wrapper_tls[]
     run_async_wrapper(Ex ex, std::stop_token st, Handlers h, Alloc a) noexcept
-        : tr_(detail::make_trampoline<Ex, Handlers, Alloc>(
+        : tr_(capy::detail::make_trampoline<Ex, Handlers, Alloc>(
             std::move(ex), std::move(h), std::move(a)))
         , st_(std::move(st))
-        , saved_tls_(get_current_frame_allocator())   // remember prior TLS
+        // remember prior TLS
+        , saved_tls_(capy::get_current_frame_allocator())
     {
         // Set TLS before task argument is evaluated
-        set_current_frame_allocator(tr_.h_.promise().get_resource());
+        capy::set_current_frame_allocator(tr_.h_.promise().get_resource());
     }
 
     ~run_async_wrapper()
     {
         // Restore the prior TLS so a stale pointer does not outlive
         // the execution context that owns the trampoline's resource.
-        set_current_frame_allocator(saved_tls_);
+        capy::set_current_frame_allocator(saved_tls_);
     }
     // end::wrapper_tls[]
 };
@@ -163,8 +140,8 @@ public:
 
 // Instantiating every member checks the shown ctor and dtor bodies.
 template class wrapper_sketch::run_async_wrapper<
-    thread_pool::executor_type,
-    detail::default_handler,
+    capy::thread_pool::executor_type,
+    capy::detail::default_handler,
     std::pmr::memory_resource*>;
 
 // Simplified: the real mixin in <boost/capy/ex/frame_alloc_mixin.hpp>
@@ -175,7 +152,7 @@ struct promise_new_sketch
     // tag::operator_new[]
     static void* operator new(std::size_t size)
     {
-        auto* mr = get_current_frame_allocator();
+        auto* mr = capy::get_current_frame_allocator();
         if(!mr)
             mr = std::pmr::get_default_resource();
         return mr->allocate(size, alignof(std::max_align_t));
@@ -188,7 +165,7 @@ struct run_api_test
     void testRunAsyncForms()
     {
         tasks_run = 0;
-        thread_pool pool(2);
+        capy::thread_pool pool(2);
         auto ex = pool.get_executor();
         auto* my_pool = std::pmr::new_delete_resource();
         std::stop_token st;
@@ -198,28 +175,28 @@ struct run_api_test
 
         // tag::run_async_usage[]
         // Executor only (uses default recycling allocator)
-        run_async(ex)(my_task());
+        capy::run_async(ex)(my_task());
 
         // With a stop token for cooperative cancellation
         std::stop_source source;
-        run_async(ex, source.get_token())(cancellable_task());
+        capy::run_async(ex, source.get_token())(cancellable_task());
 
         // With a custom memory resource
-        run_async(ex, my_pool)(my_task());
+        capy::run_async(ex, my_pool)(my_task());
 
         // With a result handler
-        run_async(ex, [](int result) {
+        capy::run_async(ex, [](int result) {
             std::cout << "Got: " << result << "\n";
         })(compute_value());
 
         // With separate success and error handlers
-        run_async(ex,
+        capy::run_async(ex,
             [](int result) { std::cout << "Got: " << result << "\n"; },
             [](std::exception_ptr ep) { /* handle error */ }
         )(compute_value());
 
         // Full: executor, stop_token, allocator, success handler, error handler
-        run_async(ex, st, alloc, h1, h2)(my_task());
+        capy::run_async(ex, st, alloc, h1, h2)(my_task());
         // end::run_async_usage[]
 
         pool.join();
@@ -228,27 +205,27 @@ struct run_api_test
 
     void testRunForms()
     {
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         auto ex = pool.get_executor();
-        run_async(ex)(parent());
-        run_async(ex)(with_timeout());
-        run_async(ex)(with_custom_alloc());
-        run_async(ex)(full_control());
+        capy::run_async(ex)(parent());
+        capy::run_async(ex)(with_timeout());
+        capy::run_async(ex)(with_custom_alloc());
+        capy::run_async(ex)(full_control());
         pool.join();
     }
 
     void testPostfixOrder()
     {
         tasks_run = 0;
-        thread_pool pool(1);
+        capy::thread_pool pool(1);
         auto ex = pool.get_executor();
         auto* alloc = std::pmr::new_delete_resource();
 
         // tag::postfix_order[]
         // Step 1: wrapper constructor sets TLS allocator
-        //         v~~~~~~~~~~~~~~v
-           run_async(ex, alloc)    (my_task());
-        //                          ^~~~~~~~~^
+        //               v~~~~~~~~~~~~~~v
+           capy::run_async(ex, alloc)    (my_task());
+        //                                ^~~~~~~~~^
         // Step 2: task frame allocated using TLS allocator
         // end::postfix_order[]
 

--- a/test/doc/snippets/9m_why_not_cobalt.cpp
+++ b/test/doc/snippets/9m_why_not_cobalt.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,46 +10,21 @@
 
 // Compiled fragments shown in pages/9.design/9m.WhyNotCobalt.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/ex/io_env.hpp>
 
 #include <coroutine>
 
-namespace {
+namespace capy = boost::capy;
 
-using boost::capy::io_env;
+namespace {
 
 // Shows the IoAwaitable protocol signature used for context propagation.
 struct context_propagating_op
 {
     // tag::await_suspend_env[]
-    auto await_suspend(std::coroutine_handle<> h, io_env const* env);
+    auto await_suspend(std::coroutine_handle<> h, capy::io_env const* env);
     // end::await_suspend_env[]
 };
 

--- a/test/doc/snippets/9n_why_not_cobalt_concepts.cpp
+++ b/test/doc/snippets/9n_why_not_cobalt_concepts.cpp
@@ -10,32 +10,7 @@
 
 // Compiled fragments shown in pages/9.design/9n.WhyNotCobaltConcepts.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/concept/io_awaitable.hpp>
@@ -68,13 +43,11 @@ static_assert(capy::IoRunnable<capy::task<int>>);
 
 namespace context_propagation {
 
-using boost::capy::io_env;
-
 // Shows the protocol signature; the declaration is the fragment.
 struct child_operation
 {
     // tag::await_suspend_env[]
-    auto await_suspend(std::coroutine_handle<> h, io_env const* env);
+    auto await_suspend(std::coroutine_handle<> h, capy::io_env const* env);
     // end::await_suspend_env[]
 };
 

--- a/test/doc/snippets/9o_why_not_tmc.cpp
+++ b/test/doc/snippets/9o_why_not_tmc.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,32 +10,7 @@
 
 // Compiled fragments shown in pages/9.design/9o.WhyNotTMC.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/task.hpp>
 #include <boost/capy/concept/io_awaitable.hpp>
@@ -51,8 +27,6 @@
 namespace capy = boost::capy;
 
 namespace {
-
-using boost::capy::io_env;
 
 // The page shows the three standard await_suspend forms as one listing;
 // they differ only in return type, so each lives in its own scaffolding
@@ -83,7 +57,7 @@ struct plain_awaitable_handle
 struct io_awaitable_form
 {
     // tag::await_suspend_env[]
-    auto await_suspend(std::coroutine_handle<> h, io_env const* env);
+    auto await_suspend(std::coroutine_handle<> h, capy::io_env const* env);
     // end::await_suspend_env[]
 };
 
@@ -121,10 +95,9 @@ struct why_not_tmc_test
         capy::thread_pool pool(1);
         auto ex = pool.get_executor();
         connection socket;
-        using capy::run_async;
         // tag::arena[]
         std::pmr::monotonic_buffer_resource arena;
-        run_async(ex, &arena)(handle_connection(socket));
+        capy::run_async(ex, &arena)(handle_connection(socket));
         // On disconnect: entire arena reclaimed instantly
         // end::arena[]
         pool.join();

--- a/test/doc/snippets/http_client.hpp
+++ b/test/doc/snippets/http_client.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -17,8 +18,7 @@
 #include <map>
 #include <string>
 
-// The page shows unqualified names.
-using namespace boost::capy;
+namespace capy = boost::capy;
 
 // tag::http_client_header[]
 // http_client.hpp
@@ -36,10 +36,11 @@ struct http_response
 {
     int status_code;
     std::map<std::string, std::string> headers;
-    any_read_stream body;  // Body is read as a stream
+    capy::any_read_stream body;  // Body is read as a stream
 };
 
 // Send request, receive response
 // Works with any transport that provides any_stream
-task<http_response> send_request(any_stream& conn, http_request const& req);
+capy::task<http_response> send_request(
+    capy::any_stream& conn, http_request const& req);
 // end::http_client_header[]

--- a/test/doc/snippets/index_page.cpp
+++ b/test/doc/snippets/index_page.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,35 +10,10 @@
 
 // Compiled fragments shown in pages/index.adoc.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 // tag::convention[]
 #include <boost/capy.hpp>
 
-using namespace boost::capy;
+namespace capy = boost::capy;
 // end::convention[]

--- a/test/doc/snippets/protocol.hpp
+++ b/test/doc/snippets/protocol.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -18,11 +19,10 @@
 #include <boost/capy/task.hpp>
 // end::protocol_header[]
 
-// The page shows unqualified names.
-using namespace boost::capy;
+namespace capy = boost::capy;
 
 // tag::protocol_header[]
 
 // Declaration only - no implementation details
-task<> handle_protocol(any_stream& stream);
+capy::task<> handle_protocol(capy::any_stream& stream);
 // end::protocol_header[]

--- a/test/doc/snippets/quick_start.cpp
+++ b/test/doc/snippets/quick_start.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,32 +11,7 @@
 // Compiled fragments shown in pages/quick-start.adoc. Pages include the
 // tagged regions; scaffolding stays outside the tags.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(disable: 4834) // discarding [[nodiscard]] return value
-#pragma warning(disable: 4189) // local variable initialized but not referenced
-#pragma warning(disable: 4100) // unreferenced formal parameter
-#pragma warning(disable: 4101) // unreferenced local variable
-#pragma warning(disable: 4456) // declaration hides previous local declaration
-#pragma warning(disable: 4457) // declaration hides function parameter
-#pragma warning(disable: 4458) // declaration hides class member
-#pragma warning(disable: 4459) // declaration hides global declaration
-#endif
+#include "../doc_warnings.hpp"
 
 #include <boost/capy/task.hpp>
 #include <boost/capy/ex/run_async.hpp>

--- a/test/doc/snippets/why_capy.cpp
+++ b/test/doc/snippets/why_capy.cpp
@@ -1,43 +1,31 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 // Official repository: https://github.com/cppalliance/capy
 //
-// Fragments deliberately leave named results unused; page comments
-// explain the values instead.
 
-// Fragments deliberately leave results and bindings unused; the pages
-// explain the values in prose instead.
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wunused-function"
-// gcc 15 with sanitizers misattributes coroutine frame delete paths
-#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
-#endif
+#include "../doc_warnings.hpp"
 
 // tag::invariant[]
 #include <boost/capy/buffers/make_buffer.hpp>
 #include <boost/capy/io/any_stream.hpp>
 #include <boost/capy/task.hpp>
 
-using namespace boost::capy;
+namespace capy = boost::capy;
 
 // Every resumption happens on the executor this task was started with, so
 // `count` needs no mutex: nothing else can run between the suspension
 // points.
-task<> count_messages(any_stream& stream, int& count)
+capy::task<> count_messages(capy::any_stream& stream, int& count)
 {
     char buf[64];
     for(;;)
     {
-        auto [ec, n] = co_await stream.read_some(make_buffer(buf));
+        auto [ec, n] = co_await stream.read_some(capy::make_buffer(buf));
         if(ec)
             break;
         ++count;


### PR DESCRIPTION
Every file under test/doc/ opened with the same 24-line warning-suppression preamble -- 105 copies of it, byte for byte -- and most carried both `namespace capy = boost::capy;` and `using namespace boost::capy;`, where the directive supersedes the alias and makes the alias dead text.

The preamble now lives in test/doc/doc_warnings.hpp, included once per file outside every tag:: region. Three files kept a warning of their own, each under a comment saying why.

The using-directives are gone and every capy name in a doc fragment is spelled capy::, so a reader can tell which names in an example come from the library. example/ already read this way; test/doc now matches it.

-Werror does not finish this conversion on its own: write, read, when_all, when_any, run_async and the make_buffer overloads are ordinary free function templates, so ADL keeps finding them unqualified once a call has a capy-typed argument. Those were found by sweeping the tree against the symbol list MrDocs publishes, not by the compiler. A second class the compiler cannot see is the using-declaration -- `using capy::task;` in scaffolding feeds a bare name into a tagged region that renders on a page; nine of those are gone too.

Eight fragments rendered a using-directive on the site; those show the alias instead. The inline pseudocode blocks on 7a.drivers, 4b.launching and 5a.buffers contradicted the fragments beside them and are qualified to match. make_error_code was spelled three ways across the docs and now names its owner at every call site.

Blocks that verbatim-quote library-internal source keep that source's own unqualified spelling, since inside namespace boost::capy that is what the library actually says.

The convention is recorded in doc/STYLE_GUIDE.md as B5, enforced by review only -- no gate.

Closes #387