### PR TITLE
fix(concept): remove detail:: from the IoAwaitable definition

### DIFF
--- a/include/boost/capy/concept/io_awaitable.hpp
+++ b/include/boost/capy/concept/io_awaitable.hpp
@@ -12,24 +12,41 @@
 #define BOOST_CAPY_CONCEPT_IO_AWAITABLE_HPP
 
 #include <boost/capy/detail/config.hpp>
-#include <coroutine>
 #include <boost/capy/ex/io_env.hpp>
+#include <concepts>
+#include <coroutine>
 #include <ranges>
+#include <type_traits>
 
 namespace boost {
 namespace capy {
 
-namespace detail {
+/** Requires a valid `await_suspend` return type.
 
-    template <typename T>
-    constexpr bool is_coroutine_handle = false;
+    In a `co_await` expression the language accepts exactly three
+    return types from `await_suspend`: `void`, `bool`, and
+    `std::coroutine_handle<P>` for any promise type `P`. This concept
+    expresses that rule so that @ref IoAwaitable can reject a malformed
+    awaitable at constraint-checking time rather than deep inside the
+    coroutine machinery.
 
-    template <typename T>
-    constexpr bool is_coroutine_handle<std::coroutine_handle<T>> = true; 
+    See the description of `await_suspend` in @ref IoAwaitable for the
+    meaning attached to each return type.
 
-    template <typename T>
-    concept await_suspend_valid_result = std::same_as<T, void> || std::same_as<T, bool> || is_coroutine_handle<T>;
-}
+    @tparam T The return type of `await_suspend`.
+
+    @see @ref IoAwaitable
+*/
+template<typename T>
+concept AwaitSuspendResult =
+    std::same_as<T, void> ||
+    std::same_as<T, bool> ||
+    std::same_as<T, std::coroutine_handle<>> ||
+    requires(T h)
+    {
+        requires std::same_as<T, std::coroutine_handle<
+            std::remove_reference_t<decltype(h.promise())>>>;
+    };
 
 /** Describes types that can be `co_await`-ed in Capy-coroutines and 
     that can be passed the information about the execution environment.
@@ -121,7 +138,7 @@ namespace detail {
     General-purpose class templates that model `IoAwaitable`: @ref task, @ref quitter, @ref immediate.
 
 
-    @see @ref IoRunnable, @ref io_env, @ref executor_ref
+    @see @ref AwaitSuspendResult, @ref IoRunnable, @ref io_env, @ref executor_ref
 */
 template<typename A>
 concept IoAwaitable = std::move_constructible<A> &&
@@ -131,7 +148,7 @@ concept IoAwaitable = std::move_constructible<A> &&
         io_env const* env)
     {
         { a.await_ready() } -> std::same_as<bool>;
-        { a.await_suspend(h, env) } -> detail::await_suspend_valid_result;   
+        { a.await_suspend(h, env) } -> AwaitSuspendResult;
         a.await_resume();
     };
 

--- a/test/unit/concept/io_awaitable.cpp
+++ b/test/unit/concept/io_awaitable.cpp
@@ -1,0 +1,181 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/capy
+//
+
+// Test that header file is self-contained.
+#include <boost/capy/concept/io_awaitable.hpp>
+
+#include <coroutine>
+#include <cstddef>
+#include <vector>
+
+namespace boost {
+namespace capy {
+
+namespace {
+
+struct mock_promise
+{
+};
+
+// Valid awaitable for each await_suspend return type
+
+struct awaitable_suspend_void
+{
+    bool await_ready() const noexcept { return true; }
+
+    void await_suspend(
+        std::coroutine_handle<>,
+        io_env const*) const noexcept
+    {
+    }
+
+    void await_resume() const noexcept {}
+};
+
+struct awaitable_suspend_bool
+{
+    bool await_ready() const noexcept { return true; }
+
+    bool await_suspend(
+        std::coroutine_handle<>,
+        io_env const*) const noexcept
+    {
+        return false;
+    }
+
+    int await_resume() const noexcept { return 0; }
+};
+
+struct awaitable_suspend_handle
+{
+    bool await_ready() const noexcept { return true; }
+
+    std::coroutine_handle<> await_suspend(
+        std::coroutine_handle<> h,
+        io_env const*) const noexcept
+    {
+        return h;
+    }
+
+    void await_resume() const noexcept {}
+};
+
+struct awaitable_suspend_typed_handle
+{
+    bool await_ready() const noexcept { return true; }
+
+    std::coroutine_handle<mock_promise> await_suspend(
+        std::coroutine_handle<>,
+        io_env const*) const noexcept
+    {
+        return {};
+    }
+
+    void await_resume() const noexcept {}
+};
+
+// Invalid: await_suspend returns a type the language rejects
+struct awaitable_suspend_int
+{
+    bool await_ready() const noexcept { return true; }
+
+    int await_suspend(
+        std::coroutine_handle<>,
+        io_env const*) const noexcept
+    {
+        return 0;
+    }
+
+    void await_resume() const noexcept {}
+};
+
+// Invalid: standard one-argument await_suspend only
+struct awaitable_one_arg_suspend
+{
+    bool await_ready() const noexcept { return true; }
+
+    void await_suspend(std::coroutine_handle<>) const noexcept {}
+
+    void await_resume() const noexcept {}
+};
+
+// Invalid: await_ready does not return bool
+struct awaitable_ready_void
+{
+    void await_ready() const noexcept {}
+
+    void await_suspend(
+        std::coroutine_handle<>,
+        io_env const*) const noexcept
+    {
+    }
+
+    void await_resume() const noexcept {}
+};
+
+// Invalid: not move constructible
+struct awaitable_no_move
+{
+    awaitable_no_move(awaitable_no_move&&) = delete;
+
+    bool await_ready() const noexcept { return true; }
+
+    void await_suspend(
+        std::coroutine_handle<>,
+        io_env const*) const noexcept
+    {
+    }
+
+    void await_resume() const noexcept {}
+};
+
+// Convertible to a handle but not a handle
+struct handle_convertible
+{
+    operator std::coroutine_handle<>() const noexcept { return {}; }
+};
+
+} // namespace
+
+// AwaitSuspendResult accepts exactly void, bool, and coroutine handles
+static_assert(AwaitSuspendResult<void>);
+static_assert(AwaitSuspendResult<bool>);
+static_assert(AwaitSuspendResult<std::coroutine_handle<>>);
+static_assert(AwaitSuspendResult<std::coroutine_handle<mock_promise>>);
+static_assert(AwaitSuspendResult<decltype(std::noop_coroutine())>);
+
+static_assert(!AwaitSuspendResult<int>);
+static_assert(!AwaitSuspendResult<std::nullptr_t>);
+static_assert(!AwaitSuspendResult<handle_convertible>);
+static_assert(!AwaitSuspendResult<std::coroutine_handle<>*>);
+
+// Every valid await_suspend return type satisfies IoAwaitable
+static_assert(IoAwaitable<awaitable_suspend_void>);
+static_assert(IoAwaitable<awaitable_suspend_bool>);
+static_assert(IoAwaitable<awaitable_suspend_handle>);
+static_assert(IoAwaitable<awaitable_suspend_typed_handle>);
+
+// Invalid protocol shapes are rejected
+static_assert(!IoAwaitable<awaitable_suspend_int>);
+static_assert(!IoAwaitable<awaitable_one_arg_suspend>);
+static_assert(!IoAwaitable<awaitable_ready_void>);
+static_assert(!IoAwaitable<awaitable_no_move>);
+static_assert(!IoAwaitable<int>);
+
+// awaitable_result_t names the await_resume return type
+static_assert(std::same_as<awaitable_result_t<awaitable_suspend_void>, void>);
+static_assert(std::same_as<awaitable_result_t<awaitable_suspend_bool>, int>);
+
+// IoAwaitableRange requires a sized input range of IoAwaitables
+static_assert(IoAwaitableRange<std::vector<awaitable_suspend_void>>);
+static_assert(!IoAwaitableRange<std::vector<awaitable_one_arg_suspend>>);
+static_assert(!IoAwaitableRange<awaitable_suspend_void>);
+
+} // namespace capy
+} // namespace boost


### PR DESCRIPTION
The await_suspend return-type constraint referenced detail::await_suspend_valid_result, leaking an implementation name into the documented definition of the library's central concept. Replace it with a public, documented AwaitSuspendResult concept whose definition is self-contained: typed coroutine handles are detected by round-tripping the promise type through decltype(h.promise()) instead of a partial-specialization trait. Satisfaction behavior is unchanged, pinned by a new unit test for the header.